### PR TITLE
cache the averaging operators

### DIFF
--- a/discretize/DiffOperators.py
+++ b/discretize/DiffOperators.py
@@ -673,25 +673,34 @@ class DiffOperators(object):
     @property
     def aveF2CC(self):
         "Construct the averaging operator on cell faces to cell centers."
-        if(self.dim == 1):
-            return self.aveFx2CC
-        elif(self.dim == 2):
-            return (0.5)*sp.hstack((self.aveFx2CC, self.aveFy2CC),
-                                   format="csr")
-        elif(self.dim == 3):
-            return (1./3.)*sp.hstack((self.aveFx2CC, self.aveFy2CC,
-                                      self.aveFz2CC), format="csr")
+        if getattr(self, '_aveF2CC', None) is None:
+            if self.dim == 1:
+                self._aveF2CC = self.aveFx2CC
+            elif self.dim == 2:
+                self._aveF2CC = (0.5)*sp.hstack((
+                    self.aveFx2CC, self.aveFy2CC
+                ), format="csr")
+            elif self.dim == 3:
+                self._aveF2CC = (1./3.)*sp.hstack((
+                    self.aveFx2CC, self.aveFy2CC, self.aveFz2CC
+                ), format="csr")
+        return self._aveF2CC
 
     @property
     def aveF2CCV(self):
         "Construct the averaging operator on cell faces to cell centers."
-        if(self.dim == 1):
-            return self.aveFx2CC
-        elif(self.dim == 2):
-            return sp.block_diag((self.aveFx2CC, self.aveFy2CC), format="csr")
-        elif(self.dim == 3):
-            return sp.block_diag((self.aveFx2CC, self.aveFy2CC, self.aveFz2CC),
-                                 format="csr")
+        if getattr(self, '_aveF2CCV', None) is None:
+            if self.dim == 1:
+                self._aveF2CCV = self.aveFx2CC
+            elif self.dim == 2:
+                self._aveF2CCV = sp.block_diag((
+                    self.aveFx2CC, self.aveFy2CC
+                ), format="csr")
+            elif self.dim == 3:
+                self._aveF2CCV = sp.block_diag((
+                    self.aveFx2CC, self.aveFy2CC, self.aveFz2CC
+                ), format="csr")
+        return self._aveF2CCV
 
     @property
     def aveFx2CC(self):
@@ -702,11 +711,11 @@ class DiffOperators(object):
 
         if getattr(self, '_aveFx2CC', None) is None:
             n = self.vnC
-            if(self.dim == 1):
+            if self.dim == 1:
                 self._aveFx2CC = av(n[0])
-            elif(self.dim == 2):
+            elif self.dim == 2:
                 self._aveFx2CC = sp.kron(speye(n[1]), av(n[0]))
-            elif(self.dim == 3):
+            elif self.dim == 3:
                 self._aveFx2CC = kron3(speye(n[2]), speye(n[1]), av(n[0]))
         return self._aveFx2CC
 
@@ -722,7 +731,7 @@ class DiffOperators(object):
             n = self.vnC
             if(self.dim == 2):
                 self._aveFy2CC = sp.kron(av(n[1]), speye(n[0]))
-            elif(self.dim == 3):
+            elif self.dim == 3:
                 self._aveFy2CC = kron3(speye(n[2]), av(n[1]), speye(n[0]))
         return self._aveFy2CC
 
@@ -744,45 +753,58 @@ class DiffOperators(object):
     def aveCC2F(self):
         "Construct the averaging operator on cell cell centers to faces."
         if getattr(self, '_aveCC2F', None) is None:
-            n = self.vnC
-            if(self.dim == 1):
-                self._aveCC2F = av_extrap(n[0])
-            elif(self.dim == 2):
-                self._aveCC2F = sp.vstack((sp.kron(speye(n[1]),
-                                           av_extrap(n[0])),
-                                           sp.kron(av_extrap(n[1]),
-                                           speye(n[0]))), format="csr")
-            elif(self.dim == 3):
-                self._aveCC2F = sp.vstack((kron3(speye(n[2]), speye(n[1]),
-                                                 av_extrap(n[0])),
-                                           kron3(speye(n[2]), av_extrap(n[1]),
-                                                 speye(n[0])),
-                                           kron3(av_extrap(n[2]), speye(n[1]),
-                                                 speye(n[0]))),
-                                          format="csr")
+            if self.dim == 1:
+                self._aveCC2F = av_extrap(self.nCx)
+            elif self.dim == 2:
+                self._aveCC2F = sp.vstack((
+                    sp.kron(speye(self.nCy), av_extrap(self.nCx)),
+                    sp.kron(av_extrap(self.nCy), speye(self.nCx))
+                ), format="csr")
+            elif self.dim == 3:
+                self._aveCC2F = sp.vstack((
+                    kron3(
+                        speye(self.nCz), speye(self.nCy), av_extrap(self.nCx)
+                    ),
+                    kron3(
+                        speye(self.nCz), av_extrap(self.nCy), speye(self.nCx)
+                    ),
+                    kron3(
+                        av_extrap(self.nCz), speye(self.nCy), speye(self.nCx)
+                    )
+                ), format="csr")
         return self._aveCC2F
 
     @property
     def aveE2CC(self):
         "Construct the averaging operator on cell edges to cell centers."
-        if(self.dim == 1):
-            return self.aveEx2CC
-        elif(self.dim == 2):
-            return 0.5*sp.hstack((self.aveEx2CC, self.aveEy2CC), format="csr")
-        elif(self.dim == 3):
-            return (1./3)*sp.hstack((self.aveEx2CC, self.aveEy2CC,
-                                     self.aveEz2CC), format="csr")
+        if getattr(self, '_aveE2CC', None) is None:
+            if self.dim == 1:
+                self._avE2CC = self.aveEx2CC
+            elif self.dim == 2:
+                self._avE2CC = 0.5*sp.hstack(
+                    (self.aveEx2CC, self.aveEy2CC), format="csr"
+                )
+            elif self.dim == 3:
+                self._avE2CC = (1./3)*sp.hstack((
+                    self.aveEx2CC, self.aveEy2CC, self.aveEz2CC
+                ), format="csr")
+        return self._avE2CC
 
     @property
     def aveE2CCV(self):
         "Construct the averaging operator on cell edges to cell centers."
-        if(self.dim == 1):
-            return self.aveEx2CC
-        elif(self.dim == 2):
-            return sp.block_diag((self.aveEx2CC, self.aveEy2CC), format="csr")
-        elif(self.dim == 3):
-            return sp.block_diag((self.aveEx2CC, self.aveEy2CC, self.aveEz2CC),
-                                 format="csr")
+        if getattr(self, '_aveE2CCV', None) is None:
+            if self.dim == 1:
+                self._aveE2CCV = self.aveEx2CC
+            elif self.dim == 2:
+                self._aveE2CCV = sp.block_diag(
+                    (self.aveEx2CC, self.aveEy2CC), format="csr"
+                )
+            elif self.dim == 3:
+                self._aveE2CCV = sp.block_diag(
+                    (self.aveEx2CC, self.aveEy2CC, self.aveEz2CC), format="csr"
+                )
+        return self._aveE2CCV
 
     @property
     def aveEx2CC(self):


### PR DESCRIPTION
- cache `aveF2CC`, `aveF2CCV`, `aveE2CC`, `aveE2CCV` as per #48 
- question: do we want to be also caching the components (eg. `aveFx2CC`, ...)? Currently we are, but I think this might be unnecessary. The components are called once more to get the regularization operators constructed, but are then cached there, so it is really only one more call