### PR TITLE
serialization of basemesh 

### DIFF
--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -84,6 +84,9 @@
 #      |           |         ^
 #      |___________|         |___> x
 #      0    e3     1
+
+import properties
+
 from .base import BaseTensorMesh
 from .InnerProducts import InnerProducts
 from .MeshIO import TreeMeshIO
@@ -101,7 +104,12 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
     _meshType = 'TREE'
 
     #inheriting stuff from BaseTensorMesh that isn't defined in _QuadTree
-    def __init__(self, h, x0=None, **kwargs):
+    def __init__(self, h=None, x0=None, **kwargs):
+        if 'h' in kwargs.keys():
+            h = kwargs.pop('h')
+        if 'x0' in kwargs.keys():
+            x0 = kwargs.pop('x0')
+        # print(h, x0)
         BaseTensorMesh.__init__(self, h, x0)#TODO:, **kwargs) # pass the kwargs for copy/paste
 
         nx = len(self.h[0])
@@ -230,6 +238,10 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         full_tbl += "</table>\n"
 
         return full_tbl
+
+    @properties.validator('x0')
+    def _x0_validator(self, change):
+        self._set_x0(change['value'])
 
     @property
     def vntF(self):

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -121,6 +121,11 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         # Now can initialize cpp tree parent
         _TreeMesh.__init__(self, self.h, self.x0)
 
+        if 'cell_levels' in kwargs.keys() and 'cell_indexes' in kwargs.keys():
+            inds = kwargs.pop('cell_indexes')
+            levels = kwargs.pop('cell_levels')
+            self.__setstate__((inds, levels))
+
     def __repr__(self):
         """Plain text representation."""
         mesh_name = '{0!s}TreeMesh'.format(('Oc' if self.dim==3 else 'Quad'))
@@ -644,8 +649,17 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
             plt.show()
         return tuple(out)
 
-    def save(self, *args, **kwargs):
-        raise NotImplementedError()
+    def serialize(self):
+        serial = BaseTensorMesh.serialize(self)
+        inds, levels = self.__getstate__()
+        serial['cell_indexes'] = inds
+        serial['cell_levels'] = levels
+        return serial
+
+    @classmethod
+    def deserialize(cls, serial):
+        mesh = cls(**serial)
+        return mesh
 
     def load(self, *args, **kwargs):
         raise NotImplementedError()

--- a/discretize/base/base_mesh.py
+++ b/discretize/base/base_mesh.py
@@ -29,9 +29,9 @@ class BaseMesh(properties.HasProperties, InterfaceMixins):
 
     x0 = properties.Array(
         "origin of the mesh (dim, )",
-        dtype=float,
+        dtype=(float, int),
         shape=('*',),
-        required=True
+        required=True,
     )
 
     # Instantiate the class
