### PR TITLE
docs: update link for the numpy for matlab users page

### DIFF
--- a/docs/content/installing.rst
+++ b/docs/content/installing.rst
@@ -86,7 +86,7 @@ Python for scientific computing
 Numpy and Matlab
 ----------------
 
-* `NumPy for Matlab Users <https://docs.scipy.org/doc/numpy-dev/user/numpy-for-matlab-users.html>`_
+* `NumPy for Matlab Users <https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html>`_
 * `Python vs Matlab <https://sites.google.com/site/pythonforscientists/python-vs-matlab>`_
 
 Lessons in Python


### PR DESCRIPTION
The page on "numpy for matlab users" has moved to: 
https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html