### PR TITLE
Add `(x,y,z)lim` to plot_3d_slicer

### DIFF
--- a/discretize/View.py
+++ b/discretize/View.py
@@ -736,7 +736,7 @@ class TensorView(object):
 
     def plot_3d_slicer(self, v, xslice=None, yslice=None, zslice=None,
                        vType='CC', view='real', axis='xy', transparent=None,
-                       clim=None, range_x=None, range_y=None, range_z=None,
+                       clim=None, xlim=None, ylim=None, zlim=None,
                        aspect='auto', grid=[2, 2, 1], pcolorOpts=None,
                        fig=None):
         """Plot slices of a 3D volume, interactively (scroll wheel).
@@ -774,13 +774,14 @@ class TensorView(object):
         # Populate figure
         tracker = Slicer(
             self, v, xslice, yslice, zslice, vType, view, axis, transparent,
-            clim, range_x, range_y, range_z, aspect, grid, pcolorOpts
+            clim, xlim, ylim, zlim, aspect, grid, pcolorOpts
         )
 
         # Connect figure to scrolling
         fig.canvas.mpl_connect('scroll_event', tracker.onscroll)
 
-        return fig
+        # Show figure
+        plt.show()
 
 
 class CylView(object):
@@ -1218,7 +1219,7 @@ class Slicer(object):
     clim : None or list of [min, max]
         For pcolormesh (vmin, vmax).
 
-    range_x, range_y, range_z : None or list of [min, max]
+    xlim, ylim, zlim : None or list of [min, max]
         Axis limits.
 
     aspect : 'auto', 'equal', or num
@@ -1241,8 +1242,8 @@ class Slicer(object):
 
     def __init__(self, mesh, v, xslice=None, yslice=None, zslice=None,
                  vType='CC', view='real', axis='xy', transparent=None,
-                 clim=None, range_x=None, range_y=None, range_z=None,
-                 aspect='auto', grid=[2, 2, 1], pcolorOpts=None):
+                 clim=None, xlim=None, ylim=None, zlim=None, aspect='auto',
+                 grid=[2, 2, 1], pcolorOpts=None):
         """Initialize interactive figure."""
 
         # 0. Some checks, not very extensive
@@ -1347,16 +1348,16 @@ class Slicer(object):
                                     rowspan=grid[0], aspect=aspect1)
         if self.yx:
             self.ax1.set_ylabel('x')
-            if range_y is not None:
-                self.ax1.set_xlim([range_y[0], range_y[1]])
-            if range_x is not None:
-                self.ax1.set_ylim([range_x[0], range_x[1]])
+            if ylim is not None:
+                self.ax1.set_xlim([ylim[0], ylim[1]])
+            if xlim is not None:
+                self.ax1.set_ylim([xlim[0], xlim[1]])
         else:
             self.ax1.set_ylabel('y')
-            if range_x is not None:
-                self.ax1.set_xlim([range_x[0], range_x[1]])
-            if range_y is not None:
-                self.ax1.set_ylim([range_y[0], range_y[1]])
+            if xlim is not None:
+                self.ax1.set_xlim([xlim[0], xlim[1]])
+            if ylim is not None:
+                self.ax1.set_ylim([ylim[0], ylim[1]])
         self.ax1.xaxis.set_ticks_position('top')
         plt.setp(self.ax1.get_xticklabels(), visible=False)
 
@@ -1367,15 +1368,15 @@ class Slicer(object):
         self.ax2.yaxis.set_ticks_position('both')
         if self.yx:
             self.ax2.set_xlabel('y')
-            if range_y is not None:
-                self.ax2.set_xlim([range_y[0], range_y[1]])
+            if ylim is not None:
+                self.ax2.set_xlim([ylim[0], ylim[1]])
         else:
             self.ax2.set_xlabel('x')
-            if range_x is not None:
-                self.ax2.set_xlim([range_x[0], range_x[1]])
+            if xlim is not None:
+                self.ax2.set_xlim([xlim[0], xlim[1]])
         self.ax2.set_ylabel('z')
-        if range_z is not None:
-            self.ax2.set_ylim([range_z[0], range_z[1]])
+        if zlim is not None:
+            self.ax2.set_ylim([zlim[0], zlim[1]])
 
         # Z-Y
         self.ax3 = plt.subplot2grid(figgrid, (0, grid[1]), colspan=grid[2],
@@ -1386,13 +1387,13 @@ class Slicer(object):
         self.ax3.invert_xaxis()
         plt.setp(self.ax3.get_yticklabels(), visible=False)
         if self.yx:
-            if range_x is not None:
-                self.ax3.set_ylim([range_x[0], range_x[1]])
+            if xlim is not None:
+                self.ax3.set_ylim([xlim[0], xlim[1]])
         else:
-            if range_y is not None:
-                self.ax3.set_ylim([range_y[0], range_y[1]])
-        if range_z is not None:
-            self.ax3.set_xlim([range_z[1], range_z[0]])
+            if ylim is not None:
+                self.ax3.set_ylim([ylim[0], ylim[1]])
+        if zlim is not None:
+            self.ax3.set_xlim([zlim[1], zlim[0]])
 
         # Cross-line properties
         # We have to lines, a thick white one, and in the middle a thin black

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -736,8 +736,9 @@ class TensorView(object):
 
     def plot_3d_slicer(self, v, xslice=None, yslice=None, zslice=None,
                        vType='CC', view='real', axis='xy', transparent=None,
-                       clim=None, aspect='auto', grid=[2, 2, 1],
-                       pcolorOpts=None, fig=None):
+                       clim=None, range_x=None, range_y=None, range_z=None,
+                       aspect='auto', grid=[2, 2, 1], pcolorOpts=None,
+                       fig=None):
         """Plot slices of a 3D volume, interactively (scroll wheel).
 
         If called from a notebook, make sure to set