@@ -503,8 +503,8 @@ class BaseRectangularMesh(BaseMesh):
     """
 
 
-    def __init__(self, n, x0=None, **kwargs):
-        BaseMesh.__init__(self, n, x0=x0, **kwargs)
+    def __init__(self, n=None, x0=None, **kwargs):
+        BaseMesh.__init__(self, n=n, x0=x0, **kwargs)
 
     @property
     def nCx(self):

--- a/discretize/base/base_mesh.py
+++ b/discretize/base/base_mesh.py
@@ -35,8 +35,9 @@ class BaseMesh(properties.HasProperties, InterfaceMixins):
     )
 
     # Instantiate the class
-    def __init__(self, n, x0=None, **kwargs):
-        self._n = n  # number of dimensions
+    def __init__(self, n=None, x0=None, **kwargs):
+        if n is not None:
+            self._n = n  # number of dimensions
 
         if x0 is None:
             self.x0 = np.zeros(len(self._n))

--- a/discretize/base/base_tensor_mesh.py
+++ b/discretize/base/base_tensor_mesh.py
@@ -84,7 +84,7 @@ class BaseTensorMesh(BaseMesh):
                     raise Exception(
                         "x0[{0:d}] must be a scalar or '0' to be zero, "
                         "'C' to center, or 'N' to be negative. The input value"
-                        "{} is invalid".format(i, x_i)
+                        "{1} is invalid".format(i, x_i)
                     )
 
         if 'n' in kwargs.keys():

--- a/discretize/base/base_tensor_mesh.py
+++ b/discretize/base/base_tensor_mesh.py
@@ -84,7 +84,7 @@ class BaseTensorMesh(BaseMesh):
                     raise Exception(
                         "x0[{0:d}] must be a scalar or '0' to be zero, "
                         "'C' to center, or 'N' to be negative. The input value"
-                        "{1} is invalid".format(i, x_i)
+                        " {1} <{2}> is invalid".format(i, x_i, type(x_i))
                     )
 
         if 'n' in kwargs.keys():

--- a/discretize/base/base_tensor_mesh.py
+++ b/discretize/base/base_tensor_mesh.py
@@ -84,7 +84,7 @@ class BaseTensorMesh(BaseMesh):
                     raise Exception(
                         "x0[{0:d}] must be a scalar or '0' to be zero, "
                         "'C' to center, or 'N' to be negative. The input value"
-                        " {1} <{2}> is invalid".format(i, x_i, type(x_i))
+                        " {1} {2} is invalid".format(i, x_i, type(x_i))
                     )
 
         if 'n' in kwargs.keys():

--- a/discretize/base/base_tensor_mesh.py
+++ b/discretize/base/base_tensor_mesh.py
@@ -83,7 +83,8 @@ class BaseTensorMesh(BaseMesh):
                 else:
                     raise Exception(
                         "x0[{0:d}] must be a scalar or '0' to be zero, "
-                        "'C' to center, or 'N' to be negative.".format(i)
+                        "'C' to center, or 'N' to be negative. The input value"
+                        "{} is invalid".format(i, x_i)
                     )
 
         if 'n' in kwargs.keys():

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -12,7 +12,6 @@ import scipy.sparse as sp
 from scipy.spatial import Delaunay, cKDTree
 from six import integer_types
 import numpy as np
-from properties.utils import Sentinel
 
 cdef class TreeCell:
     """A Cell of the `TreeMesh`
@@ -446,10 +445,6 @@ cdef class _TreeMesh:
         self.tree.number()
 
     def _set_x0(self, x0):
-        # On object creation, x0 attempts to be set to properties.utils.Sentinel, so guard against this
-        # I believe this happens in the BaseMesh class
-        if isinstance(x0, Sentinel):
-            return # do nothing!!
         if not isinstance(x0, (list, tuple, np.ndarray)):
             raise ValueError('x0 must be a list, tuple or numpy array')
         self._x0 = np.asarray(x0, dtype=np.float64)

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -445,13 +445,7 @@ cdef class _TreeMesh:
         """Number the cells, nodes, faces, and edges of the TreeMesh"""
         self.tree.number()
 
-    @property
-    def x0(self):
-        """Origin of the mesh"""
-        return np.array(self._x0)
-
-    @x0.setter
-    def x0(self, x0):
+    def _set_x0(self, x0):
         # On object creation, x0 attempts to be set to properties.utils.Sentinel, so guard against this
         # I believe this happens in the BaseMesh class
         if isinstance(x0, Sentinel):

--- a/discretize/utils/codeutils.py
+++ b/discretize/utils/codeutils.py
@@ -2,9 +2,9 @@ from __future__ import print_function, division
 import numpy as np
 import sys
 if sys.version_info < (3,):
-    scalarTypes = [float, int, long, np.float_, np.int_]
+    scalarTypes = [float, int, long, np.float64, np.int64, np.int32]
 else:
-    scalarTypes = [float, int, np.float_, np.int_]
+    scalarTypes = [float, int, np.float64, np.int64, np.int32]
 
 
 def isScalar(f):

