### PR TITLE
Add vtki support to make using VTK data objects more Pythonic

### DIFF
--- a/discretize/mixins/vtkModule.py
+++ b/discretize/mixins/vtkModule.py
@@ -52,6 +52,7 @@ from vtk import vtkXMLUnstructuredGridWriter
 from vtk import vtkXMLStructuredGridWriter
 from vtk import vtkXMLRectilinearGridReader
 
+import warnings
 
 
 def assignCellData(vtkDS, models=None):
@@ -320,7 +321,14 @@ class vtkInterface(object):
             convert = converters[key]
         except KeyError:
             raise RuntimeError('Mesh type `{}` is not currently supported for VTK conversion.'.format(key))
-        return convert(mesh, models=models)
+        # Convert the data object then attempt a wrapping with `vtki`
+        cvtd = convert(mesh, models=models)
+        try:
+            import vtki
+            cvtd = vtki.wrap(cvtd)
+        except ImportError:
+            warnings.warn('For easier use of VTK objects, you should install `vtki` (the VTK interface): pip install vtki>=0.13.0')
+        return cvtd
 
     @staticmethod
     def _saveUnstructuredGrid(fileName, vtkUnstructGrid, directory=''):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,3 +18,4 @@ wheel
 pytest
 twine
 vtk
+vtki>=0.13.0


### PR DESCRIPTION
I recently added a ton of new features to [`vtki`](https://github.com/akaszynski/vtki) (the VTK interface Python package) that help make using just about any VTK data objects more intuitive/Pythonic. If `vtki` is available in your Python environment then these changes make using VTK data objects way easier. Here's a screenshot of what this currently looks like in a Jupyter notebook (creates static renderings but can also be interactive in a separate pop-up window). 

Also check out [this notebook](https://github.com/OpenGeoVis/PVGeo-Examples/blob/master/3.0%20-%20Using%20the%20vtkInterface%20Package.ipynb) to see more ways to use [`PVGeo`](https://github.com/OpenGeoVis/PVGeo), `discretize`, and [`vtki`](https://github.com/akaszynski/vtki). Below is a screenshot of a simple use case:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22067021/50529593-109b6d00-0ac4-11e9-8785-44b58f87ee29.gif)

<img width="757" alt="screen shot 2018-12-28 at 2 27 21 pm" src="https://user-images.githubusercontent.com/22067021/50525947-ba6eff80-0aac-11e9-8b1d-dfbc770fe3c9.png">


Some sample code to do it yourself!

```py
import discretize
import numpy as np

# Create a simple TensorMesh
h1 = np.linspace(.1, .5, 3)
h2 = np.linspace(.1, .5, 5)
h3 = np.linspace(.1, .5, 3)
mesh = discretize.TensorMesh([h1, h2, h3])

# Convert to VTK object and use vtki to render it
mesh.toVTK().plot(notebook=False)
```