### PR TITLE
Numpy build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,7 @@ env:
 
 matrix:
   include:
-    # test the base code on 2.7, 3.6, 3.7
-    - name: "Python 2.7 - base"
-      os: linux
-      env:
-        - PYTHON=2.7
-        - TEST=true
-        - TEST_DIR="tests/base"
+    # test the base code on 3.6, 3.7
     - name: "Python 3.6 - base"
       os: linux
       env:
@@ -40,13 +34,7 @@ matrix:
         - TEST=true
         - TEST_DIR="tests/base"
 
-    # test the cyl code on 2.7, 3.6, 3.7
-    - name: "Python 2.7 - cyl"
-      os: linux
-      env:
-        - PYTHON=2.7
-        - TEST=true
-        - TEST_DIR="tests/cyl"
+    # test the cyl code on 3.6, 3.7
     - name: "Python 3.6 - cyl"
       os: linux
       env:
@@ -60,15 +48,7 @@ matrix:
         - TEST=true
         - TEST_DIR="tests/cyl"
 
-    # test the cyl code on 2.7, 3.6, 3.7
-    - name: "Python 2.7 - tree"
-      os: linux
-      env:
-        - PYTHON=2.7
-        - TEST=true
-        - TEST_DIR="tests/tree"
-        - DEPLOY_PYPI=true
-        - CONDA_INSTALL_EXTRA="twine"
+    # test the cyl code on 3.6, 3.7
     - name: "Python 3.6 - tree"
       os: linux
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ build: off
 
 environment:
   matrix:
-    - PYTHON_VERSION: 2.7
-      CONDA: C:\Miniconda
-
     - PYTHON_VERSION: 3.6
       CONDA: C:\Miniconda36
 

