### PR TITLE
Add access for vtkToTensorMesh function

### DIFF
--- a/discretize/mixins/vtkModule.py
+++ b/discretize/mixins/vtkModule.py
@@ -469,26 +469,17 @@ class vtkTensorRead(object):
     """Provides a convienance method for reading VTK Rectilinear Grid files
     as ``TensorMesh`` objects."""
 
+
     @classmethod
-    def readVTK(TensorMesh, fileName, directory=''):
-        """Read VTK Rectilinear (vtr xml file) and return Tensor mesh and model
-
-        Input:
-
-        :param str fileName: path to the vtr model file to read or just its name if directory is specified
-        :param str directory: directory where the UBC GIF file lives
+    def vtkToTensorMesh(TensorMesh, vtrGrid):
+        """Converts a ``vtkRectilinearGrid`` or :class:`vtki.RectilinearGrid`
+        to a :class:`discretize.TensorMesh` object.
 
         Output:
 
         :rtype: tuple
         :return: (TensorMesh, modelDictionary)
         """
-        fname = os.path.join(directory, fileName)
-        # Read the file
-        vtrReader = vtkXMLRectilinearGridReader()
-        vtrReader.SetFileName(fname)
-        vtrReader.Update()
-        vtrGrid = vtrReader.GetOutput()
         # Sort information
         hx = np.abs(np.diff(nps.vtk_to_numpy(vtrGrid.GetXCoordinates())))
         xR = nps.vtk_to_numpy(vtrGrid.GetXCoordinates())[0]
@@ -521,3 +512,25 @@ class vtkTensorRead(object):
 
         # Return the data
         return tensMsh, models
+
+    @classmethod
+    def readVTK(TensorMesh, fileName, directory=''):
+        """Read VTK Rectilinear (vtr xml file) and return Tensor mesh and model
+
+        Input:
+
+        :param str fileName: path to the vtr model file to read or just its name if directory is specified
+        :param str directory: directory where the UBC GIF file lives
+
+        Output:
+
+        :rtype: tuple
+        :return: (TensorMesh, modelDictionary)
+        """
+        fname = os.path.join(directory, fileName)
+        # Read the file
+        vtrReader = vtkXMLRectilinearGridReader()
+        vtrReader.SetFileName(fname)
+        vtrReader.Update()
+        vtrGrid = vtrReader.GetOutput()
+        return vtkTensorRead.vtkToTensorMesh(TensorMesh, vtkRectGrid)

--- a/discretize/mixins/vtkModule.py
+++ b/discretize/mixins/vtkModule.py
@@ -533,4 +533,4 @@ class vtkTensorRead(object):
         vtrReader.SetFileName(fname)
         vtrReader.Update()
         vtrGrid = vtrReader.GetOutput()
-        return vtkTensorRead.vtkToTensorMesh(TensorMesh, vtrGrid)
+        return TensorMesh.vtkToTensorMesh(vtrGrid)

--- a/discretize/mixins/vtkModule.py
+++ b/discretize/mixins/vtkModule.py
@@ -533,4 +533,4 @@ class vtkTensorRead(object):
         vtrReader.SetFileName(fname)
         vtrReader.Update()
         vtrGrid = vtrReader.GetOutput()
-        return vtkTensorRead.vtkToTensorMesh(TensorMesh, vtkRectGrid)
+        return vtkTensorRead.vtkToTensorMesh(TensorMesh, vtrGrid)


### PR DESCRIPTION
The code was already in `discretize`, these changes just make the function accessible to users to convert `vtkRectilinearGrid` objects to `TensorMesh` objects.

Needed this recently for a project - it was easiest to create my mesh in `vtki` and repeatedly visualize it while tweaking its size. Then I could convert it to `discretize` to use in an inversion.

### Example

For example (needs to be done in IPython)

```py
import vtki
from vtki import examples
import discretize
import numpy as np

# Create a plotting window
p = vtki.BackgroundPlotter()
p.show_grid()
```

```py
# Get a sample topo surface from vtki
# Note: this requires vtki>=0.17.1
topo = examples.download_st_helens().warp_by_scalar()

p.add_mesh(topo, name='topo')
```

```py
# Create the mesh interactively
# tweak these parameters and rerun this cell until satisfied

b = topo.bounds
xcoords = np.linspace(b[0], b[1], 50)
ycoords = np.linspace(b[2], b[3], 50)
zcoords = np.linspace(b[4]-5000, b[5], 50)

mesh = vtki.RectilinearGrid(xcoords, ycoords, zcoords)

p.add_mesh(mesh, name='mesh', opacity=0.5, show_edges=True)
# output the mesh
mesh
```

<table><tr><th>RectilinearGrid</th><th>Information</th></tr><tr><td>N Cells</td><td>117649</td></tr><tr><td>N Points</td><td>125000</td></tr><tr><td>X Bounds</td><td>5.579e+05, 5.677e+05</td></tr><tr><td>Y Bounds</td><td>5.108e+06, 5.122e+06</td></tr><tr><td>Z Bounds</td><td>-3.636e+03, 3.225e+03</td></tr><tr><td>Volume</td><td>9.381e+11</td></tr><tr><td>N Scalars</td><td>0</td></tr></table>

```py
# Once satisfied, convert to discretize:
dmesh, _ = discretize.TensorMesh.vtkToTensorMesh(mesh)
dmesh
```
<discretize.TensorMesh.TensorMesh at 0xb2a555588>


#### And a GIF to demo


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22067021/53910336-d0e78900-4010-11e9-8cbe-7c2a06676bd7.gif)


