### PR TITLE
Remove pymatsolver

### DIFF
--- a/docs/release/0.4.12-notes.rst
+++ b/docs/release/0.4.12-notes.rst
@@ -33,6 +33,6 @@ Pull requests
 =============
 
 * `#193 <https://github.com/simpeg/discretize/pull/193>`__: Remove pymatsolver
-* `#198 <https://github.com/simpeg/discretize/pull/197>`__: Refine tree xyz
+* `#198 <https://github.com/simpeg/discretize/pull/198>`__: Refine tree xyz
 * `#201 <https://github.com/simpeg/discretize/pull/201>`__: Update README.rst
 * `#203 <https://github.com/simpeg/discretize/pull/203>`__: consolidating tests on travis

--- a/docs/release/0.4.12-notes.rst
+++ b/docs/release/0.4.12-notes.rst
@@ -17,16 +17,22 @@ when attempting to extend the padding vertically using ``method=surface``.
 We have update links as we are now using discourse over google groups as a means
 for users to ask for general help.
 
+We are removing ``pymatsolver`` from the list of explicit dependancies for ``discretize``.
+It is **highly** recommended, but it isn't actually required to run anything
+within the ``discretize`` package.
+
 Contributors
 ============
 
 * @domfournier/@fourndo
 * @jcapriot
 * @lheagy
+* @prisae
 
 Pull requests
 =============
 
+* `#193 <https://github.com/simpeg/discretize/pull/193>`__: Remove pymatsolver
 * `#198 <https://github.com/simpeg/discretize/pull/197>`__: Refine tree xyz
 * `#201 <https://github.com/simpeg/discretize/pull/201>`__: Update README.rst
 * `#203 <https://github.com/simpeg/discretize/pull/203>`__: consolidating tests on travis

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,4 +18,4 @@ coverage
 codecov
 omf
 matplotlib
-pymatsolver
+pymatsolver>=0.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,3 +18,4 @@ coverage
 codecov
 omf
 matplotlib
+pymatsolver

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ build_requires = [
     'numpy>=1.8',
     'scipy>=0.13',
     'cython>=0.2',
-    'pymatsolver>=0.1.2',
     'properties',
     'vectormath',
     ]


### PR DESCRIPTION
Remove `pymatsolver` from `build_requires` in `setup.py`, as it is not required (keep requirements low).