--- a/discretize/utils/codeutils.py
+++ b/discretize/utils/codeutils.py
@@ -2,13 +2,13 @@ from __future__ import print_function, division
 import numpy as np
 import sys
 if sys.version_info < (3,):
-    scalarTypes = [float, int, long, np.float64, np.int64, np.int32]
+    scalarTypes = (float, int, long, np.float64, np.int64, np.int32)
 else:
-    scalarTypes = [float, int, np.float64, np.int64, np.int32]
+    scalarTypes = (float, int, np.float64, np.int64, np.int32)
 
 
 def isScalar(f):
-    if type(f) in scalarTypes:
+    if isinstance(f, scalarTypes):
         return True
     elif isinstance(f, np.ndarray) and f.size == 1 and type(f[0]) in scalarTypes:
         return True

--- a/discretize/utils/codeutils.py
+++ b/discretize/utils/codeutils.py
@@ -3,14 +3,14 @@ import numpy as np
 import sys
 
 
-scalarTypes = (float, int, np.number)
+scalarTypes = (complex, float, int, np.number)
 if sys.version_info < (3,):
     scalarTypes += (long, )
 
 def isScalar(f):
     if isinstance(f, scalarTypes):
         return True
-    elif isinstance(f, np.ndarray) and f.size == 1 and type(f[0]) in scalarTypes:
+    elif isinstance(f, np.ndarray) and f.size == 1 and isinstance(f[0], scalarTypes):
         return True
     return False
 

--- a/discretize/utils/codeutils.py
+++ b/discretize/utils/codeutils.py
@@ -3,7 +3,7 @@ import numpy as np
 import sys
 
 
-scalarTypes = (float, int, np.float_, np.float64, np.int64, np.int32, np.number)
+scalarTypes = (float, int, np.number)
 if sys.version_info < (3,):
     scalarTypes += (long, )
 

--- a/discretize/utils/codeutils.py
+++ b/discretize/utils/codeutils.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division
 import numpy as np
 import sys
-if sys.version_info < (3,):
-    scalarTypes = (float, int, long, np.float64, np.int64, np.int32)
-else:
-    scalarTypes = (float, int, np.float64, np.int64, np.int32)
 
+
+scalarTypes = (float, int, np.float_, np.float64, np.int64, np.int32, np.number)
+if sys.version_info < (3,):
+    scalarTypes += (long, )
 
 def isScalar(f):
     if isinstance(f, scalarTypes):

--- a/tests/base/test_basemesh.py
+++ b/tests/base/test_basemesh.py
@@ -106,6 +106,12 @@ class TestBaseMesh(unittest.TestCase):
         self.assertTrue(np.all(Yc == 2))
         self.assertTrue(np.all(Zc == 3))
 
+    def test_serialization(self):
+        self.mesh.x0 = np.r_[-1., -2., 1.]
+        mesh2 = BaseRectangularMesh.deserialize(self.mesh.serialize())
+        self.assertTrue(np.all(self.mesh.x0 == mesh2.x0))
+        self.assertTrue(np.all(self.mesh._n == mesh2._n))
+
 
 class TestMeshNumbers2D(unittest.TestCase):
 

--- a/tests/base/test_tensor.py
+++ b/tests/base/test_tensor.py
@@ -117,6 +117,14 @@ class BasicTensorMeshTests(unittest.TestCase):
         M = discretize.TensorMesh([[(10., 2)]])
         self.assertLess(np.abs(M.hx - np.r_[10., 10.]).sum(), TOL)
 
+    def test_serialization(self):
+        mesh = discretize.TensorMesh.deserialize(self.mesh2.serialize())
+        self.assertTrue(np.all(self.mesh2.x0 == mesh.x0))
+        self.assertTrue(np.all(self.mesh2._n == mesh._n))
+        self.assertTrue(np.all(self.mesh2.hx == mesh.hx))
+        self.assertTrue(np.all(self.mesh2.hy == mesh.hy))
+        self.assertTrue(np.all(self.mesh2.gridCC == mesh.gridCC))
+
 
 class TestPoissonEqn(discretize.Tests.OrderTest):
     name = "Poisson Equation"

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -209,10 +209,12 @@ class TestSequenceFunctions(unittest.TestCase):
     def test_isScalar(self):
         self.assertTrue(isScalar(1.))
         self.assertTrue(isScalar(1))
