### PR TITLE
minor update in plotGrid - linestyle 

### DIFF
--- a/discretize/View.py
+++ b/discretize/View.py
@@ -585,7 +585,7 @@ class TensorView(object):
                 )
             if lines:
                 ax.plot(
-                    self.gridN, np.ones(self.nN), color="C0", linestyle=".-"
+                    self.gridN, np.ones(self.nN), color="C0", linestyle="-"
                 )
             ax.set_xlabel('x1')
         elif self.dim == 2:


### PR DESCRIPTION
- `".-"` is no longer valid for a linestyle input in matplotlib, it should instead be "-." (however, a solid line looks better anyways for the 1d). 

![image](https://user-images.githubusercontent.com/6361812/43050325-739585fa-8dcc-11e8-9b37-e428afeda3f9.png)
