### PR TITLE
docs: broken links

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,8 +35,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install numpy scipy matplotlib cython ipython pillow wheel
-  - conda install -c menpo vtk
-  - pip install -r requirements_dev.txt
+  - pip install nose
   - python setup.py install
 
 test_script:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,6 @@ linkcheck_ignore = [
     'http://wiki.python.org/moin/PythonEditors',
     'http://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html#numpy.array',
     'http://dx.doi.org/10.1016/j.cageo.2015.09.015',
-    'http://www.ctcms.nist.gov/*',
 ]
 
 linkcheck_retries = 3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,8 @@ linkcheck_ignore = [
     'http://wiki.python.org/moin/NumericAndScientific',
     'http://wiki.python.org/moin/PythonEditors',
     'http://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html#numpy.array',
-    'http://dx.doi.org/10.1016/j.cageo.2015.09.015'
+    'http://dx.doi.org/10.1016/j.cageo.2015.09.015',
+    'http://www.ctcms.nist.gov/*',
 ]
 
 linkcheck_retries = 3

--- a/docs/examples/plot_cahn_hilliard.py
+++ b/docs/examples/plot_cahn_hilliard.py
@@ -37,7 +37,9 @@ mean of 0.5. The grid is 60x60 and takes a few seconds to solve ~130
 times. The results are seen below, and you can see the field separating
 as the time increases.
 
-.. _FiPy: http://www.ctcms.nist.gov/fipy/examples/cahnHilliard/generated/examples.cahnHilliard.mesh2DCoupled.html
+.. _FiPy: https://github.com/usnistgov/fipy
+
+.. http://www.ctcms.nist.gov/fipy/examples/cahnHilliard/generated/examples.cahnHilliard.mesh2DCoupled.html
 
 """
 from __future__ import print_function


### PR DESCRIPTION
The link to the FiPy site is currently down causing the docs and new prs to fail (e.g. as in #130). I have replaced the link in the example to the FiPy github url for now.  