### PR TITLE
setup.py

### DIFF
--- a/discretize/__init__.py
+++ b/discretize/__init__.py
@@ -2,8 +2,20 @@ from discretize.BaseMesh import BaseMesh
 from discretize.TensorMesh import TensorMesh
 from discretize.CylMesh import CylMesh
 from discretize.CurvilinearMesh import CurvilinearMesh
-from discretize.TreeMesh import TreeMesh
 from discretize import Tests
+
+try:
+    from discretize.TreeMesh import TreeMesh
+except ImportError:
+    print(
+        """
+        TreeMesh not imported. You need to run:
+
+        python setup.py install
+
+        to build the TreeMesh cython code.
+        """
+    )
 
 __version__   = '0.1.5'
 __author__    = 'SimPEG Team'

--- a/discretize/utils/interputils.py
+++ b/discretize/utils/interputils.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     print("""Interpolation will not work, use setup.py to compile the cython:
 
-        python setup.py build_ext --inplace""")
+        python setup.py install""")
     _interpCython = False
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -251,7 +251,7 @@ man_pages = [
 
 # Intersphinx
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/release/2.7.12/', None),
+    'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.org/', None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -251,7 +251,7 @@ man_pages = [
 
 # Intersphinx
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/2', None),
+    'python': ('https://docs.python.org/release/2.7.12/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.org/', None)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==1.5.6
 sphinx_rtd_theme
 sphinx-gallery
 nose

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-sphinx==1.5.5
+sphinx
 sphinx_rtd_theme
 sphinx-gallery
 nose

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-sphinx==1.5.6
+sphinx==1.5.5
 sphinx_rtd_theme
 sphinx-gallery
 nose

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,15 @@ Discretization tools for finite volume and inverse problems.
 """
 
 from setuptools import find_packages
-from numpy.distutils.core import setup
+
+try:
+    from numpy.distutils.core import setup
+except Exception:
+    raise Exception(
+        "Install requires numpy. "
+        "If you use conda, `conda install numpy` "
+        "or you can use pip, `pip install numpy`"
+    )
 
 import os
 import sys


### PR DESCRIPTION
- better error handling on the import of numpy in setup.py as per #51
- if cython interputils not built - tell user to run `python setup.py install` (not `python setup.py build_ext --inplace`) @rowanc1 or @jcapriot: could one of you double-check me on this? Thanks!   