### PR TITLE
Initial mesh tools branch for TensorMeshes

### DIFF
--- a/discretize/utils/meshutils.py
+++ b/discretize/utils/meshutils.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy import optimize
 import scipy.ndimage as ndi
 import scipy.sparse as sp
 
@@ -255,3 +256,306 @@ def ExtractCoreMesh(xyzlim, mesh, meshType='tensor'):
         raise Exception("Not implemented!")
 
     return actind, meshCore
+
+
+# HELPER FUNCTIONS TO CREATE MESH
+def get_domain(x0=0, freq=1, rho=0.3, limits=None, min_width=None,
+               fact_min=0.2, fact_neg=5, fact_pos=None):
+    r"""Get domain extent and minimum cell width as a function of skin depth.
+
+    Returns the extent of the calculation domain and the minimum cell width as
+    a multiple of the skin depth, with possible user restrictions on minimum
+    calculation domain and range of possible minimum cell widths.
+
+    .. math::
+
+            \delta &= 503.3 \sqrt{\frac{\rho}{f}} , \\
+            x_\text{start} &= x_0-k_\text{neg}\delta , \\
+            x_\text{end} &= x_0+k_\text{pos}\delta , \\
+            h_\text{min} &= k_\text{min} \delta .
+
+
+    Parameters
+    ----------
+
+    x0 : float
+        Center of the calculation domain. Normally the source location.
+        Default is 0.
+
+    freq : float
+        Frequency (Hz) to calculate the skin depth.
+        Default is 1 Hz.
+
+    rho : float, optional
+        Resistivity (Ohm m) to calculate skin depth.
+        Default is 0.3 Ohm m (sea water).
+
+    limits : None or list
+        [start, end] of model domain. This extent represents the minimum extent
+        of the domain. The domain is therefore only adjusted if it has to reach
+        outside of [start, end].
+        Default is None.
+
+    min_width : None or list
+        [min, max] for the minimum cell width. This extent is the range which
+        ``h_min`` can take.
+        Default is None.
+
+    fact_min, fact_neg, fact_pos : floats
+        The skin depth is multiplied with these factors to estimate:
+
+            - Minimum cell width (``fact_min``, default 0.2)
+            - Domain-start (``fact_neg``, default 5), and
+            - Domain-end (``fact_pos``, defaults to ``fact_neg``).
+
+
+    Returns
+    -------
+
+    h_min : float
+        Minimum cell width.
+
+    domain : list
+        Start- and end-points of calculation domain.
+
+    """
+
+    # Set fact_pos to fact_neg if not provided
+    if fact_pos is None:
+        fact_pos = fact_neg
+
+    # Calculate the skin depth
+    skind = 503.3*np.sqrt(rho/freq)
+
+    # Estimate minimum cell width
+    h_min = fact_min*skind
+    if min_width is not None:  # Respect user input
+        h_min = np.clip(h_min, *min_width)
+
+    # Estimate calculation domain
+    domain = [x0-fact_neg*skind, x0+fact_pos*skind]
+    if limits is not None:  # Respect user input
+        domain = [min(limits[0], domain[0]), max(limits[1], domain[1])]
+
+    return h_min, domain
+
+
+def get_stretched_h(h_min, domain, nx, x0=0, x1=None, resp_domain=False):
+    """Return cell widths for a stretched grid within the domain.
+
+    Returns ``nx`` cell widths within ``domain``, where the minimum cell width
+    is ``h_min``. The cells are not stretched within ``x0`` and ``x1``, and
+    outside uses a power-law stretching. The actual stretching factor and the
+    number of cells left and right of ``x0`` and ``x1`` are find in a
+    minimization process.
+
+    The domain is not completely respected. The starting point of the domain
+    is, but the endpoint of the domain might slightly shift (this is more
+    likely the case for small ``nx``, for big ``nx`` the shift should be
+    small). The new endpoint can be obtained with ``domain[0]+np.sum(hx)``. If
+    you want the domain to be respected absolutely, set ``resp_domain=True``.
+    However, be aware that this will introduce one stretch-factor which is
+    different from the other stretch factors, to accommodate the restriction.
+    This one-off factor is between the left- and right-side of ``x0``, or, if
+    ``x1`` is provided, just after ``x1``.
+
+
+    Parameters
+    ----------
+
+    h_min : float
+        Minimum cell width.
+
+    domain : list
+        [start, end] of model domain.
+
+    nx : int
+        Number of cells.
+
+    x0 : float
+        Center of the grid. ``x0`` is restricted to ``domain``.
+        Default is 0.
+
+    x1 : float
+        If provided, then no stretching is applied between ``x0`` and ``x1``.
+        The non-stretched part starts at ``x0`` and stops at the first possible
+        location at or after ``x1``. ``x1`` is restricted to ``domain``.
+
+    resp_domain : bool
+        If False (default), then the domain-end might shift slightly to assure
+        that the same stretching factor is applied throughout. If set to True,
+        however, the domain is respected absolutely. This will introduce one
+        stretch-factor which is different from the other stretch factors, to
+        accommodate the restriction. This one-off factor is between the left-
+        and right-side of ``x0``, or, if ``x1`` is provided, just after ``x1``.
+
+
+    Returns
+    -------
+    hx : ndarray
+        Cell widths of mesh.
+
+    """
+
+    # Cast to arrays
+    domain = np.array(domain, dtype=float)
+    x0 = np.array(x0, dtype=float)
+    x0 = np.clip(x0, *domain)  # Restrict to model domain
+    if x1 is not None:
+        x1 = np.array(x1, dtype=float)
+        x1 = np.clip(x1, *domain)  # Restrict to model domain
+
+    # If x1 is provided (a part is not stretched)
+    if x1 is not None:
+
+        # Store original values
+        xlim_orig = domain.copy()
+        nx_orig = int(nx)
+        x0_orig = x0.copy()
+
+        # Get number of non-stretched cells
+        n_nos = int(np.ceil((x1-x0)/h_min))-1
+        # Note that wee subtract one cell, because the standard scheme provides
+        # one h_min-cell.
+
+        # Reset x0, because the first h_min comes from normal scheme
+        x0 += h_min
+
+        # Reset xmax for normal scheme
+        domain[1] -= n_nos*h_min
+
+        # Reset nx for normal scheme
+        nx -= n_nos
+
+        # If there are not enough points reset to standard procedure
+        # This five is arbitrary. However, nx should be much bigger than five
+        # anyways, otherwise stretched grid doesn't make sense.
+        if nx <= 5:
+            print("Warning :: Not enough points for non-stretched part,"
+                  "ignoring therefore `x1`.")
+            domain = xlim_orig
+            nx = nx_orig
+            x0 = x0_orig
+            x1 = None
+
+    # Get stretching factor (a = 1+alpha).
+    if h_min == 0 or h_min > np.diff(domain)/nx:
+        # If h_min is bigger than the domain-extent divided by nx, no
+        # stretching is required at all.
+        alpha = 0
+    else:
+
+        # Wrap _get_dx into a minimization function to call with fsolve.
+        def find_alpha(alpha, h_min, args):
+            """Find alpha such that min(hx) = h_min."""
+            return min(get_hx(alpha, *args))/h_min-1
+
+        # Search for best alpha, must be at least 0
+        args = (domain, nx, x0)
+        alpha = max(0, optimize.fsolve(find_alpha, 0.02, (h_min, args)))
+
+    # With alpha get actual cell spacing with `resp_domain` to respect the
+    # users decision.
+    hx = get_hx(alpha, domain, nx, x0, resp_domain)
+
+    # Add the non-stretched center if x1 is provided
+    if x1 is not None:
+        hx = np.r_[hx[: np.argmin(hx)], np.ones(n_nos)*h_min,
+                   hx[np.argmin(hx):]]
+
+    # Print mesh dimensions
+    print(f"extent : {domain[0]:>10,.1f} - {domain[0]+np.sum(hx):<10,.1f}; "
+          f"min/max width: {min(hx):>6,.1f} - {max(hx):<6,.1f}; "
+          f"stretching: {1+np.squeeze(alpha):.3f}")
+
+    return hx
+
+
+def get_hx(alpha, domain, nx, x0, resp_domain=True):
+    r"""Return cell widths for given input.
+
+    Find the number of cells left and right of ``x0``, ``nl`` and ``nr``
+    respectively, for the provided alpha. For this, we solve
+
+    .. math::   \frac{x_\text{max}-x_0}{x_0-x_\text{min}} =
+                \frac{a^{nr}-1}{a^{nl}-1}
+
+    where :math:`a = 1+\alpha`.
+
+
+    Parameters
+    ----------
+
+    alpha : float
+        Stretching factor ``a`` is given by ``a=1+alpha``.
+
+    domain : list
+        [start, end] of model domain.
+
+    nx : int
+        Number of cells.
+
+    x0 : float
+        Center of the grid. ``x0`` is restricted to ``domain``.
+
+    resp_domain : bool
+        If False (default), then the domain-end might shift slightly to assure
+        that the same stretching factor is applied throughout. If set to True,
+        however, the domain is respected absolutely. This will introduce one
+        stretch-factor which is different from the other stretch factors, to
+        accommodate the restriction. This one-off factor is between the left-
+        and right-side of ``x0``, or, if ``x1`` is provided, just after ``x1``.
+
+
+    Returns
+    -------
+    hx : ndarray
+        Cell widths of mesh.
+
+    """
+    if alpha <= 0.:  # If alpha <= 0: equal spacing (no stretching at all)
+        hx = np.ones(nx)*np.diff(domain)/nx
+
+    else:            # Get stretched hx
+        a = alpha+1
+
+        # Get hx depending if x0 is on the domain boundary or not.
+        if x0 == domain[0] or x0 == domain[1]:
+            # Get al a's
+            alr = np.diff(domain)*alpha/(a**nx-1)*a**np.arange(nx)
+            if x0 == domain[1]:
+                alr = alr[::-1]
+
+            # Calculate differences
+            hx = alr*np.diff(domain)/sum(alr)
+
+        else:
+            # Find number of elements left and right by solving:
+            #     (xmax-x0)/(x0-xmin) = a**nr-1/(a**nl-1)
+            nr = np.arange(2, nx+1)
+            er = (domain[1]-x0)/(x0-domain[0]) - (a**nr[::-1]-1)/(a**nr-1)
+            nl = np.argmin(abs(np.floor(er)))+1
+            nr = nx-nl
+
+            # Get all a's
+            al = a**np.arange(nl-1, -1, -1)
+            ar = a**np.arange(1, nr+1)
+
+            # Calculate differences
+            if resp_domain:
+                # This version honours domain[0] and domain[1], but to achieve
+                # this it introduces one stretch-factor which is different from
+                # all the others between al to ar.
+                hx = np.r_[al*(x0-domain[0])/sum(al),
+                           ar*(domain[1]-x0)/sum(ar)]
+            else:
+                # This version moves domain[1], but each stretch-factor is
+                # exactly the same.
+                fact = (x0-domain[0])/sum(al)  # Take distance from al.
+                hx = np.r_[al, ar]*fact
+
+                # Note: this hx is equivalent as providing the following h
+                # to TensorMesh:
+                # h = [(h_min, nl-1, -a), (h_min, n_nos+1), (h_min, nr, a)]
+
+    return hx

