### PR TITLE
Expand the `plot_3d_slicer` to other `vTypes` and `views`.

### DIFF
--- a/discretize/View.py
+++ b/discretize/View.py
@@ -700,8 +700,9 @@ class TensorView(object):
 
 
     def plot_3d_slicer(self, v, xslice=None, yslice=None, zslice=None,
-                       vType='CC', view='xy', transparent=None, clim=None,
-                       aspect='auto', grid=[2, 2, 1], pcolorOpts=None):
+                       vType='CC', view='real', axis='xy', transparent=None,
+                       clim=None, aspect='auto', grid=[2, 2, 1],
+                       pcolorOpts=None):
         """Plot slices of a 3D volume, interactively (scroll wheel).
 
         If called from a notebook, make sure to set
@@ -728,7 +729,7 @@ class TensorView(object):
         fig = plt.figure()
 
         # Populate figure
-        tracker = Slicer(self, v, xslice, yslice, zslice, vType, view,
+        tracker = Slicer(self, v, xslice, yslice, zslice, vType, view, axis,
                          transparent, clim, aspect, grid, pcolorOpts)
 
         # Connect figure to scrolling
@@ -1153,9 +1154,14 @@ class Slicer(object):
         defaults to the middle of the volume.
 
     vType: str
-        Type of visualization. At the moment only 'CC' is implemented.
+        Type of visualization. Default is 'CC'.
+        One of ['CC', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'Ex', 'Ey', 'Ez'].
 
-    view : 'xy' (default) or 'yx'
+    view : str
+        Which component to show. Defaults to 'real'.
+        One of  ['real', 'imag', 'abs'].
+
+    axis : 'xy' (default) or 'yx'
         'xy': horizontal axis is x, vertical axis is y. Reversed otherwise.
 
     transparent : 'slider' or list of floats or pairs of floats, optional
@@ -1188,26 +1194,52 @@ class Slicer(object):
     """
 
     def __init__(self, mesh, v, xslice=None, yslice=None, zslice=None,
-                 vType='CC', view='xy', transparent=None, clim=None,
-                 aspect='auto', grid=[2, 2, 1], pcolorOpts=None):
+                 vType='CC', view='real', axis='xy', transparent=None,
+                 clim=None, aspect='auto', grid=[2, 2, 1], pcolorOpts=None):
         """Initialize interactive figure."""
 
         # 0. Some checks, not very extensive
+
+        # (a) Mesh dimensionality
         if mesh.dim != 3:
             err = 'Must be a 3D mesh. Use plotImage instead.'
             err += ' Mesh provided has {} dimension(s).'.format(mesh.dim)
             raise ValueError(err)
 
-        vTypeOpts = ['CC', ]
+        # (b) vType  # Not yet working for ['CCv']
+        vTypeOpts = ['CC', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'Ex', 'Ey', 'Ez']
         if vType not in vTypeOpts:
             err = "vType must be in ['{0!s}'].".format("', '".join(vTypeOpts))
             err += " vType provided: '{0!s}'.".format(vType)
             raise ValueError(err)
 
+        if vType == 'CC':
+            pass
+        elif vType == 'CCv':
+            if view != 'vec':
+                raise AssertionError('Other types for CCv not supported')
+        else:
+            aveOp = 'ave' + vType + ('2CCV' if view == 'vec' else '2CC')
+            Av = getattr(mesh, aveOp)
+            if v.size == Av.shape[1]:
+                v = Av * v
+            else:
+                v = mesh.r(v, vType[0], vType) # get specific component
+                v = Av * v
+
+        # (c) vOpts  # Not yet working for 'vec'
+        viewOpts = ['real', 'imag', 'abs', 'vec']
+        if view in ['real', 'imag', 'abs']:
+            v = getattr(np, view)(v) # e.g. np.real(v)
+        else:
+            err = "view must be in ['{0!s}'].".format("', '".join(viewOpts))
+            err += " view provided: '{0!s}'.".format(view)
+            raise ValueError(err)
+
         # 1. Store relevant data
 
         # Store data in self as (nx, ny, nz)
-        self.v = v.reshape(mesh.nCx, mesh.nCy, mesh.nCz, order='F').copy()
+        self.v = mesh.r(v.reshape((mesh.nC, -1), order='F'), 'CC', 'CC', 'M')
         self.v = np.ma.masked_where(np.isnan(self.v), self.v)
 
         # Store relevant information from mesh in self

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -1385,19 +1385,19 @@ class Slicer(object):
 
         # Update slice index depending on subplot over which mouse is
         if event.inaxes == self.ax1:    # X-Y
-            self.zind = (self.zind + pm) % (self.zc.size - 1)
+            self.zind = (self.zind + pm) % self.zc.size
             self.update_xy()
         elif event.inaxes == self.ax2:  # X-Z
             if self.yx:
-                self.xind = (self.xind + pm) % (self.xc.size - 1)
+                self.xind = (self.xind + pm) % self.xc.size
             else:
-                self.yind = (self.yind + pm) % (self.yc.size - 1)
+                self.yind = (self.yind + pm) % self.yc.size
             self.update_xz()
         elif event.inaxes == self.ax3:  # Z-Y
             if self.yx:
-                self.yind = (self.yind + pm) % (self.yc.size - 1)
+                self.yind = (self.yind + pm) % self.yc.size
             else:
-                self.xind = (self.xind + pm) % (self.xc.size - 1)
+                self.xind = (self.xind + pm) % self.xc.size
             self.update_zy()
 
         plt.draw()


### PR DESCRIPTION
Expand `plot_3d_slicer`
===

Addresses #116 .

Bug fix
---
First, it contains a minor bug-fix in the scrolling behavior (last element in each direction was not acceptable, only noticeable in small grids).

`vType`
---
Included all `vType`'s except `CCv`. Testing status:
- [x] `CC`, `Ex`, `Ey`, `Ez` (I briefly tested them)
- [ ] `N`, `F`, `E`, `Fx`, `Fy`, `Fz` (please let me know if you tested them)

`view`
---
Included all `view`'s except `vec`. Testing status:
- [x] `real` (I briefly tested the default)
- [ ] `imag`, `abs` (please let me know if you tested them)

Backwards incompatibility / name-clash!
'''
The problem with the `view`-parameter is that I stupidly used it to switch the x-y-axis. I changed the previous `view`-parameter to `axis` (hence `axis='xy'` or `axis='yx'`). It is probably better to break this than to have different parameters as, for instance, in `plotSlice`. I will add a switch for backwards-compatibility (hence, if `view='xy'` or `view='yx'` is provided, it will set `axis=view` and then re-assign `view='real'`).
Comments on that are welcomed!