--- a/discretize/Tests.py
+++ b/discretize/Tests.py
@@ -363,7 +363,6 @@ def checkDerivative(fctn, x0, num=7, plotIt=True, dx=None, expectedOrder=2, tole
         print("{0!s}\n{1!s} FAIL! {2!s}\n{3!s}".format('*'*57, '<'*25, '>'*25, '*'*57))
         print(sadness[np.random.randint(len(sadness))]+'\n')
 
-
     @requires({'matplotlib': matplotlib})
     def plot_it(ax):
         if plotIt:
@@ -381,7 +380,7 @@ def checkDerivative(fctn, x0, num=7, plotIt=True, dx=None, expectedOrder=2, tole
                 ['$\mathcal{O}(h)$', '$\mathcal{O}(h^2)$'], loc='best',
                 title="$f(x + h\Delta x) - f(x) - h g(x) \Delta x - \mathcal{O}(h^2) = 0$",
                 frameon=False)
-            plt.setp(leg.get_title(),fontsize=15)
+            plt.setp(leg.get_title(), fontsize=15)
             plt.show()
 
     plot_it(ax)

--- a/discretize/Tests.py
+++ b/discretize/Tests.py
@@ -365,7 +365,7 @@ def checkDerivative(fctn, x0, num=7, plotIt=True, dx=None, expectedOrder=2, tole
 
 
     @requires({'matplotlib': matplotlib})
-    def plot_it():
+    def plot_it(ax):
         if plotIt:
             if ax is None:
                 ax = plt.subplot(111)
@@ -384,7 +384,7 @@ def checkDerivative(fctn, x0, num=7, plotIt=True, dx=None, expectedOrder=2, tole
             plt.setp(leg.get_title(),fontsize=15)
             plt.show()
 
-    plot_it()
+    plot_it(ax)
 
     return passTest
 

--- a/examples/plot_dc_resistivity.py
+++ b/examples/plot_dc_resistivity.py
@@ -47,14 +47,15 @@ def run(plotIt=True):
     # Step4: Making Figure
     fig, axes = plt.subplots(1, 2, figsize=(12*1.2, 4*1.2))
     vmin, vmax = phitM.min(), phitM.max()
+    
     dat = tM.plotImage(phitM, ax=axes[0], clim=(vmin, vmax), grid=True)
-    dat = rM.plotImage(phirM, ax=axes[1], clim=(vmin, vmax), grid=True)
     cb0 = plt.colorbar(dat[0], ax=axes[0])
-    cb1 = plt.colorbar(dat[0], ax=axes[1])
     cb0.set_label("Voltage (V)")
-    cb1.set_label("Voltage (V)")
-
     axes[0].set_title('TensorMesh')
+
+    dat = rM.plotImage(phirM, ax=axes[1], clim=(vmin, vmax), grid=True)
+    cb1 = plt.colorbar(dat[0], ax=axes[1])
+    cb1.set_label("Voltage (V)")
     axes[1].set_title('CurvilinearMesh')
 
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
             'clean')):
         # For these actions, NumPy is not required.
         #
-        # They are required to succeed without Numpy for example when
+        # They are required to succeed without Numpy, for example when
         # pip is used to install discretize when Numpy is not yet present in
         # the system.
         try:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ build_requires = [
     'scipy>=0.13',
     'cython>=0.2',
     'pymatsolver>=0.1.2',
-    'properties[math]',
+    'properties',
+    'vectormath',
     ]
 
 metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ else:
     metadata['configuration'] = configuration
 
     # A Small hack to remove -std=c99 from c++ compiler options (if present)
+    # This should only be if numpy 1.18.0 is installed.
     from numpy.distutils.ccompiler import CCompiler_customize, CCompiler
     from numpy.distutils.ccompiler import replace_method
     _np_customize = CCompiler_customize

--- a/setup.py
+++ b/setup.py
@@ -5,20 +5,8 @@ from __future__ import print_function
 Discretization tools for finite volume and inverse problems.
 """
 
-from setuptools import find_packages
-
-try:
-    from numpy.distutils.core import setup
-except Exception:
-    raise Exception(
-        "Install requires numpy. "
-        "If you use conda, `conda install numpy` "
-        "or you can use pip, `pip install numpy`"
-    )
-
 import os
 import sys
-import numpy
 
 
 CLASSIFIERS = [
@@ -37,9 +25,6 @@ CLASSIFIERS = [
     'Natural Language :: English',
 ]
 
-with open("README.rst") as f:
-    LONG_DESCRIPTION = ''.join(f.readlines())
-
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
@@ -54,16 +39,23 @@ def configuration(parent_package='', top_path=None):
 
     return config
 
-setup(
+
+with open("README.rst") as f:
+    LONG_DESCRIPTION = ''.join(f.readlines())
+
+build_requires = [
+    'numpy>=1.8',
+    'scipy>=0.13',
+    'cython>=0.2',
+    'pymatsolver>=0.1.2',
+    'properties[math]',
+    ]
+
+metadata = dict(
     name="discretize",
     version="0.4.10",
-    install_requires=[
-        'numpy>=1.8',
-        'scipy>=0.13',
-        'cython>=0.2',
-        'pymatsolver>=0.1.2',
-        'properties[math]',
-    ],
+    setup_requires=build_requires,
+    install_requires=build_requires,
     author="SimPEG developers",
     author_email="rowanc1@gmail.com",
     description="Discretization tools for finite volume and inverse problems",
@@ -74,7 +66,45 @@ setup(
     download_url="http://github.com/simpeg/discretize",
     classifiers=CLASSIFIERS,
     platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
-    use_2to3=False,
-    setup_requires=['numpy'],
-    configuration=configuration
 )
+
+if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
+        sys.argv[1] in ('--help-commands', 'egg_info', '--version',
+            'clean')):
+        # For these actions, NumPy is not required.
+        #
+        # They are required to succeed without Numpy for example when
+        # pip is used to install discretize when Numpy is not yet present in
+        # the system.
+        try:
+            from setuptools import setup
+        except ImportError:
+            from distutils.core import setup
+else:
+    if (len(sys.argv) >= 2 and sys.argv[1] in ('bdist_wheel', 'bdist_egg')) or (
+                'develop' in sys.argv):
+        # bdist_wheel/bdist_egg needs setuptools
+        import setuptools
+
+    from numpy.distutils.core import setup
+
+    # Add the configuration to the setup dict when building
+    # after numpy is installed
+    metadata['configuration'] = configuration
+
+    # A Small hack to remove -std=c99 from c++ compiler options (if present)
+    from numpy.distutils.ccompiler import CCompiler_customize, CCompiler
+    from numpy.distutils.ccompiler import replace_method
+    _np_customize = CCompiler_customize
+    def _simpeg_customize(self, dist, need_cxx=0):
+        _np_customize(self, dist, need_cxx)
+        if need_cxx:
+            # Remove -std=c99 option if present
+            try:
+                self.compiler_so.remove('-std=c99')
+            except (AttributeError, ValueError):
+                pass
+    replace_method(CCompiler, 'customize', _simpeg_customize)
+
+
+setup(**metadata)


### PR DESCRIPTION
This branch contains a few small bug fixes.
Mainly, it enables discretize to be installed on a system without NumPy present beforehand (for example when pip installing discretize). Resolve #51, Resolve #147
It also contains a small update to the curvilinear mesh view that updates that function to be in line with the other ``plotImage`` functions. Resolve #190 

Also note that this branch removes testing and automatic wheel building for python 2.7