### PR TITLE
Resolving #184

### DIFF
--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -97,6 +97,15 @@ from scipy.spatial import Delaunay
 import scipy.sparse as sp
 from six import integer_types
 
+from discretize.utils.codeutils import requires
+# matplotlib is a soft dependencies for discretize
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib
+except ImportError:
+    matplotlib = False
+
+
 class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
     """
     TreeMesh is a class for adaptive QuadTree (2D) and OcTree (3D) meshes.
@@ -521,6 +530,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
             P = np.r_[Px, Py, Pz]
         return sp.identity(self.nE).tocsr()[P]
 
+    @requires({'matplotlib': matplotlib})
     def plotSlice(
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
@@ -562,9 +572,6 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
 
         if not isinstance(grid, bool):
             raise TypeError('grid must be a boolean')
-
-        import matplotlib.pyplot as plt
-        import matplotlib
 
         normalInd = {'X': 0, 'Y': 1, 'Z': 2}[normal]
         antiNormalInd = {'X': [1, 2], 'Y': [0, 2], 'Z': [0, 1]}[normal]

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -17,7 +17,6 @@ except ImportError:
     matplotlib = False
 
 
-@requires({'matplotlib': matplotlib})
 class TensorView(object):
     """Provides viewing functions for TensorMesh
 
@@ -49,6 +48,7 @@ class TensorView(object):
     #         pltNum +=1
     #     if showIt: plt.show()
 
+    @requires({'matplotlib': matplotlib})
     def plotImage(
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
@@ -202,6 +202,7 @@ class TensorView(object):
             plt.show()
         return ph
 
+    @requires({'matplotlib': matplotlib})
     def plotSlice(
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
@@ -369,6 +370,7 @@ class TensorView(object):
         ax.set_title('Slice {0:.0f}'.format(ind))
         return out
 
+    @requires({'matplotlib': matplotlib})
     def _plotImage2D(
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
@@ -570,6 +572,7 @@ class TensorView(object):
             plt.show()
         return out
 
+    @requires({'matplotlib': matplotlib})
     def plotGrid(
         self, ax=None, nodes=False, faces=False, centers=False, edges=False,
         lines=True, showIt=False, **kwargs
@@ -742,6 +745,7 @@ class TensorView(object):
         return ax
 
 
+    @requires({'matplotlib': matplotlib})
     def plot_3d_slicer(self, v, xslice=None, yslice=None, zslice=None,
                        vType='CC', view='real', axis='xy', transparent=None,
                        clim=None, xlim=None, ylim=None, zlim=None,
@@ -792,9 +796,12 @@ class TensorView(object):
         plt.show()
 
 
-@requires({'matplotlib': matplotlib})
 class CylView(object):
 
+    def __init__(self):
+        pass
+
+    @requires({'matplotlib': matplotlib})
     def _plotCylTensorMesh(self, plotType, *args, **kwargs):
 
         if not self.isSymmetric:
@@ -891,6 +898,7 @@ class CylView(object):
 
         return out
 
+    @requires({'matplotlib': matplotlib})
     def plotGrid(self, *args, **kwargs):
         if self.isSymmetric:
             return self._plotCylTensorMesh('plotGrid', *args, **kwargs)
@@ -960,6 +968,7 @@ for reference, see: http://matplotlib.org/examples/pylab_examples/polar_demo.htm
 
         return ax
 
+    @requires({'matplotlib': matplotlib})
     def _plotGridThetaSlice(self, *args, **kwargs):
         if self.isSymmetric:
             return self.plotGrid(*args, **kwargs)
@@ -969,6 +978,7 @@ for reference, see: http://matplotlib.org/examples/pylab_examples/polar_demo.htm
         mesh2D = self.__class__(h=h2d, x0=self.x0)
         return mesh2D.plotGrid(*args, **kwargs)
 
+    @requires({'matplotlib': matplotlib})
     def _plotGridZSlice(self, *args, **kwargs):
         # https://github.com/matplotlib/matplotlib/issues/312
         ax = kwargs.get('ax', None)
@@ -1019,11 +1029,11 @@ for reference, see: http://matplotlib.org/examples/pylab_examples/polar_demo.htm
 
         return ax
 
+    @requires({'matplotlib': matplotlib})
     def plotImage(self, *args, **kwargs):
         return self._plotCylTensorMesh('plotImage', *args, **kwargs)
 
 
-@requires({'matplotlib': matplotlib})
 class CurviView(object):
     """
     Provides viewing functions for CurvilinearMesh
@@ -1034,6 +1044,7 @@ class CurviView(object):
     def __init__(self):
         pass
 
+    @requires({'matplotlib': matplotlib})
     def plotGrid(
         self, ax=None, nodes=False, faces=False, centers=False, edges=False,
         lines=True, showIt=False, **kwargs
@@ -1131,6 +1142,7 @@ class CurviView(object):
 
         return ax
 
+    @requires({'matplotlib': matplotlib})
     def plotImage(
         self, I, ax=None, showIt=False, grid=False, clim=None
     ):

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -13,6 +13,19 @@ from scipy.spatial import Delaunay, cKDTree
 from six import integer_types
 import numpy as np
 
+from discretize.utils.codeutils import requires
+# matplotlib is a soft dependencies for discretize
+try:
+    import matplotlib
+    import matplotlib.cm as cmx
+    import matplotlib.pyplot as plt
+    import matplotlib.colors as colors
+    from mpl_toolkits.mplot3d import Axes3D
+    from matplotlib.collections import PatchCollection
+except ImportError:
+    matplotlib = False
+
+
 cdef class TreeCell:
     """A Cell of the `TreeMesh`
 
@@ -3303,6 +3316,7 @@ cdef class _TreeMesh:
 
         return sp.csr_matrix((V, (I, J)), shape=(locs.shape[0],self.nC))
 
+    @requires({'matplotlib': matplotlib})
     def plotGrid(self,
         ax=None, nodes=False, faces=False, centers=False, edges=False,
         lines=True, cell_line=False,
@@ -3345,15 +3359,10 @@ cdef class _TreeMesh:
             Axes handle for the plot
 
         """
-        import matplotlib
         if ax is None:
-            import matplotlib.pyplot as plt
-            import matplotlib.colors as colors
-            import matplotlib.cm as cmx
             if(self._dim == 2):
                 ax = plt.subplot(111)
             else:
-                from mpl_toolkits.mplot3d import Axes3D
                 ax = plt.subplot(111, projection='3d')
         else:
             if not isinstance(ax, matplotlib.axes.Axes):
@@ -3504,6 +3513,7 @@ cdef class _TreeMesh:
 
         return ax
 
+    @requires({'matplotlib': matplotlib})
     def plotImage(self, v, vType='CC', grid=False, view='real',
                   ax=None, clim=None, showIt=False,
                   pcolorOpts=None,
@@ -3544,13 +3554,6 @@ cdef class _TreeMesh:
 
         if view == 'vec':
             raise NotImplementedError('Vector ploting is not supported on TreeMesh (yet)')
-
-        import matplotlib.pyplot as plt
-        import matplotlib
-        import matplotlib.colors as colors
-        import matplotlib.cm as cmx
-        from matplotlib.collections import PatchCollection
-
 
         if view in ['real', 'imag', 'abs']:
             v = getattr(np, view)(v) # e.g. np.real(v)


### PR DESCRIPTION
The problem of #184 is that the plotting classes are inherited by other classes, so they should always be available. The fix is therefore to move the `@requires` from the class level down to the function level. This should answer @rowanc1 question :wink: (https://github.com/simpeg/discretize/pull/156#discussion_r281029700).

This PR will close #184.