### PR TITLE
Add `fig`-parameter to `plot_3d_slicer`

### DIFF
--- a/discretize/View.py
+++ b/discretize/View.py
@@ -737,7 +737,7 @@ class TensorView(object):
     def plot_3d_slicer(self, v, xslice=None, yslice=None, zslice=None,
                        vType='CC', view='real', axis='xy', transparent=None,
                        clim=None, aspect='auto', grid=[2, 2, 1],
-                       pcolorOpts=None):
+                       pcolorOpts=None, fig=None):
         """Plot slices of a 3D volume, interactively (scroll wheel).
 
         If called from a notebook, make sure to set
@@ -759,9 +759,15 @@ class TensorView(object):
 
           `fig.get_children()[0].get_children()`.
 
+        One can also provide an existing figure instance, which can be useful
+        for interactive widgets in Notebooks.
+
         """
         # Initiate figure
-        fig = plt.figure()
+        do_show = False
+        if fig is None:
+            do_not_show = True
+            fig = plt.figure()
 
         # Populate figure
         tracker = Slicer(self, v, xslice, yslice, zslice, vType, view, axis,
@@ -771,7 +777,8 @@ class TensorView(object):
         fig.canvas.mpl_connect('scroll_event', tracker.onscroll)
 
         # Show figure
-        plt.show()
+        if do_show:
+            plt.show()
 
 
 class CylView(object):

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -760,14 +760,15 @@ class TensorView(object):
           `fig.get_children()[0].get_children()`.
 
         One can also provide an existing figure instance, which can be useful
-        for interactive widgets in Notebooks.
+        for interactive widgets in Notebooks. The provided figure is cleared
+        first.
 
         """
         # Initiate figure
-        do_show = False
         if fig is None:
-            do_not_show = True
             fig = plt.figure()
+        else:
+            fig.clf()
 
         # Populate figure
         tracker = Slicer(self, v, xslice, yslice, zslice, vType, view, axis,
@@ -777,8 +778,7 @@ class TensorView(object):
         fig.canvas.mpl_connect('scroll_event', tracker.onscroll)
 
         # Show figure
-        if do_show:
-            plt.show()
+        plt.show()
 
 
 class CylView(object):


### PR DESCRIPTION
# Add `fig`-parameter to `plot_3d_slicer`

Small change to provide more flexibility for `plot_3d_slicer`. It now takes an optional `fig`-parameter (100% backwards compatible), in which one can provide an existing figure handle. The figure is cleared at every call, but no new figure is created. This can give some more flexibility, for instance in the use together with widgets.

Initiated upon an idea by @fourndo, who uses it for a Mag Tutorial:
![Peek 2019-03-25 20-24](https://user-images.githubusercontent.com/8020943/54948373-c6981b00-4f3c-11e9-93cc-7496b252e377.gif)
where he used the figure handle to replace the YZ-plot with a data plot, and wrap it into a widget.

Code example: Now you can call
```
fig = plt.figure()
mesh.plot_3d_slicer(model, fig=fig)
```
where `fig` is an existing figure. And then you can do more funky stuff with your figure handle. It is sort of a convenience addition, as the same would be possible with:
```
fig = plt.figure()
tracker = discretize.View.Slicer(mesh, model, **kwargs)
fig.canvas.mpl_connect('scroll_event', tracker.onscroll)
```