### PR TITLE
fix/py27: Fix the Travis build for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,15 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pillow cython ipython;
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
+      echo "Using pip to install dependencies"
+    else
+      conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pillow cython ipython;
+    fi
   - conda install --quiet --yes -c menpo vtk
+  - which pip
+  - pip --version
+  - pip install --upgrade pip
   - pip install -r requirements_dev.txt
   - python --version
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,12 @@ before_install:
 
 install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-      echo "Using pip to install dependencies"
+      echo "Using native pip to install dependencies"
     else
       conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pillow cython ipython;
     fi
   - conda install --quiet --yes -c menpo vtk
   - which pip
-  - pip --version
   - pip install --upgrade pip
   - pip install -r requirements_dev.txt
   - python --version


### PR DESCRIPTION
There was some weirdness happening with the pip installed from conda on py2.7. To mitigate this, I just set the build to use the native py27 pip for all dependencies. If Python version is 3.x then it uses conda to manage dependencies.