### PR TITLE
Create IO for 2D Tree mesh in UBC-like format

### DIFF
--- a/discretize/MeshIO.py
+++ b/discretize/MeshIO.py
@@ -394,8 +394,6 @@ class TreeMeshIO(object):
         fileLines = np.genfromtxt(meshFile, dtype=str,
                                   delimiter='\n', comments='!')
         nCunderMesh = np.array(fileLines[0].split('!')[0].split(), dtype=int)
-        nCunderMesh = nCunderMesh[:]
-
         tswCorn = np.array(
             fileLines[1].split('!')[0].split(),
             dtype=float
@@ -408,47 +406,25 @@ class TreeMeshIO(object):
         indArr = np.genfromtxt((line.encode('utf8') for line in fileLines[4::]),
                                dtype=np.int)
 
-        dim = len(smallCell)
-        if dim == 2:
-            h1, h2 = [np.ones(nr)*sz for nr, sz in zip(nCunderMesh, smallCell)]
-            x0 = tswCorn - np.array([0, np.sum(h2)])
-            
-            ls = np.log2(nCunderMesh).astype(int)
-            if ls[0] == ls[1]:
-                max_level = ls[0]
-            else:
-                max_level = min(ls)+1
-            
-            mesh = TreeMesh([h1, h2], x0=x0)
-            levels = indArr[:, -1]
-            indArr = indArr[:, :-1]
-    
-            indArr -= 1  # shift by 1....
-            indArr = 2*indArr + levels[:, None]  # get cell center index
-            indArr[:, 1] = 2*nCunderMesh[1] - indArr[:, 1]  # switch direction of iz
-            levels = max_level-np.log2(levels)  # calculate level
-            
+        hs = [np.ones(nr)*sz for nr, sz in zip(nCunderMesh, smallCell)]
+        x0 = tswCorn
+        x0[-1] -= np.sum(hs[-1])
+
+        ls = np.log2(nCunderMesh).astype(int)
+        # if all ls are equal
+        if min(ls) == max(ls):
+            max_level = ls[0]
         else:
-            h1, h2, h3 = [np.ones(nr)*sz for nr, sz in zip(nCunderMesh, smallCell)]
-            x0 = tswCorn - np.array([0, 0, np.sum(h3)])
+            max_level = min(ls)+1
 
-            ls = np.log2(nCunderMesh).astype(int)
-            if ls[0] == ls[1] and ls[1] == ls[2]:
-                max_level = ls[0]
-            else:
-                max_level = min(ls)+1
+        mesh = TreeMesh(hs, x0=x0)
+        levels = indArr[:, -1]
+        indArr = indArr[:, :-1]
 
-            # Convert indArr to points in coordinates of underlying cpp tree
-            # indArr is ix, iy, iz(top-down) need it in ix, iy, iz (bottom-up)
-            mesh = TreeMesh([h1, h2, h3], x0=x0)
-            levels = indArr[:, -1]
-            indArr = indArr[:, :-1]
-    
-            indArr -= 1  # shift by 1....
-            indArr = 2*indArr + levels[:, None]  # get cell center index
-            indArr[:, 2] = 2*nCunderMesh[2] - indArr[:, 2]  # switch direction of iz
-            levels = max_level-np.log2(levels)  # calculate level
-
+        indArr -= 1  # shift by 1....
+        indArr = 2*indArr + levels[:, None]  # get cell center index
+        indArr[:, -1] = 2*nCunderMesh[-1] - indArr[:, -1]  # switch direction of iz
+        levels = max_level-np.log2(levels)  # calculate level
 
         mesh.__setstate__((indArr, levels))
         return mesh
@@ -488,12 +464,10 @@ class TreeMeshIO(object):
         if np.any(~uniform_hs):
             raise Exception('UBC form does not support variable cell widths')
         nCunderMesh = np.array([h.size for h in mesh.h], dtype=np.int64)
-        
-        if mesh.dim == 2:
-            tswCorn = mesh.x0 + np.array([0, np.sum(mesh.h[1])])
-        else:
-            tswCorn = mesh.x0 + np.array([0, 0, np.sum(mesh.h[2])])
-            
+
+        tswCorn = mesh.x0.copy()
+        tswCorn[-1] += np.sum(mesh.h[-1])
+
         smallCell = np.array([h[0] for h in mesh.h])
         nrCells = mesh.nC
 
@@ -504,33 +478,10 @@ class TreeMeshIO(object):
         levels = levels[ubc_order]
 
         # Write the UBC octree mesh file
-        if mesh.dim == 2:
-            head = (
-                '{:.0f} {:.0f} \n'.format(
-                    nCunderMesh[0], nCunderMesh[1]
-                ) +
-                '{:.4f} {:.4f} \n'.format(
-                    tswCorn[0], tswCorn[1]
-                ) +
-                '{:.3f} {:.3f} \n'.format(
-                    smallCell[0], smallCell[1]
-                ) +
-                '{:.0f}'.format(nrCells)
-            )
-
-        else:
-            head = (
-                '{:.0f} {:.0f} {:.0f}\n'.format(
-                    nCunderMesh[0], nCunderMesh[1], nCunderMesh[2]
-                ) +
-                '{:.4f} {:.4f} {:.4f}\n'.format(
-                    tswCorn[0], tswCorn[1], tswCorn[2]
-                ) +
-                '{:.3f} {:.3f} {:.3f}\n'.format(
-                    smallCell[0], smallCell[1], smallCell[2]
-                ) +
-                '{:.0f}'.format(nrCells)
-            )
+        head = ' '.join([f"{int(n)}" for n in nCunderMesh])+" \n"
+        head += ' '.join([f"{v:.4f}" for v in tswCorn])+" \n"
+        head += ' '.join([f"{v:.3f}" for v in smallCell]) + " \n"
+        head += f"{int(nrCells)}"
         np.savetxt(fileName, np.c_[indArr, levels], fmt='%i', header=head, comments='')
 
         # Print the models

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -659,20 +659,14 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
     def serialize(self):
         serial = BaseTensorMesh.serialize(self)
         inds, levels = self.__getstate__()
-        serial['cell_indexes'] = inds
-        serial['cell_levels'] = levels
+        serial['cell_indexes'] = inds.tolist()
+        serial['cell_levels'] = levels.tolist()
         return serial
 
     @classmethod
     def deserialize(cls, serial):
         mesh = cls(**serial)
         return mesh
-
-    def load(self, *args, **kwargs):
-        raise NotImplementedError()
-
-    def copy(self, *args, **kwargs):
-        raise NotImplementedError()
 
     def __reduce__(self):
         return TreeMesh, (self.h, self.x0), self.__getstate__()

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3695,8 +3695,7 @@ cdef class _TreeMesh:
             return self.__ubc_indArr
         indArr, levels = self.__getstate__()
 
-        max_level = self.max_level
-        # max_level = self.tree.max_level
+        max_level = self.tree.max_level
 
         levels = 1<<(max_level - levels)
 
@@ -3704,7 +3703,7 @@ cdef class _TreeMesh:
             indArr[:, -1] = (self._ys.shape[0]-1) - indArr[:, -1]
         else:
             indArr[:, -1] = (self._zs.shape[0]-1) - indArr[:, -1]
-        
+
         indArr = (indArr - levels[:, None])//2
         indArr += 1
 

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3695,11 +3695,16 @@ cdef class _TreeMesh:
             return self.__ubc_indArr
         indArr, levels = self.__getstate__()
 
-        max_level = self.tree.max_level
+        max_level = self.max_level
+        # max_level = self.tree.max_level
 
         levels = 1<<(max_level - levels)
 
-        indArr[:, 2] = (self._zs.shape[0]-1) - indArr[:, 2]
+        if self.dim == 2:
+            indArr[:, -1] = (self._ys.shape[0]-1) - indArr[:, -1]
+        else:
+            indArr[:, -1] = (self._zs.shape[0]-1) - indArr[:, -1]
+        
         indArr = (indArr - levels[:, None])//2
         indArr += 1
 
@@ -3711,7 +3716,10 @@ cdef class _TreeMesh:
         if self.__ubc_order is not None:
             return self.__ubc_order
         indArr, _ = self._ubc_indArr
-        self.__ubc_order = np.lexsort((indArr[:, 0], indArr[:, 1], indArr[:, 2]))
+        if self.dim == 2:
+            self.__ubc_order = np.lexsort((indArr[:, 0], indArr[:, 1]))
+        else:
+            self.__ubc_order = np.lexsort((indArr[:, 0], indArr[:, 1], indArr[:, 2]))
         return self.__ubc_order
 
     def __dealloc__(self):

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3658,6 +3658,8 @@ cdef class _TreeMesh:
 
     def __setstate__(self, state):
         indArr, levels = state
+        indArr = np.asarray(indArr)
+        levels = np.asarray(levels)
         xs = np.array(self._xs)
         ys = np.array(self._ys)
         if self._dim == 3:

--- a/docs/release/0.4.13-notes.rst
+++ b/docs/release/0.4.13-notes.rst
@@ -6,4 +6,22 @@
 ``discretize`` 0.4.13 Release Notes
 ===================================
 
-Placeholder
+This release contains some bug fixes:
+
+First, we have squashed a few bugs related to serializing the TreeMesh to a json
+object. ``tree_mesh.save`` should now work. We have also added the ability to
+write out a 2D ``TreeMesh`` to a UBC-GIF-like format. There is no official QuadTree
+mesh from UBC-GIF however, so this just mimics the 3D format for a 2D mesh.
+
+
+Contributors
+============
+
+* @dccowan
+* @jcapriot
+
+
+Pull requests
+=============
+
+* `#208 <https://github.com/simpeg/discretize/pull/208>`__: Create IO for 2D Tree mesh in UBC-like format

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -1,0 +1,9 @@
+.. currentmodule:: discretize
+
+.. _0.4.14_notes:
+
+===================================
+``discretize`` 0.4.14 Release Notes
+===================================
+
+Placeholder

--- a/tests/tree/test_tree_io.py
+++ b/tests/tree/test_tree_io.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import discretize
 import pickle
+import json
 
 try:
     import vtk
@@ -124,6 +125,96 @@ class TestPickle(unittest.TestCase):
         self.assertTrue(np.allclose(mesh0.gridCC, mesh1.gridCC))
         self.assertTrue(np.allclose(np.array(mesh0.h), np.array(mesh1.h)))
         print('Pickling of 3D TreeMesh is working')
+
+class TestSerialize(unittest.TestCase):
+
+    def test_dic_serialize2D(self):
+        mesh0 = discretize.TreeMesh([8, 8])
+
+        def refine(cell):
+            xyz = cell.center
+            dist = ((xyz - 0.25)**2).sum()**0.5
+            if dist < 0.25:
+                return 3
+            return 2
+
+        mesh0.refine(refine)
+
+        mesh_dict = mesh0.serialize()
+        mesh1 = discretize.TreeMesh.deserialize(mesh_dict)
+
+        self.assertEqual(mesh0.nC, mesh1.nC)
+        self.assertEqual(mesh0.__str__(), mesh1.__str__())
+        self.assertTrue(np.allclose(mesh0.gridCC, mesh1.gridCC))
+        self.assertTrue(np.allclose(np.array(mesh0.h), np.array(mesh1.h)))
+        print('dic serialize 2D is working')
+
+    def test_save_load_json2D(self):
+        mesh0 = discretize.TreeMesh([8, 8])
+
+        def refine(cell):
+            xyz = cell.center
+            dist = ((xyz - 0.25)**2).sum()**0.5
+            if dist < 0.25:
+                return 3
+            return 2
+
+        mesh0.refine(refine)
+
+        mesh0.save('tree.json')
+        with open('tree.json', 'r') as outfile:
+            jsondict = json.load(outfile)
+        mesh1 = discretize.TreeMesh.deserialize(jsondict)
+
+        self.assertEqual(mesh0.nC, mesh1.nC)
+        self.assertEqual(mesh0.__str__(), mesh1.__str__())
+        self.assertTrue(np.allclose(mesh0.gridCC, mesh1.gridCC))
+        self.assertTrue(np.allclose(np.array(mesh0.h), np.array(mesh1.h)))
+        print('json serialize 2D is working')
+
+    def test_dic_serialize3D(self):
+        mesh0 = discretize.TreeMesh([8, 8, 8])
+
+        def refine(cell):
+            xyz = cell.center
+            dist = ((xyz - 0.25)**2).sum()**0.5
+            if dist < 0.25:
+                return 3
+            return 2
+
+        mesh0.refine(refine)
+
+        mesh_dict = mesh0.serialize()
+        mesh1 = discretize.TreeMesh.deserialize(mesh_dict)
+
+        self.assertEqual(mesh0.nC, mesh1.nC)
+        self.assertEqual(mesh0.__str__(), mesh1.__str__())
+        self.assertTrue(np.allclose(mesh0.gridCC, mesh1.gridCC))
+        self.assertTrue(np.allclose(np.array(mesh0.h), np.array(mesh1.h)))
+        print('dic serialize 3D is working')
+
+    def test_save_load_json3D(self):
+        mesh0 = discretize.TreeMesh([8, 8, 8])
+
+        def refine(cell):
+            xyz = cell.center
+            dist = ((xyz - 0.25)**2).sum()**0.5
+            if dist < 0.25:
+                return 3
+            return 2
+
+        mesh0.refine(refine)
+
+        mesh0.save('tree.json')
+        with open('tree.json', 'r') as outfile:
+            jsondict = json.load(outfile)
+        mesh1 = discretize.TreeMesh.deserialize(jsondict)
+
+        self.assertEqual(mesh0.nC, mesh1.nC)
+        self.assertEqual(mesh0.__str__(), mesh1.__str__())
+        self.assertTrue(np.allclose(mesh0.gridCC, mesh1.gridCC))
+        self.assertTrue(np.allclose(np.array(mesh0.h), np.array(mesh1.h)))
+        print('json serialize 3D is working')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Even though the set of meshes used by UBC does not include Quad Tree, it would be useful to add this to the IO. This PR will add QuadTree meshes to the readUBC, writeUBC, readModelUBC and writeModelUBC.