+        self.assertTrue(isScalar(1j))
         if sys.version_info < (3, ):
             self.assertTrue(isScalar(long(1)))
         self.assertTrue(isScalar(np.r_[1.]))
         self.assertTrue(isScalar(np.r_[1]))
+        self.assertTrue(isScalar(np.r_[1j]))
 
     def test_asArray_N_x_Dim(self):
 

--- a/tests/cyl/test_cyl.py
+++ b/tests/cyl/test_cyl.py
@@ -298,6 +298,15 @@ class TestCyl2DMesh(unittest.TestCase):
         assert np.abs(mag[dist > 0.1].max() - 1) < TOL
         assert np.abs(mag[dist > 0.1].min() - 1) < TOL
 
+    def test_serialization(self):
+        mesh = discretize.CylMesh.deserialize(self.mesh.serialize())
+        self.assertTrue(np.all(self.mesh.x0 == mesh.x0))
+        self.assertTrue(np.all(self.mesh._n == mesh._n))
+        self.assertTrue(np.all(self.mesh.hx == mesh.hx))
+        self.assertTrue(np.all(self.mesh.hy == mesh.hy))
+        self.assertTrue(np.all(self.mesh.hz == mesh.hz))
+        self.assertTrue(np.all(self.mesh.gridCC == mesh.gridCC))
+
 
 MESHTYPES = ['uniformCylMesh']
 call2 = lambda fun, xyz: fun(xyz[:, 0], xyz[:, 2])

--- a/tests/tree/test_tree.py
+++ b/tests/tree/test_tree.py
@@ -114,6 +114,7 @@ class TestSimpleQuadTree(unittest.TestCase):
     def test_serialization(self):
         hx, hy = np.r_[1., 2, 3, 4], np.r_[5., 6, 7, 8]
         mesh1 = discretize.TreeMesh([hx, hy], levels=2, x0=np.r_[-1, -1])
+        mesh1.refine(2)
         mesh2 = discretize.TreeMesh.deserialize(mesh1.serialize())
         self.assertTrue(np.all(mesh1.x0 == mesh2.x0))
         self.assertTrue(np.all(mesh1._n == mesh2._n))

--- a/tests/tree/test_tree.py
+++ b/tests/tree/test_tree.py
@@ -111,6 +111,18 @@ class TestSimpleQuadTree(unittest.TestCase):
 
         self.assertEqual((M.faceDiv - T.permuteCC*T.faceDiv*T.permuteF.T).nnz, 0)
 
+    def test_serialization(self):
+        hx, hy = np.r_[1., 2, 3, 4], np.r_[5., 6, 7, 8]
+        mesh1 = discretize.TreeMesh([hx, hy], levels=2, x0=np.r_[-1, -1])
+        mesh2 = discretize.TreeMesh.deserialize(mesh1.serialize())
+        self.assertTrue(np.all(mesh1.x0 == mesh2.x0))
+        self.assertTrue(np.all(mesh1._n == mesh2._n))
+        self.assertTrue(np.all(mesh1.gridCC == mesh2.gridCC))
+
+        mesh1.x0 = np.r_[-2., 2]
+        mesh2 = discretize.TreeMesh.deserialize(mesh1.serialize())
+        self.assertTrue(np.all(mesh1.x0 == mesh2.x0))
+
 
 class TestOcTree(unittest.TestCase):
 


### PR DESCRIPTION
update instantiation of basemesh so meshes can be formed from their serialized state, e.g.
```
mesh = discretize.BaseMesh.deserialize(mesh_json)
```
will have the value of `_n` stored, thus, `n` does not need to be provided on instantiation 