--- a/docs/examples/plot_meshutils.py
+++ b/docs/examples/plot_meshutils.py
@@ -1,0 +1,59 @@
+"""
+``meshutils`` to create complicated meshes
+==========================================
+
+The examples demonstrate some of the tools in `utils.meshutils`.
+"""
+
+# %matplotlib notebook
+import discretize
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+
+if sys.version_info[0] < 3:
+    print("This example only runs on Python 3")
+    sys.exit(0)
+
+###############################################################################
+# 1. Get stretched grid with one stretching factor for various restrictions
+# -------------------------------------------------------------------------
+#
+# - Source at 500 => Domain is centered around this point
+# - Frequency 10 Hz, Resistivity 1 Ohm m
+# - 2^5 cells
+h_min, domain = discretize.utils.meshutils.get_domain(x0=500, freq=10, rho=1)
+
+hx = discretize.utils.meshutils.get_stretched_h(h_min, domain, nx=2**5, x0=500)
+grid = discretize.TensorMesh([hx, 1], x0=[domain[0], 0])
+grid.plotGrid()
+
+###############################################################################
+# 1.b As before, but with following additional restrictions
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# - My model goes from -800 to 3500, so I want this extent at least.
+# - I want the minimum cell width to be within 5-100 meters, no smaller, no
+#   wider.
+# - From 300 to 800 meter I want regular spacing with min cell width.
+
+h_min, domain = discretize.utils.meshutils.get_domain(
+    x0=500, freq=10, rho=1, limits=[-800, 3500], min_width=[5, 100])
+
+hx = discretize.utils.meshutils.get_stretched_h(
+        h_min, domain, nx=2**5, x0=300, x1=800)
+grid = discretize.TensorMesh([hx, 1], x0=[domain[0], 0])
+grid.plotGrid()
+mesh.plot_3d_slicer(Lpout)
+
+###############################################################################
+# 1.c As before, but for ``f=0.1`` instead
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+h_min, domain = discretize.utils.meshutils.get_domain(
+    x0=500, freq=0.1, rho=1, limits=[-800, 3500], min_width=[5, 100])
+
+hx = discretize.utils.meshutils.get_stretched_h(
+        h_min, domain, nx=2**5, x0=300, x1=800)
+grid = discretize.TensorMesh([hx, 1], x0=[domain[0], 0])
+grid.plotGrid()


### PR DESCRIPTION
# Add more meshing tools to create fancy meshes

## Motivation
We probably all have our own little routines to create more complex meshes. I think it would be great to incorporate some of these into discretize, so not everyone has to do the same again.

## Status so far
Here, I included my most used routines:
- `get_domain`: A routine that calculates minimum cell width and calculation extent based on multiples of the skin depth. The user can restrict the domain to a minimum domain, and give a range for the possible min-cell width. Good for on-the-fly mesh creations.
- `get_stretched_h`: Get the input (together with `get_domain`) for a `TensorMesh` for a certain domain size, a certain number of cells, a minimum cell width, and an optional domain without stretching. The routine finds the suitable stretching factor.

## Warning
- This is an initial draft. I tried to document as good as possible, so it should be easy to incorporate other ideas and stuff from other routines. Please add your own stuff!
- I added tests for 100% coverage. However, in pytest, so they probably will fail hilariously. I thought I won't bother checking if they are good for unittest as long as it is in an early stage.
- I also added an initial notebook, didn't check, will probably fail too.
