### PR TITLE
feat/TestMimeticProperties

### DIFF
--- a/discretize/Tests.py
+++ b/discretize/Tests.py
@@ -37,6 +37,92 @@ sadness = [
 ]
 
 
+def setupMesh(meshType, nC, nDim):
+    """
+    For a given number of cells nc, generate a TensorMesh with uniform
+    cells with edge length h=1/nc.
+    """
+
+    if 'TensorMesh' in meshType:
+        if 'uniform' in meshType:
+            h = [nC, nC, nC]
+        elif 'random' in meshType:
+            h1 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h2 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h3 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h = [hi/np.sum(hi) for hi in [h1, h2, h3]]  # normalize
+        else:
+            raise Exception('Unexpected meshType')
+
+        mesh = TensorMesh(h[:nDim])
+        max_h = max([np.max(hi) for hi in mesh.h])
+
+    elif 'CylMesh' in meshType:
+        if 'uniform' in meshType:
+            h = [nC, nC, nC]
+        elif 'random' in meshType:
+            h1 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h2 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h3 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h = [hi/np.sum(hi) for hi in [h1, h2, h3]]  # normalize
+            h[1] = h[1]*2*np.pi
+        else:
+            raise Exception('Unexpected meshType')
+
+        if nDim == 2:
+            mesh = CylMesh([h[0], 1, h[2]])
+            max_h = max([np.max(hi) for hi in [mesh.hx, mesh.hz]])
+        elif nDim == 3:
+            mesh = CylMesh(h)
+            max_h = max([np.max(hi) for hi in mesh.h])
+
+    elif 'Curv' in meshType:
+        if 'uniform' in meshType:
+            kwrd = 'rect'
+        elif 'rotate' in meshType:
+            kwrd = 'rotate'
+        else:
+            raise Exception('Unexpected meshType')
+        if nDim == 1:
+            raise Exception('Lom not supported for 1D')
+        elif nDim == 2:
+            X, Y = utils.exampleLrmGrid([nC, nC], kwrd)
+            mesh = CurvilinearMesh([X, Y])
+        elif nDim == 3:
+            X, Y, Z = utils.exampleLrmGrid([nC, nC, nC], kwrd)
+            mesh = CurvilinearMesh([X, Y, Z])
+        max_h = 1./nC
+
+    elif 'Tree' in meshType:
+        nC *= 2
+        if 'uniform' in meshType or 'notatree' in meshType:
+            h = [nC, nC, nC]
+        elif 'random' in meshType:
+            h1 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h2 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h3 = np.random.rand(nC)*nC*0.5 + nC*0.5
+            h = [hi/np.sum(hi) for hi in [h1, h2, h3]]  # normalize
+        else:
+            raise Exception('Unexpected meshType')
+
+        levels = int(np.log(nC)/np.log(2))
+        mesh = Tree(h[:self.meshDimension], levels=levels)
+
+        def function(cell):
+            if 'notatree' in meshType:
+                return levels - 1
+            r = cell.center - np.array([0.5]*len(cell.center))
+            dist = np.sqrt(r.dot(r))
+            if dist < 0.2:
+                return levels
+            return levels - 1
+        mesh.refine(function, balance=False)
+        mesh.number(balance=False)
+        # mesh.plotGrid(showIt=True)
+        max_h = max([np.max(hi) for hi in self.M.h])
+    return mesh, max_h
+
+
 class OrderTest(unittest.TestCase):
     """
 
@@ -102,89 +188,10 @@ class OrderTest(unittest.TestCase):
     _meshType = meshTypes[0]
     meshDimension = 3
 
-    def setupMesh(self, nc):
-        """
-        For a given number of cells nc, generate a TensorMesh with uniform cells with edge length h=1/nc.
-        """
-        if 'TensorMesh' in self._meshType:
-            if 'uniform' in self._meshType:
-                h = [nc, nc, nc]
-            elif 'random' in self._meshType:
-                h1 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h2 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h3 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h = [hi/np.sum(hi) for hi in [h1, h2, h3]]  # normalize
-            else:
-                raise Exception('Unexpected meshType')
-
-            self.M = TensorMesh(h[:self.meshDimension])
-            max_h = max([np.max(hi) for hi in self.M.h])
-            return max_h
-
-        elif 'CylMesh' in self._meshType:
-            if 'uniform' in self._meshType:
-                h = [nc, nc, nc]
-            elif 'random' in self._meshType:
-                h1 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h2 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h3 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h = [hi/np.sum(hi) for hi in [h1, h2, h3]]  # normalize
-                h[1] = h[1]*2*np.pi
-            else:
-                raise Exception('Unexpected meshType')
-
-            if self.meshDimension == 2:
-                self.M = CylMesh([h[0], 1, h[2]])
-                max_h = max([np.max(hi) for hi in [self.M.hx, self.M.hz]])
-            elif self.meshDimension == 3:
-                self.M = CylMesh(h)
-                max_h = max([np.max(hi) for hi in self.M.h])
-            return max_h
-
-        elif 'Curv' in self._meshType:
-            if 'uniform' in self._meshType:
-                kwrd = 'rect'
-            elif 'rotate' in self._meshType:
-                kwrd = 'rotate'
-            else:
-                raise Exception('Unexpected meshType')
-            if self.meshDimension == 1:
-                raise Exception('Lom not supported for 1D')
-            elif self.meshDimension == 2:
-                X, Y = utils.exampleLrmGrid([nc, nc], kwrd)
-                self.M = CurvilinearMesh([X, Y])
-            elif self.meshDimension == 3:
-                X, Y, Z = utils.exampleLrmGrid([nc, nc, nc], kwrd)
-                self.M = CurvilinearMesh([X, Y, Z])
-            return 1./nc
-
-        elif 'Tree' in self._meshType:
-            nc *= 2
-            if 'uniform' in self._meshType or 'notatree' in self._meshType:
-                h = [nc, nc, nc]
-            elif 'random' in self._meshType:
-                h1 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h2 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h3 = np.random.rand(nc)*nc*0.5 + nc*0.5
-                h = [hi/np.sum(hi) for hi in [h1, h2, h3]]  # normalize
-            else:
-                raise Exception('Unexpected meshType')
-
-            levels = int(np.log(nc)/np.log(2))
-            self.M = Tree(h[:self.meshDimension], levels=levels)
-            def function(cell):
-                if 'notatree' in self._meshType:
-                    return levels - 1
-                r = cell.center - np.array([0.5]*len(cell.center))
-                dist = np.sqrt(r.dot(r))
-                if dist < 0.2:
-                    return levels
-                return levels - 1
-            self.M.refine(function,balance=False)
-            self.M.number(balance=False)
-            # self.M.plotGrid(showIt=True)
-            max_h = max([np.max(hi) for hi in self.M.h])
-            return max_h
+    def setupMesh(self, nC):
+        mesh, max_h = setupMesh(self._meshType, nC, self.meshDimension)
+        self.M = mesh
+        return max_h
 
     def getError(self):
         """For given h, generate A[h], f and A(f) and return norm of error."""

--- a/discretize/Tests.py
+++ b/discretize/Tests.py
@@ -119,7 +119,7 @@ def setupMesh(meshType, nC, nDim):
         mesh.refine(function, balance=False)
         mesh.number(balance=False)
         # mesh.plotGrid(showIt=True)
-        max_h = max([np.max(hi) for hi in self.M.h])
+        max_h = max([np.max(hi) for hi in mesh.h])
     return mesh, max_h
 
 

--- a/discretize/Tests.py
+++ b/discretize/Tests.py
@@ -106,7 +106,7 @@ def setupMesh(meshType, nC, nDim):
             raise Exception('Unexpected meshType')
 
         levels = int(np.log(nC)/np.log(2))
-        mesh = Tree(h[:self.meshDimension], levels=levels)
+        mesh = Tree(h[:nDim], levels=levels)
 
         def function(cell):
             if 'notatree' in meshType:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -251,7 +251,7 @@ man_pages = [
 
 # Intersphinx
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/2', None),
+    'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.org/', None)

--- a/tests/base/test_operators.py
+++ b/tests/base/test_operators.py
@@ -530,5 +530,45 @@ class TestAveraging3D(discretize.Tests.OrderTest):
         self.expectedOrders = ORDERS
 
 
+class MimeticProperties(unittest.TestCase):
+    meshTypes = MESHTYPES
+    meshDimension = 3
+    meshSize = 64
+    tol = 1e-11  # there is still some error due to rounding
+
+    def test_DivCurl(self):
+
+        for meshType in self.meshTypes:
+            mesh, _ = discretize.Tests.setupMesh(
+                meshType, self.meshSize, self.meshDimension
+            )
+            v = np.random.rand(mesh.nE)
+            divcurlv = mesh.faceDiv * (mesh.edgeCurl * v)
+            rel_err = np.linalg.norm(divcurlv) / np.linalg.norm(v)
+            passed = rel_err  < self.tol
+            print(
+                "Testing Div * Curl on {} : |Div Curl v| / |v| = {} "
+                "... {}".format(
+                    meshType, rel_err, 'FAIL' if passed is False else 'ok'
+                )
+            )
+
+    def test_CurlGrad(self):
+
+        for meshType in self.meshTypes:
+            mesh, _ = discretize.Tests.setupMesh(
+                meshType, self.meshSize, self.meshDimension
+            )
+            v = np.random.rand(mesh.nN)
+            curlgradv = mesh.edgeCurl * (mesh.nodalGrad * v)
+            rel_err = np.linalg.norm(curlgradv) / np.linalg.norm(v)
+            passed = rel_err  < self.tol
+            print(
+                "Testing Curl * Grad on {} : |Curl Grad v| / |v|= {} "
+                "... {}".format(
+                    meshType, rel_err, 'FAIL' if passed is False else 'ok'
+                )
+            )
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cyl/test_cylOperators.py
+++ b/tests/cyl/test_cylOperators.py
@@ -496,5 +496,45 @@ class TestCylEdgeInnerProducts_Order(Tests.OrderTest):
         self.orderTest()
 
 
+class MimeticProperties(unittest.TestCase):
+    meshTypes = MESHTYPES
+    meshDimension = 3
+    meshSize = 64
+    tol = 1e-11  # there is still some error due to rounding
+
+    def test_DivCurl(self):
+        for meshType in self.meshTypes:
+            mesh, _ = discretize.Tests.setupMesh(
+                meshType, self.meshSize, self.meshDimension
+            )
+            v = np.random.rand(mesh.nE)
+            divcurlv = mesh.faceDiv * (mesh.edgeCurl * v)
+            rel_err = np.linalg.norm(divcurlv) / np.linalg.norm(v)
+            passed = rel_err  < self.tol
+            print(
+                "Testing Div * Curl on {} : |Div Curl v| / |v| = {} "
+                "... {}".format(
+                    meshType, rel_err, 'FAIL' if passed is False else 'ok'
+                )
+            )
+
+    # # Nodal Grad has not been implemented yet
+    # def test_CurlGrad(self):
+    #     for meshType in self.meshTypes:
+    #         mesh, _ = discretize.Tests.setupMesh(
+    #             meshType, self.meshSize, self.meshDimension
+    #         )
+    #         v = np.random.rand(mesh.nN)
+    #         curlgradv = mesh.edgeCurl * (mesh.nodalGrad * v)
+    #         rel_err = np.linalg.norm(curlgradv) / np.linalg.norm(v)
+    #         passed = rel_err  < self.tol
+    #         print(
+    #             "Testing Curl * Grad on {} : |Curl Grad v| / |v|= {} "
+    #             "... {}".format(
+    #                 meshType, rel_err, 'FAIL' if passed is False else 'ok'
+    #             )
+    #         )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- pull out the setupMesh method in OrderTests so it can be used from the outside like a util
- add tests on mimetic properties of meshes (Curl * Grad == 0, Div * Curl == 0, within rounding errors)