@@ -771,8 +772,10 @@ class TensorView(object):
             fig.clf()
 
         # Populate figure
-        tracker = Slicer(self, v, xslice, yslice, zslice, vType, view, axis,
-                         transparent, clim, aspect, grid, pcolorOpts)
+        tracker = Slicer(
+            self, v, xslice, yslice, zslice, vType, view, axis, transparent,
+            clim, range_x, range_y, range_z, aspect, grid, pcolorOpts
+        )
 
         # Connect figure to scrolling
         fig.canvas.mpl_connect('scroll_event', tracker.onscroll)
@@ -1216,6 +1219,9 @@ class Slicer(object):
     clim : None or list of [min, max]
         For pcolormesh (vmin, vmax).
 
+    range_x, range_y, range_z : None or list of [min, max]
+        Axis limits.
+
     aspect : 'auto', 'equal', or num
         Aspect ratio of subplots. Defaults to 'auto'.
 
@@ -1236,7 +1242,8 @@ class Slicer(object):
 
     def __init__(self, mesh, v, xslice=None, yslice=None, zslice=None,
                  vType='CC', view='real', axis='xy', transparent=None,
-                 clim=None, aspect='auto', grid=[2, 2, 1], pcolorOpts=None):
+                 clim=None, range_x=None, range_y=None, range_z=None,
+                 aspect='auto', grid=[2, 2, 1], pcolorOpts=None):
         """Initialize interactive figure."""
 
         # 0. Some checks, not very extensive
@@ -1341,8 +1348,16 @@ class Slicer(object):
                                     rowspan=grid[0], aspect=aspect1)
         if self.yx:
             self.ax1.set_ylabel('x')
+            if range_y is not None:
+                self.ax1.set_xlim([range_y[0], range_y[1]])
+            if range_x is not None:
+                self.ax1.set_ylim([range_x[0], range_x[1]])
         else:
             self.ax1.set_ylabel('y')
+            if range_x is not None:
+                self.ax1.set_xlim([range_x[0], range_x[1]])
+            if range_y is not None:
+                self.ax1.set_ylim([range_y[0], range_y[1]])
         self.ax1.xaxis.set_ticks_position('top')
         plt.setp(self.ax1.get_xticklabels(), visible=False)
 
@@ -1353,9 +1368,15 @@ class Slicer(object):
         self.ax2.yaxis.set_ticks_position('both')
         if self.yx:
             self.ax2.set_xlabel('y')
+            if range_y is not None:
+                self.ax2.set_xlim([range_y[0], range_y[1]])
         else:
             self.ax2.set_xlabel('x')
+            if range_x is not None:
+                self.ax2.set_xlim([range_x[0], range_x[1]])
         self.ax2.set_ylabel('z')
+        if range_z is not None:
+            self.ax2.set_ylim([range_z[0], range_z[1]])
 
         # Z-Y
         self.ax3 = plt.subplot2grid(figgrid, (0, grid[1]), colspan=grid[2],
@@ -1365,6 +1386,14 @@ class Slicer(object):
         self.ax3.xaxis.set_ticks_position('both')
         self.ax3.invert_xaxis()
         plt.setp(self.ax3.get_yticklabels(), visible=False)
+        if self.yx:
+            if range_x is not None:
+                self.ax3.set_ylim([range_x[0], range_x[1]])
+        else:
+            if range_y is not None:
+                self.ax3.set_ylim([range_y[0], range_y[1]])
+        if range_z is not None:
+            self.ax3.set_xlim([range_z[1], range_z[0]])
 
         # Cross-line properties
         # We have to lines, a thick white one, and in the middle a thin black


### PR DESCRIPTION
Add `(x,y,z)lim` to limit the axis. It works with the interactive tools and the home-button will reset to the provided limits. Resolves #165.

![Peek 2019-05-21 08-25](https://user-images.githubusercontent.com/8020943/58073128-19d7c400-7ba2-11e9-8b97-e603410128a0.gif)

