### PR TITLE
Add ability to handle "norm" keyword in pcolorOpts on the TreeMesh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - MASTER_BRANCH=master
     - TEST=false
     - TEST_DIR=""
-    - DEPLOY_PYPI=false
     - CONDA_REQUIREMENTS="numpy scipy matplotlib cython pip"
     - PYPI_REQUIREMENTS=requirements.txt
     - PYPI_REQUIREMENTS_DEV=requirements_dev.txt
@@ -49,6 +48,7 @@ matrix:
         - TEST=true
         - TEST_DIR="tests/docs"
         - DEPLOY_DOCS=true
+        - DEPLOY_PYPI=true
 
 before_install:
   - source ci/setup-miniconda.sh

--- a/discretize/CurvilinearMesh.py
+++ b/discretize/CurvilinearMesh.py
@@ -40,7 +40,7 @@ class CurvilinearMesh(
         import discretize
         X, Y = discretize.utils.exampleLrmGrid([3,3],'rotate')
         mesh = discretize.CurvilinearMesh([X, Y])
-        mesh.plotGrid(showIt=True)
+        mesh.plotGrid(show_it=True)
     """
 
     _meshType = 'Curv'

--- a/discretize/Tests.py
+++ b/discretize/Tests.py
@@ -134,7 +134,7 @@ def setupMesh(meshType, nC, nDim):
             return levels - 1
         mesh.refine(function)
         # mesh.number()
-        # mesh.plotGrid(showIt=True)
+        # mesh.plotGrid(show_it=True)
         max_h = max([np.max(hi) for hi in mesh.h])
     return mesh, max_h
 

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -535,7 +535,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
     def plotSlice(
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
-        ax=None, clim=None, showIt=False,
+        ax=None, clim=None, show_it=False,
         pcolor_opts=None, stream_opts=None, grid_opts=None,
         range_x=None, range_y=None, **other_kwargs
     ):
@@ -548,6 +548,9 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         if "gridOpts" in other_kwargs:
             grid_opts = other_kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
+        if "showIt" in other_kwargs:
+            show_it = other_kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
@@ -651,7 +654,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         out = temp_mesh.plotImage(
             v2d, vType='CC',
             grid=grid, view=view,
-            ax=ax, clim=clim, showIt=False,
+            ax=ax, clim=clim, show_it=False,
             pcolor_opts=pcolor_opts,
             grid_opts=grid_opts,
             range_x=range_x,
@@ -662,7 +665,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         ax.set_title(
             'Slice {0:d}, {1!s} = {2:4.2f}'.format(ind, normal, slice_loc)
         )
-        if showIt:
+        if show_it:
             plt.show()
         return tuple(out)
 

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -536,17 +536,20 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, showIt=False,
-        pcolor_opts=None, streamOpts=None, gridOpts=None,
+        pcolor_opts=None, stream_opts=None, gridOpts=None,
         range_x=None, range_y=None, **other_kwargs
     ):
         if "pcolorOpts" in other_kwargs:
             pcolor_opts = other_kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+        if "streamOpts" in other_kwargs:
+            stream_opts = other_kwargs["streamOpts"]
+            warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
-        if streamOpts is None:
-            streamOpts = {'color': 'k'}
+        if stream_opts is None:
+            stream_opts = {'color': 'k'}
         if gridOpts is None:
             gridOpts = {'color': 'k', 'alpha': 0.5}
         vTypeOpts = ['CC', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez']

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -533,7 +533,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
 
     @requires({'matplotlib': matplotlib})
     def plotSlice(
-        self, v, vType='CC',
+        self, v, v_type='CC',
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, show_it=False,
         pcolor_opts=None, stream_opts=None, grid_opts=None,
@@ -551,6 +551,9 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         if "showIt" in other_kwargs:
             show_it = other_kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
+        if "vType" in other_kwargs:
+            show_it = other_kwargs["vType"]
+            warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
@@ -558,12 +561,12 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
             stream_opts = {'color': 'k'}
         if grid_opts is None:
             grid_opts = {'color': 'k', 'alpha': 0.5}
-        vTypeOpts = ['CC', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez']
+        v_typeOpts = ['CC', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez']
         viewOpts = ['real', 'imag', 'abs']
         normalOpts = ['X', 'Y', 'Z']
-        if vType not in vTypeOpts:
+        if v_type not in v_typeOpts:
             raise ValueError(
-                "vType must be in ['{0!s}']".format("', '".join(vTypeOpts))
+                "v_type must be in ['{0!s}']".format("', '".join(v_typeOpts))
             )
         if self.dim == 2:
             raise NotImplementedError(
@@ -625,18 +628,18 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         tm_gridboost[:, normalInd] = slice_loc
 
         # interpolate values to self.gridCC if not 'CC'
-        if vType is not 'CC':
-            aveOp = 'ave' + vType + '2CC'
+        if v_type is not 'CC':
+            aveOp = 'ave' + v_type + '2CC'
             Av = getattr(self, aveOp)
             if v.size == Av.shape[1]:
                 v = Av*v
-            elif len(vType) == 2:
+            elif len(v_type) == 2:
                 # was one of Fx, Fy, Fz, Ex, Ey, Ez
                 # assuming v has all three components in these cases
-                vec_ind = {'x': 0, 'y': 1, 'z': 2}[vType[1]]
-                if vType[0] == 'E':
+                vec_ind = {'x': 0, 'y': 1, 'z': 2}[v_type[1]]
+                if v_type[0] == 'E':
                     i_s = np.cumsum([0, self.nEx, self.nEy, self.nEz])
-                elif vType[0] == 'F':
+                elif v_type[0] == 'F':
                     i_s = np.cumsum([0, self.nFx, self.nFy, self.nFz])
                 v = v[i_s[vec_ind]:i_s[vec_ind+1]]
                 v = Av*v
@@ -652,7 +655,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
             raise Exception("ax must be an matplotlib.axes.Axes")
 
         out = temp_mesh.plotImage(
-            v2d, vType='CC',
+            v2d, v_type='CC',
             grid=grid, view=view,
             ax=ax, clim=clim, show_it=False,
             pcolor_opts=pcolor_opts,

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -96,6 +96,7 @@ import numpy as np
 from scipy.spatial import Delaunay
 import scipy.sparse as sp
 from six import integer_types
+import warnings
 
 from discretize.utils.codeutils import requires
 # matplotlib is a soft dependencies for discretize
@@ -535,12 +536,15 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, showIt=False,
-        pcolorOpts=None, streamOpts=None, gridOpts=None,
-        range_x=None, range_y=None,
+        pcolor_opts=None, streamOpts=None, gridOpts=None,
+        range_x=None, range_y=None, **other_kwargs
     ):
+        if "pcolorOpts" in other_kwargs:
+            pcolor_opts = other_kwargs["pcolorOpts"]
+            warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
 
-        if pcolorOpts is None:
-            pcolorOpts = {}
+        if pcolor_opts is None:
+            pcolor_opts = {}
         if streamOpts is None:
             streamOpts = {'color': 'k'}
         if gridOpts is None:
@@ -642,7 +646,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
             v2d, vType='CC',
             grid=grid, view=view,
             ax=ax, clim=clim, showIt=False,
-            pcolorOpts=pcolorOpts,
+            pcolor_opts=pcolor_opts,
             gridOpts=gridOpts,
             range_x=range_x,
             range_y=range_y)

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -537,22 +537,22 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, show_it=False,
         pcolor_opts=None, stream_opts=None, grid_opts=None,
-        range_x=None, range_y=None, **other_kwargs
+        range_x=None, range_y=None, **kwargs
     ):
-        if "pcolorOpts" in other_kwargs:
-            pcolor_opts = other_kwargs["pcolorOpts"]
+        if "pcolorOpts" in kwargs:
+            pcolor_opts = kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
-        if "streamOpts" in other_kwargs:
-            stream_opts = other_kwargs["streamOpts"]
+        if "streamOpts" in kwargs:
+            stream_opts = kwargs["streamOpts"]
             warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
-        if "gridOpts" in other_kwargs:
-            grid_opts = other_kwargs["gridOpts"]
+        if "gridOpts" in kwargs:
+            grid_opts = kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
-        if "showIt" in other_kwargs:
-            show_it = other_kwargs["showIt"]
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
-        if "vType" in other_kwargs:
-            show_it = other_kwargs["vType"]
+        if "vType" in kwargs:
+            show_it = kwargs["vType"]
             warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if pcolor_opts is None:

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -536,7 +536,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, showIt=False,
-        pcolor_opts=None, stream_opts=None, gridOpts=None,
+        pcolor_opts=None, stream_opts=None, grid_opts=None,
         range_x=None, range_y=None, **other_kwargs
     ):
         if "pcolorOpts" in other_kwargs:
@@ -545,13 +545,16 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         if "streamOpts" in other_kwargs:
             stream_opts = other_kwargs["streamOpts"]
             warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
+        if "gridOpts" in other_kwargs:
+            grid_opts = other_kwargs["gridOpts"]
+            warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
         if stream_opts is None:
             stream_opts = {'color': 'k'}
-        if gridOpts is None:
-            gridOpts = {'color': 'k', 'alpha': 0.5}
+        if grid_opts is None:
+            grid_opts = {'color': 'k', 'alpha': 0.5}
         vTypeOpts = ['CC', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez']
         viewOpts = ['real', 'imag', 'abs']
         normalOpts = ['X', 'Y', 'Z']
@@ -650,7 +653,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
             grid=grid, view=view,
             ax=ax, clim=clim, showIt=False,
             pcolor_opts=pcolor_opts,
-            gridOpts=gridOpts,
+            grid_opts=grid_opts,
             range_x=range_x,
             range_y=range_y)
 

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -55,7 +55,7 @@ class TensorView(object):
         ax=None, clim=None, showIt=False,
         pcolor_opts=None,
         stream_opts=None,
-        gridOpts=None,
+        grid_opts=None,
         numbering=True, annotationColor='w',
         range_x=None, range_y=None, sample_grid=None,
         stream_threshold=None, **other_kwargs
@@ -105,13 +105,16 @@ class TensorView(object):
         if "streamOpts" in other_kwargs:
             stream_opts = other_kwargs["streamOpts"]
             warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
+        if "gridOpts" in other_kwargs:
+            grid_opts = other_kwargs["gridOpts"]
+            warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
         if stream_opts is None:
             stream_opts = {'color': 'k'}
-        if gridOpts is None:
-            gridOpts = {'color': 'k'}
+        if grid_opts is None:
+            grid_opts = {'color': 'k'}
 
         if ax is None:
             fig = plt.figure()
@@ -137,7 +140,7 @@ class TensorView(object):
                 v, vType=vType, grid=grid, view=view,
                 ax=ax, clim=clim, showIt=showIt,
                 pcolor_opts=pcolor_opts, stream_opts=stream_opts,
-                gridOpts=gridOpts, range_x=range_x, range_y=range_y,
+                grid_opts=grid_opts, range_x=range_x, range_y=range_y,
                 sample_grid=sample_grid, stream_threshold=stream_threshold
             )
         elif self.dim == 3:
@@ -217,7 +220,7 @@ class TensorView(object):
         ax=None, clim=None, showIt=False,
         pcolor_opts=None,
         stream_opts=None,
-        gridOpts=None,
+        grid_opts=None,
         range_x=None,
         range_y=None,
         sample_grid=None,
@@ -252,13 +255,16 @@ class TensorView(object):
         if "streamOpts" in other_kwargs:
             stream_opts = other_kwargs["streamOpts"]
             warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
+        if "gridOpts" in other_kwargs:
+            grid_opts = other_kwargs["gridOpts"]
+            warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
         if stream_opts is None:
             stream_opts = {'color':'k'}
-        if gridOpts is None:
-            gridOpts = {'color':'k', 'alpha':0.5}
+        if grid_opts is None:
+            grid_opts = {'color':'k', 'alpha':0.5}
         if type(vType) in [list, tuple]:
             if ax is not None:
                 raise AssertionError(
@@ -272,7 +278,7 @@ class TensorView(object):
                         v, vType=vTypeI, normal=normal, ind=ind, grid=grid,
                         view=view, ax=ax, clim=clim, showIt=False,
                         pcolor_opts=pcolor_opts, stream_opts=stream_opts,
-                        gridOpts=gridOpts, stream_threshold=stream_threshold,
+                        grid_opts=grid_opts, stream_threshold=stream_threshold,
                         stream_thickness=stream_thickness
                     )
                 ]
@@ -371,7 +377,7 @@ class TensorView(object):
             grid=grid, view=view,
             ax=ax, clim=clim, showIt=showIt,
             pcolor_opts=pcolor_opts, stream_opts=stream_opts,
-            gridOpts=gridOpts,
+            grid_opts=grid_opts,
             range_x=range_x,
             range_y=range_y,
             sample_grid=sample_grid,
@@ -391,7 +397,7 @@ class TensorView(object):
         ax=None, clim=None, showIt=False,
         pcolor_opts=None,
         stream_opts=None,
-        gridOpts=None,
+        grid_opts=None,
         range_x=None,
         range_y=None,
         sample_grid=None,
@@ -403,8 +409,8 @@ class TensorView(object):
             pcolor_opts = {}
         if stream_opts is None:
             stream_opts = {'color': 'k'}
-        if gridOpts is None:
-            gridOpts = {'color': 'k'}
+        if grid_opts is None:
+            grid_opts = {'color': 'k'}
         vTypeOptsCC = ['N', 'CC', 'Fx', 'Fy', 'Ex', 'Ey']
         vTypeOptsV = ['CCv', 'F', 'E']
         vTypeOpts = vTypeOptsCC + vTypeOptsV
@@ -568,7 +574,7 @@ class TensorView(object):
             xYGrid = np.c_[self.vectorNy[0]*np.ones(self.nNx), self.vectorNy[-1]*np.ones(self.nNx), np.nan*np.ones(self.nNx)].flatten()
             yXGrid = np.c_[self.vectorNx[0]*np.ones(self.nNy), self.vectorNx[-1]*np.ones(self.nNy), np.nan*np.ones(self.nNy)].flatten()
             yYGrid = np.c_[self.vectorNy, self.vectorNy, np.nan*np.ones(self.nNy)].flatten()
-            out += (ax.plot(np.r_[xXGrid, yXGrid], np.r_[xYGrid, yYGrid], **gridOpts)[0], )
+            out += (ax.plot(np.r_[xXGrid, yXGrid], np.r_[xYGrid, yYGrid], **grid_opts)[0], )
 
         ax.set_xlabel('x')
         ax.set_ylabel('y')
@@ -1166,12 +1172,15 @@ class CurviView(object):
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
         pcolor_opts=None,
-        gridOpts=None,
+        grid_opts=None,
         range_x=None, range_y=None, **other_kwargs
     ):
         if "pcolorOpts" in other_kwargs:
             pcolor_opts = other_kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+        if "gridOpts" in other_kwargs:
+            grid_opts = other_kwargs["gridOpts"]
+            warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
 
         if self.dim == 3:
             raise NotImplementedError('This is not yet done!')
@@ -1210,10 +1219,10 @@ class CurviView(object):
             alpha = pcolor_opts['alpha']
         else:
             alpha = 1.0
-        if gridOpts is None:
-            gridOpts = {'color': 'k'}
-        if 'color' not in gridOpts:
-            gridOpts['color'] = 'k'
+        if grid_opts is None:
+            grid_opts = {'color': 'k'}
+        if 'color' not in grid_opts:
+            grid_opts['color'] = 'k'
 
         cNorm = colors.Normalize(vmin=vmin, vmax=vmax)
         scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=cm)
@@ -1221,9 +1230,9 @@ class CurviView(object):
         if 'edge_color' in pcolor_opts:
             edge_color = pcolor_opts['edge_color']
         else:
-            edge_color = gridOpts['color'] if grid else 'none'
-        if 'alpha' in gridOpts:
-            edge_alpha = gridOpts['alpha']
+            edge_color = grid_opts['color'] if grid else 'none'
+        if 'alpha' in grid_opts:
+            edge_alpha = grid_opts['alpha']
         else:
             edge_alpha = 1.0
         if edge_color.lower() != 'none':

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -58,7 +58,7 @@ class TensorView(object):
         grid_opts=None,
         numbering=True, annotation_color='w',
         range_x=None, range_y=None, sample_grid=None,
-        stream_threshold=None, **other_kwargs
+        stream_threshold=None, **kwargs
     ):
         """
         Mesh.plotImage(v)
@@ -99,23 +99,23 @@ class TensorView(object):
             M.plotImage(v, annotation_color='k', show_it=True)
 
         """
-        if "pcolorOpts" in other_kwargs:
-            pcolor_opts = other_kwargs["pcolorOpts"]
+        if "pcolorOpts" in kwargs:
+            pcolor_opts = kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
-        if "streamOpts" in other_kwargs:
-            stream_opts = other_kwargs["streamOpts"]
+        if "streamOpts" in kwargs:
+            stream_opts = kwargs["streamOpts"]
             warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
-        if "gridOpts" in other_kwargs:
-            grid_opts = other_kwargs["gridOpts"]
+        if "gridOpts" in kwargs:
+            grid_opts = kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
-        if "showIt" in other_kwargs:
-            show_it = other_kwargs["showIt"]
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
-        if "annotationColor" in other_kwargs:
-            show_it = other_kwargs["annotationColor"]
+        if "annotationColor" in kwargs:
+            show_it = kwargs["annotationColor"]
             warnings.warn("annotationColor has been deprecated, please use annotation_color", DeprecationWarning)
-        if "vType" in other_kwargs:
-            show_it = other_kwargs["vType"]
+        if "vType" in kwargs:
+            show_it = kwargs["vType"]
             warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if pcolor_opts is None:
@@ -234,7 +234,7 @@ class TensorView(object):
         range_y=None,
         sample_grid=None,
         stream_threshold=None,
-        stream_thickness=None, **other_kwargs
+        stream_thickness=None, **kwargs
     ):
 
         """
@@ -258,20 +258,20 @@ class TensorView(object):
 
         """
         normal = normal.upper()
-        if "pcolorOpts" in other_kwargs:
-            pcolor_opts = other_kwargs["pcolorOpts"]
+        if "pcolorOpts" in kwargs:
+            pcolor_opts = kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
-        if "streamOpts" in other_kwargs:
-            stream_opts = other_kwargs["streamOpts"]
+        if "streamOpts" in kwargs:
+            stream_opts = kwargs["streamOpts"]
             warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
-        if "gridOpts" in other_kwargs:
-            grid_opts = other_kwargs["gridOpts"]
+        if "gridOpts" in kwargs:
+            grid_opts = kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
-        if "showIt" in other_kwargs:
-            show_it = other_kwargs["showIt"]
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
-        if "vType" in other_kwargs:
-            show_it = other_kwargs["vType"]
+        if "vType" in kwargs:
+            show_it = kwargs["vType"]
             warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if pcolor_opts is None:
@@ -789,7 +789,7 @@ class TensorView(object):
                        v_type='CC', view='real', axis='xy', transparent=None,
                        clim=None, xlim=None, ylim=None, zlim=None,
                        aspect='auto', grid=[2, 2, 1], pcolor_opts=None,
-                       fig=None, **other_kwargs):
+                       fig=None, **kwargs):
         """Plot slices of a 3D volume, interactively (scroll wheel).
 
         If called from a notebook, make sure to set
@@ -822,8 +822,8 @@ class TensorView(object):
         else:
             fig.clf()
 
-        if "pcolorOpts" in other_kwargs:
-            pcolor_opts = other_kwargs["pcolorOpts"]
+        if "pcolorOpts" in kwargs:
+            pcolor_opts = kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
 
         # Populate figure
@@ -1194,19 +1194,19 @@ class CurviView(object):
         ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         grid_opts=None,
-        range_x=None, range_y=None, **other_kwargs
+        range_x=None, range_y=None, **kwargs
     ):
-        if "pcolorOpts" in other_kwargs:
-            pcolor_opts = other_kwargs["pcolorOpts"]
+        if "pcolorOpts" in kwargs:
+            pcolor_opts = kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
-        if "gridOpts" in other_kwargs:
-            grid_opts = other_kwargs["gridOpts"]
+        if "gridOpts" in kwargs:
+            grid_opts = kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
-        if "showIt" in other_kwargs:
-            show_it = other_kwargs["showIt"]
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
-        if "vType" in other_kwargs:
-            show_it = other_kwargs["vType"]
+        if "vType" in kwargs:
+            show_it = kwargs["vType"]
             warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if self.dim == 3:
@@ -1370,12 +1370,12 @@ class Slicer(object):
     def __init__(self, mesh, v, xslice=None, yslice=None, zslice=None,
                  v_type='CC', view='real', axis='xy', transparent=None,
                  clim=None, xlim=None, ylim=None, zlim=None, aspect='auto',
-                 grid=[2, 2, 1], pcolor_opts=None, **other_kwargs):
+                 grid=[2, 2, 1], pcolor_opts=None, **kwargs):
         """Initialize interactive figure."""
 
         # 0. Some checks, not very extensive
-        if "pcolorOpts" in other_kwargs:
-            pcolor_opts = other_kwargs["pcolorOpts"]
+        if "pcolorOpts" in kwargs:
+            pcolor_opts = kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
 
         # (a) Mesh dimensionality

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -54,7 +54,7 @@ class TensorView(object):
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
         pcolor_opts=None,
-        streamOpts=None,
+        stream_opts=None,
         gridOpts=None,
         numbering=True, annotationColor='w',
         range_x=None, range_y=None, sample_grid=None,
@@ -102,11 +102,14 @@ class TensorView(object):
         if "pcolorOpts" in other_kwargs:
             pcolor_opts = other_kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+        if "streamOpts" in other_kwargs:
+            stream_opts = other_kwargs["streamOpts"]
+            warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
-        if streamOpts is None:
-            streamOpts = {'color': 'k'}
+        if stream_opts is None:
+            stream_opts = {'color': 'k'}
         if gridOpts is None:
             gridOpts = {'color': 'k'}
 
@@ -133,7 +136,7 @@ class TensorView(object):
             return self._plotImage2D(
                 v, vType=vType, grid=grid, view=view,
                 ax=ax, clim=clim, showIt=showIt,
-                pcolor_opts=pcolor_opts, streamOpts=streamOpts,
+                pcolor_opts=pcolor_opts, stream_opts=stream_opts,
                 gridOpts=gridOpts, range_x=range_x, range_y=range_y,
                 sample_grid=sample_grid, stream_threshold=stream_threshold
             )
@@ -213,7 +216,7 @@ class TensorView(object):
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, showIt=False,
         pcolor_opts=None,
-        streamOpts=None,
+        stream_opts=None,
         gridOpts=None,
         range_x=None,
         range_y=None,
@@ -246,10 +249,14 @@ class TensorView(object):
         if "pcolorOpts" in other_kwargs:
             pcolor_opts = other_kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+        if "streamOpts" in other_kwargs:
+            stream_opts = other_kwargs["streamOpts"]
+            warnings.warn("streamOpts has been deprecated, please use stream_opts", DeprecationWarning)
+
         if pcolor_opts is None:
             pcolor_opts = {}
-        if streamOpts is None:
-            streamOpts = {'color':'k'}
+        if stream_opts is None:
+            stream_opts = {'color':'k'}
         if gridOpts is None:
             gridOpts = {'color':'k', 'alpha':0.5}
         if type(vType) in [list, tuple]:
@@ -264,7 +271,7 @@ class TensorView(object):
                     self.plotSlice(
                         v, vType=vTypeI, normal=normal, ind=ind, grid=grid,
                         view=view, ax=ax, clim=clim, showIt=False,
-                        pcolor_opts=pcolor_opts, streamOpts=streamOpts,
+                        pcolor_opts=pcolor_opts, stream_opts=stream_opts,
                         gridOpts=gridOpts, stream_threshold=stream_threshold,
                         stream_thickness=stream_thickness
                     )
@@ -363,7 +370,7 @@ class TensorView(object):
             v2d, vType=('CCv' if view == 'vec' else 'CC'),
             grid=grid, view=view,
             ax=ax, clim=clim, showIt=showIt,
-            pcolor_opts=pcolor_opts, streamOpts=streamOpts,
+            pcolor_opts=pcolor_opts, stream_opts=stream_opts,
             gridOpts=gridOpts,
             range_x=range_x,
             range_y=range_y,
@@ -383,7 +390,7 @@ class TensorView(object):
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
         pcolor_opts=None,
-        streamOpts=None,
+        stream_opts=None,
         gridOpts=None,
         range_x=None,
         range_y=None,
@@ -394,8 +401,8 @@ class TensorView(object):
 
         if pcolor_opts is None:
             pcolor_opts = {}
-        if streamOpts is None:
-            streamOpts = {'color': 'k'}
+        if stream_opts is None:
+            stream_opts = {'color': 'k'}
         if gridOpts is None:
             gridOpts = {'color': 'k'}
         vTypeOptsCC = ['N', 'CC', 'Fx', 'Fy', 'Ex', 'Ey']
@@ -541,8 +548,8 @@ class TensorView(object):
                 # Scale by user defined thickness factor
                 stream_thickness = scaleFact*norm_thickness
 
-                # Add linewidth to streamOpts
-                streamOpts.update({'linewidth':stream_thickness})
+                # Add linewidth to stream_opts
+                stream_opts.update({'linewidth':stream_thickness})
 
 
             out += (
@@ -552,7 +559,7 @@ class TensorView(object):
             )
             out += (
                 ax.streamplot(
-                    tMi.vectorCCx, tMi.vectorCCy, Ui.T, Vi.T, **streamOpts
+                    tMi.vectorCCx, tMi.vectorCCy, Ui.T, Vi.T, **stream_opts
                 ),
             )
 

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -29,7 +29,7 @@ class TensorView(object):
     # def components(self):
 
     #     plotAll = len(imageType) == 1
-    #     options = {"direction":direction, "numbering":numbering, "annotationColor":annotationColor, "showIt":False}
+    #     options = {"direction":direction, "numbering":numbering, "annotationColor":annotationColor, "show_it":False}
     #     fig = plt.figure(figNum)
     #     # Determine the subplot number: 131, 121
     #     numPlots = 130 if plotAll else len(imageType)//2*10+100
@@ -47,12 +47,12 @@ class TensorView(object):
     #         ax_z = plt.subplot(numPlots+pltNum)
     #         self.plotImage(fxyz[2], imageType='Fz', ax=ax_z, **options)
     #         pltNum +=1
-    #     if showIt: plt.show()
+    #     if show_it: plt.show()
 
     @requires({'matplotlib': matplotlib})
     def plotImage(
         self, v, vType='CC', grid=False, view='real',
-        ax=None, clim=None, showIt=False,
+        ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         stream_opts=None,
         grid_opts=None,
@@ -73,7 +73,7 @@ class TensorView(object):
 
         :param str vType: type of vector ('CC', 'N', 'F', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez')
         :param matplotlib.axes.Axes ax: axis to plot to
-        :param bool showIt: call plt.show()
+        :param bool show_it: call plt.show()
 
         3D Inputs:
 
@@ -87,7 +87,7 @@ class TensorView(object):
             import numpy as np
             M = discretize.TensorMesh([20, 20])
             v = np.sin(M.gridCC[:, 0]*2*np.pi)*np.sin(M.gridCC[:, 1]*2*np.pi)
-            M.plotImage(v, showIt=True)
+            M.plotImage(v, show_it=True)
 
         .. plot::
             :include-source:
@@ -96,7 +96,7 @@ class TensorView(object):
             import numpy as np
             M = discretize.TensorMesh([20, 20, 20])
             v = np.sin(M.gridCC[:, 0]*2*np.pi)*np.sin(M.gridCC[:, 1]*2*np.pi)*np.sin(M.gridCC[:, 2]*2*np.pi)
-            M.plotImage(v, annotationColor='k', showIt=True)
+            M.plotImage(v, annotationColor='k', show_it=True)
 
         """
         if "pcolorOpts" in other_kwargs:
@@ -108,6 +108,9 @@ class TensorView(object):
         if "gridOpts" in other_kwargs:
             grid_opts = other_kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
+        if "showIt" in other_kwargs:
+            show_it = other_kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
@@ -138,7 +141,7 @@ class TensorView(object):
         elif self.dim == 2:
             return self._plotImage2D(
                 v, vType=vType, grid=grid, view=view,
-                ax=ax, clim=clim, showIt=showIt,
+                ax=ax, clim=clim, show_it=show_it,
                 pcolor_opts=pcolor_opts, stream_opts=stream_opts,
                 grid_opts=grid_opts, range_x=range_x, range_y=range_y,
                 sample_grid=sample_grid, stream_threshold=stream_threshold
@@ -209,7 +212,7 @@ class TensorView(object):
                                      '#{0:.0f}'.format(iz), color=annotationColor, verticalalignment='bottom', horizontalalignment='right', size='x-large')
 
         ax.set_title(vType)
-        if showIt:
+        if show_it:
             plt.show()
         return ph
 
@@ -217,7 +220,7 @@ class TensorView(object):
     def plotSlice(
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
-        ax=None, clim=None, showIt=False,
+        ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         stream_opts=None,
         grid_opts=None,
@@ -245,7 +248,7 @@ class TensorView(object):
             q = discretize.utils.mkvc(q)
             A = M.faceDiv * M.cellGrad
             b = Solver(A) * (q)
-            M.plotSlice(M.cellGrad*b, 'F', view='vec', grid=True, showIt=True, pcolor_opts={'alpha':0.8})
+            M.plotSlice(M.cellGrad*b, 'F', view='vec', grid=True, show_it=True, pcolor_opts={'alpha':0.8})
 
         """
         normal = normal.upper()
@@ -258,6 +261,9 @@ class TensorView(object):
         if "gridOpts" in other_kwargs:
             grid_opts = other_kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
+        if "showIt" in other_kwargs:
+            show_it = other_kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
@@ -276,7 +282,7 @@ class TensorView(object):
                 out += [
                     self.plotSlice(
                         v, vType=vTypeI, normal=normal, ind=ind, grid=grid,
-                        view=view, ax=ax, clim=clim, showIt=False,
+                        view=view, ax=ax, clim=clim, show_it=False,
                         pcolor_opts=pcolor_opts, stream_opts=stream_opts,
                         grid_opts=grid_opts, stream_threshold=stream_threshold,
                         stream_thickness=stream_thickness
@@ -375,7 +381,7 @@ class TensorView(object):
         out = tM._plotImage2D(
             v2d, vType=('CCv' if view == 'vec' else 'CC'),
             grid=grid, view=view,
-            ax=ax, clim=clim, showIt=showIt,
+            ax=ax, clim=clim, show_it=show_it,
             pcolor_opts=pcolor_opts, stream_opts=stream_opts,
             grid_opts=grid_opts,
             range_x=range_x,
@@ -394,7 +400,7 @@ class TensorView(object):
     @requires({'matplotlib': matplotlib})
     def _plotImage2D(
         self, v, vType='CC', grid=False, view='real',
-        ax=None, clim=None, showIt=False,
+        ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         stream_opts=None,
         grid_opts=None,
@@ -589,14 +595,14 @@ class TensorView(object):
         else:
             ax.set_ylim(*self.vectorNy[[0, -1]])
 
-        if showIt:
+        if show_it:
             plt.show()
         return out
 
     @requires({'matplotlib': matplotlib})
     def plotGrid(
         self, ax=None, nodes=False, faces=False, centers=False, edges=False,
-        lines=True, showIt=False, **kwargs
+        lines=True, show_it=False, **kwargs
     ):
         """Plot the nodal, cell-centered and staggered grids for 1,2 and 3 dimensions.
 
@@ -605,7 +611,7 @@ class TensorView(object):
         :param bool centers: plot centers
         :param bool edges: plot edges
         :param bool lines: plot lines connecting nodes
-        :param bool showIt: call plt.show()
+        :param bool show_it: call plt.show()
 
         .. plot::
            :include-source:
@@ -615,7 +621,7 @@ class TensorView(object):
            h1 = np.linspace(.1, .5, 3)
            h2 = np.linspace(.1, .5, 5)
            mesh = discretize.TensorMesh([h1, h2])
-           mesh.plotGrid(nodes=True, faces=True, centers=True, lines=True, showIt=True)
+           mesh.plotGrid(nodes=True, faces=True, centers=True, lines=True, show_it=True)
 
         .. plot::
            :include-source:
@@ -626,9 +632,12 @@ class TensorView(object):
            h2 = np.linspace(.1, .5, 5)
            h3 = np.linspace(.1, .5, 3)
            mesh = discretize.TensorMesh([h1, h2, h3])
-           mesh.plotGrid(nodes=True, faces=True, centers=True, lines=True, showIt=True)
+           mesh.plotGrid(nodes=True, faces=True, centers=True, lines=True, show_it=True)
 
         """
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
 
         axOpts = {'projection': '3d'} if self.dim == 3 else {}
         if ax is None:
@@ -760,7 +769,7 @@ class TensorView(object):
             ax.set_zlabel('x3')
 
         ax.grid(True)
-        if showIt:
+        if show_it:
             plt.show()
 
         return ax
@@ -910,15 +919,15 @@ class CylView(object):
             fig = ax.figure
 
         # Don't show things in the TM.plotImage
-        showIt = kwargs.get('showIt', False)
-        kwargs['showIt'] = False
+        show_it = kwargs.get('show_it', False)
+        kwargs['show_it'] = False
 
         out = getattr(M, plotType)(*args, **kwargs)
 
         ax.set_xlabel('x')
         ax.set_ylabel('z')
 
-        if showIt:
+        if show_it:
             plt.show()
 
         return out
@@ -1072,7 +1081,7 @@ class CurviView(object):
     @requires({'matplotlib': matplotlib})
     def plotGrid(
         self, ax=None, nodes=False, faces=False, centers=False, edges=False,
-        lines=True, showIt=False, **kwargs
+        lines=True, show_it=False, **kwargs
     ):
         """Plot the nodal, cell-centered and staggered grids for 1, 2 and 3 dimensions.
 
@@ -1083,13 +1092,16 @@ class CurviView(object):
             import discretize
             X, Y = discretize.utils.exampleLrmGrid([3, 3], 'rotate')
             M = discretize.CurvilinearMesh([X, Y])
-            M.plotGrid(showIt=True)
+            M.plotGrid(show_it=True)
 
         """
 
         axOpts = {'projection': '3d'} if self.dim == 3 else {}
         if ax is None:
             ax = plt.subplot(111, **axOpts)
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
 
         NN = self.r(self.gridN, 'N', 'N', 'M')
         if self.dim == 2:
@@ -1162,7 +1174,7 @@ class CurviView(object):
         ax.set_xlabel('x1')
         ax.set_ylabel('x2')
 
-        if showIt:
+        if show_it:
             plt.show()
 
         return ax
@@ -1170,7 +1182,7 @@ class CurviView(object):
     @requires({'matplotlib': matplotlib})
     def plotImage(
         self, v, vType='CC', grid=False, view='real',
-        ax=None, clim=None, showIt=False,
+        ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         grid_opts=None,
         range_x=None, range_y=None, **other_kwargs
@@ -1181,6 +1193,9 @@ class CurviView(object):
         if "gridOpts" in other_kwargs:
             grid_opts = other_kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
+        if "showIt" in other_kwargs:
+            show_it = other_kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
 
         if self.dim == 3:
             raise NotImplementedError('This is not yet done!')
@@ -1260,7 +1275,7 @@ class CurviView(object):
         scalarMap._A = []  # http://stackoverflow.com/questions/8342549/matplotlib-add-colorbar-to-a-sequence-of-line-plots
         ax.set_xlabel('x')
         ax.set_ylabel('y')
-        if showIt:
+        if show_it:
             plt.show()
         return [scalarMap]
 

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -51,7 +51,7 @@ class TensorView(object):
 
     @requires({'matplotlib': matplotlib})
     def plotImage(
-        self, v, vType='CC', grid=False, view='real',
+        self, v, v_type='CC', grid=False, view='real',
         ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         stream_opts=None,
@@ -71,7 +71,7 @@ class TensorView(object):
 
         Optional Inputs:
 
-        :param str vType: type of vector ('CC', 'N', 'F', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez')
+        :param str v_type: type of vector ('CC', 'N', 'F', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez')
         :param matplotlib.axes.Axes ax: axis to plot to
         :param bool show_it: call plt.show()
 
@@ -114,6 +114,9 @@ class TensorView(object):
         if "annotationColor" in other_kwargs:
             show_it = other_kwargs["annotationColor"]
             warnings.warn("annotationColor has been deprecated, please use annotation_color", DeprecationWarning)
+        if "vType" in other_kwargs:
+            show_it = other_kwargs["vType"]
+            warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
@@ -131,11 +134,11 @@ class TensorView(object):
             fig = ax.figure
 
         if self.dim == 1:
-            if vType == 'CC':
+            if v_type == 'CC':
                 ph = ax.plot(
                     self.vectorCCx, v, linestyle="-", color="C1", marker="o"
                 )
-            elif vType == 'N':
+            elif v_type == 'N':
                 ph = ax.plot(
                     self.vectorNx, v, linestyle="-", color="C0", marker="s"
                 )
@@ -143,7 +146,7 @@ class TensorView(object):
             ax.axis('tight')
         elif self.dim == 2:
             return self._plotImage2D(
-                v, vType=vType, grid=grid, view=view,
+                v, v_type=v_type, grid=grid, view=view,
                 ax=ax, clim=clim, show_it=show_it,
                 pcolor_opts=pcolor_opts, stream_opts=stream_opts,
                 grid_opts=grid_opts, range_x=range_x, range_y=range_y,
@@ -151,18 +154,18 @@ class TensorView(object):
             )
         elif self.dim == 3:
             # get copy of image and average to cell-centers is necessary
-            if vType == 'CC':
+            if v_type == 'CC':
                 vc = v.reshape(self.vnC, order='F')
-            elif vType == 'N':
+            elif v_type == 'N':
                 vc = (self.aveN2CC*v).reshape(self.vnC, order='F')
-            elif vType in ['Fx', 'Fy', 'Fz', 'Ex', 'Ey', 'Ez']:
-                aveOp = 'ave' + vType[0] + '2CCV'
-                # n = getattr(self, 'vn'+vType[0])
-                # if 'x' in vType: v = np.r_[v, np.zeros(n[1]), np.zeros(n[2])]
-                # if 'y' in vType: v = np.r_[np.zeros(n[0]), v, np.zeros(n[2])]
-                # if 'z' in vType: v = np.r_[np.zeros(n[0]), np.zeros(n[1]), v]
+            elif v_type in ['Fx', 'Fy', 'Fz', 'Ex', 'Ey', 'Ez']:
+                aveOp = 'ave' + v_type[0] + '2CCV'
+                # n = getattr(self, 'vn'+v_type[0])
+                # if 'x' in v_type: v = np.r_[v, np.zeros(n[1]), np.zeros(n[2])]
+                # if 'y' in v_type: v = np.r_[np.zeros(n[0]), v, np.zeros(n[2])]
+                # if 'z' in v_type: v = np.r_[np.zeros(n[0]), np.zeros(n[1]), v]
                 v = getattr(self, aveOp)*v # average to cell centers
-                ind_xyz = {'x': 0, 'y': 1, 'z': 2}[vType[1]]
+                ind_xyz = {'x': 0, 'y': 1, 'z': 2}[v_type[1]]
                 vc = self.r(
                     v.reshape((self.nC, -1), order='F'), 'CC', 'CC', 'M'
                 )[ind_xyz]
@@ -214,14 +217,14 @@ class TensorView(object):
                             ax.text((ix+1)*(self.vectorNx[-1]-self.x0[0])-pad, (iy)*(self.vectorNy[-1]-self.x0[1])+pad,
                                      '#{0:.0f}'.format(iz), color=annotation_color, verticalalignment='bottom', horizontalalignment='right', size='x-large')
 
-        ax.set_title(vType)
+        ax.set_title(v_type)
         if show_it:
             plt.show()
         return ph
 
     @requires({'matplotlib': matplotlib})
     def plotSlice(
-        self, v, vType='CC',
+        self, v, v_type='CC',
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, show_it=False,
         pcolor_opts=None,
@@ -267,6 +270,9 @@ class TensorView(object):
         if "showIt" in other_kwargs:
             show_it = other_kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
+        if "vType" in other_kwargs:
+            show_it = other_kwargs["vType"]
+            warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
@@ -274,17 +280,17 @@ class TensorView(object):
             stream_opts = {'color':'k'}
         if grid_opts is None:
             grid_opts = {'color':'k', 'alpha':0.5}
-        if type(vType) in [list, tuple]:
+        if type(v_type) in [list, tuple]:
             if ax is not None:
                 raise AssertionError(
                     "cannot specify an axis to plot on with this function."
                 )
-            fig, axs = plt.subplots(1, len(vType))
+            fig, axs = plt.subplots(1, len(v_type))
             out = []
-            for vTypeI, ax in zip(vType, axs):
+            for v_typeI, ax in zip(v_type, axs):
                 out += [
                     self.plotSlice(
-                        v, vType=vTypeI, normal=normal, ind=ind, grid=grid,
+                        v, v_type=v_typeI, normal=normal, ind=ind, grid=grid,
                         view=view, ax=ax, clim=clim, show_it=False,
                         pcolor_opts=pcolor_opts, stream_opts=stream_opts,
                         grid_opts=grid_opts, stream_threshold=stream_threshold,
@@ -294,12 +300,12 @@ class TensorView(object):
             return out
         viewOpts = ['real', 'imag', 'abs', 'vec']
         normalOpts = ['X', 'Y', 'Z']
-        vTypeOpts = ['CC', 'CCv', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez']
+        v_typeOpts = ['CC', 'CCv', 'N', 'F', 'E', 'Fx', 'Fy', 'Fz', 'E', 'Ex', 'Ey', 'Ez']
 
         # Some user error checking
-        if vType not in vTypeOpts:
+        if v_type not in v_typeOpts:
             raise AssertionError(
-                "vType must be in ['{0!s}']".format("', '".join(vTypeOpts))
+                "v_type must be in ['{0!s}']".format("', '".join(v_typeOpts))
             )
         if not self.dim == 3:
             raise AssertionError(
@@ -335,19 +341,19 @@ class TensorView(object):
             return v
 
         def doSlice(v):
-            if vType == 'CC':
+            if v_type == 'CC':
                 return getIndSlice(self.r(v, 'CC', 'CC', 'M'))
-            elif vType == 'CCv':
+            elif v_type == 'CCv':
                 if view != 'vec':
                     raise AssertionError('Other types for CCv not supported')
             else:
                 # Now just deal with 'F' and 'E' (x, y, z, maybe...)
-                aveOp = 'ave' + vType + ('2CCV' if view == 'vec' else '2CC')
+                aveOp = 'ave' + v_type + ('2CCV' if view == 'vec' else '2CC')
                 Av = getattr(self, aveOp)
                 if v.size == Av.shape[1]:
                     v = Av * v
                 else:
-                    v = self.r(v, vType[0], vType) # get specific component
+                    v = self.r(v, v_type[0], v_type) # get specific component
                     v = Av * v
                 # we should now be averaged to cell centers (might be a vector)
             v = self.r(v.reshape((self.nC, -1), order='F'), 'CC', 'CC', 'M')
@@ -382,7 +388,7 @@ class TensorView(object):
                 raise AssertionError("ax must be an matplotlib.axes.Axes")
 
         out = tM._plotImage2D(
-            v2d, vType=('CCv' if view == 'vec' else 'CC'),
+            v2d, v_type=('CCv' if view == 'vec' else 'CC'),
             grid=grid, view=view,
             ax=ax, clim=clim, show_it=show_it,
             pcolor_opts=pcolor_opts, stream_opts=stream_opts,
@@ -402,7 +408,7 @@ class TensorView(object):
 
     @requires({'matplotlib': matplotlib})
     def _plotImage2D(
-        self, v, vType='CC', grid=False, view='real',
+        self, v, v_type='CC', grid=False, view='real',
         ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         stream_opts=None,
@@ -420,19 +426,19 @@ class TensorView(object):
             stream_opts = {'color': 'k'}
         if grid_opts is None:
             grid_opts = {'color': 'k'}
-        vTypeOptsCC = ['N', 'CC', 'Fx', 'Fy', 'Ex', 'Ey']
-        vTypeOptsV = ['CCv', 'F', 'E']
-        vTypeOpts = vTypeOptsCC + vTypeOptsV
+        v_typeOptsCC = ['N', 'CC', 'Fx', 'Fy', 'Ex', 'Ey']
+        v_typeOptsV = ['CCv', 'F', 'E']
+        v_typeOpts = v_typeOptsCC + v_typeOptsV
         if view == 'vec':
-            if vType not in vTypeOptsV:
+            if v_type not in v_typeOptsV:
                 raise AssertionError(
-                    "vType must be in ['{0!s}'] when view='vec'".format(
-                        "', '".join(vTypeOptsV)
+                    "v_type must be in ['{0!s}'] when view='vec'".format(
+                        "', '".join(v_typeOptsV)
                     )
                 )
-        if vType not in vTypeOpts:
+        if v_type not in v_typeOpts:
             raise AssertionError(
-                "vType must be in ['{0!s}']".format("', '".join(vTypeOpts))
+                "v_type must be in ['{0!s}']".format("', '".join(v_typeOpts))
             )
 
         viewOpts = ['real', 'imag', 'abs', 'vec']
@@ -451,18 +457,18 @@ class TensorView(object):
                 )
 
         # Reshape to a cell centered variable
-        if vType == 'CC':
+        if v_type == 'CC':
             pass
-        elif vType == 'CCv':
+        elif v_type == 'CCv':
             if view != 'vec':
                 raise AssertionError('Other types for CCv not supported')
-        elif vType in ['F', 'E', 'N']:
-            aveOp = 'ave' + vType + ('2CCV' if view == 'vec' else '2CC')
+        elif v_type in ['F', 'E', 'N']:
+            aveOp = 'ave' + v_type + ('2CCV' if view == 'vec' else '2CC')
             v = getattr(self, aveOp)*v  # average to cell centers (might be a vector)
-        elif vType in ['Fx', 'Fy', 'Ex', 'Ey']:
-            aveOp = 'ave' + vType[0] + '2CCV'
+        elif v_type in ['Fx', 'Fy', 'Ex', 'Ey']:
+            aveOp = 'ave' + v_type[0] + '2CCV'
             v = getattr(self, aveOp)*v  # average to cell centers (might be a vector)
-            xORy = {'x': 0, 'y':1 }[vType[1]]
+            xORy = {'x': 0, 'y':1 }[v_type[1]]
             v = v.reshape((self.nC, -1), order='F')[:, xORy]
 
         out = ()
@@ -780,7 +786,7 @@ class TensorView(object):
 
     @requires({'matplotlib': matplotlib})
     def plot_3d_slicer(self, v, xslice=None, yslice=None, zslice=None,
-                       vType='CC', view='real', axis='xy', transparent=None,
+                       v_type='CC', view='real', axis='xy', transparent=None,
                        clim=None, xlim=None, ylim=None, zlim=None,
                        aspect='auto', grid=[2, 2, 1], pcolor_opts=None,
                        fig=None, **other_kwargs):
@@ -822,7 +828,7 @@ class TensorView(object):
 
         # Populate figure
         tracker = Slicer(
-            self, v, xslice, yslice, zslice, vType, view, axis, transparent,
+            self, v, xslice, yslice, zslice, v_type, view, axis, transparent,
             clim, xlim, ylim, zlim, aspect, grid, pcolor_opts
         )
 
@@ -851,21 +857,21 @@ class CylView(object):
         if len(args) > 0:
             val = args[0]
 
-        vType = kwargs.get('vType', None)
+        v_type = kwargs.get('v_type', None)
         mirror = kwargs.pop('mirror', None)
         mirror_data = kwargs.pop('mirror_data', None)
 
         if mirror_data is not None and mirror is None:
             mirror = True
 
-        if vType is not None:
-            if vType.upper() != 'CCV':
-                if vType.upper() == 'F':
+        if v_type is not None:
+            if v_type.upper() != 'CCV':
+                if v_type.upper() == 'F':
                     val = mkvc(self.aveF2CCV * val)
                     if mirror_data is not None:
                         mirror_data = mkvc(self.aveF2CCV * mirror_data)
-                    kwargs['vType'] = 'CCv'  # now the vector is cell centered
-                if vType.upper() == 'E':
+                    kwargs['v_type'] = 'CCv'  # now the vector is cell centered
+                if v_type.upper() == 'E':
                     val = mkvc(self.aveE2CCV * val)
                     if mirror_data is not None:
                         mirror_data = mkvc(self.aveE2CCV * mirror_data)
@@ -1184,7 +1190,7 @@ class CurviView(object):
 
     @requires({'matplotlib': matplotlib})
     def plotImage(
-        self, v, vType='CC', grid=False, view='real',
+        self, v, v_type='CC', grid=False, view='real',
         ax=None, clim=None, show_it=False,
         pcolor_opts=None,
         grid_opts=None,
@@ -1199,6 +1205,9 @@ class CurviView(object):
         if "showIt" in other_kwargs:
             show_it = other_kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
+        if "vType" in other_kwargs:
+            show_it = other_kwargs["vType"]
+            warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if self.dim == 3:
             raise NotImplementedError('This is not yet done!')
@@ -1208,13 +1217,13 @@ class CurviView(object):
                 )
         if view in ['real', 'imag', 'abs']:
             v = getattr(np, view)(v)  # e.g. np.real(v)
-        if vType == 'CC':
+        if v_type == 'CC':
             I = v
-        elif vType == 'N':
+        elif v_type == 'N':
             I = self.aveN2CC*v
-        elif vType in ['Fx', 'Fy', 'Ex', 'Ey']:
-            aveOp = 'ave' + vType[0] + '2CCV'
-            ind_xy = {'x': 0, 'y': 1}[vType[1]]
+        elif v_type in ['Fx', 'Fy', 'Ex', 'Ey']:
+            aveOp = 'ave' + v_type[0] + '2CCV'
+            ind_xy = {'x': 0, 'y': 1}[v_type[1]]
             I = (getattr(self, aveOp)*v).reshape(2, self.nC)[ind_xy]  # average to cell centers
 
         if ax is None:
@@ -1315,7 +1324,7 @@ class Slicer(object):
         Initial slice locations (in meter);
         defaults to the middle of the volume.
 
-    vType: str
+    v_type: str
         Type of visualization. Default is 'CC'.
         One of ['CC', 'Fx', 'Fy', 'Fz', 'Ex', 'Ey', 'Ez'].
 
@@ -1359,7 +1368,7 @@ class Slicer(object):
     """
 
     def __init__(self, mesh, v, xslice=None, yslice=None, zslice=None,
-                 vType='CC', view='real', axis='xy', transparent=None,
+                 v_type='CC', view='real', axis='xy', transparent=None,
                  clim=None, xlim=None, ylim=None, zlim=None, aspect='auto',
                  grid=[2, 2, 1], pcolor_opts=None, **other_kwargs):
         """Initialize interactive figure."""
@@ -1375,20 +1384,20 @@ class Slicer(object):
             err += ' Mesh provided has {} dimension(s).'.format(mesh.dim)
             raise ValueError(err)
 
-        # (b) vType  # Not yet working for ['CCv']
-        vTypeOpts = ['CC', 'Fx', 'Fy', 'Fz', 'Ex', 'Ey', 'Ez']
-        if vType not in vTypeOpts:
-            err = "vType must be in ['{0!s}'].".format("', '".join(vTypeOpts))
-            err += " vType provided: '{0!s}'.".format(vType)
+        # (b) v_type  # Not yet working for ['CCv']
+        v_typeOpts = ['CC', 'Fx', 'Fy', 'Fz', 'Ex', 'Ey', 'Ez']
+        if v_type not in v_typeOpts:
+            err = "v_type must be in ['{0!s}'].".format("', '".join(v_typeOpts))
+            err += " v_type provided: '{0!s}'.".format(v_type)
             raise ValueError(err)
 
-        if vType != 'CC':
-            aveOp = 'ave' + vType + '2CC'
+        if v_type != 'CC':
+            aveOp = 'ave' + v_type + '2CC'
             Av = getattr(mesh, aveOp)
             if v.size == Av.shape[1]:
                 v = Av * v
             else:
-                v = mesh.r(v, vType[0], vType) # get specific component
+                v = mesh.r(v, v_type[0], v_type) # get specific component
                 v = Av * v
 
         # (c) vOpts  # Not yet working for 'vec'

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -53,12 +53,12 @@ class TensorView(object):
     def plotImage(
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
-        pcolorOpts=None,
+        pcolor_opts=None,
         streamOpts=None,
         gridOpts=None,
         numbering=True, annotationColor='w',
         range_x=None, range_y=None, sample_grid=None,
-        stream_threshold=None
+        stream_threshold=None, **other_kwargs
     ):
         """
         Mesh.plotImage(v)
@@ -99,8 +99,12 @@ class TensorView(object):
             M.plotImage(v, annotationColor='k', showIt=True)
 
         """
-        if pcolorOpts is None:
-            pcolorOpts = {}
+        if "pcolorOpts" in other_kwargs:
+            pcolor_opts = other_kwargs["pcolorOpts"]
+            warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+
+        if pcolor_opts is None:
+            pcolor_opts = {}
         if streamOpts is None:
             streamOpts = {'color': 'k'}
         if gridOpts is None:
@@ -129,7 +133,7 @@ class TensorView(object):
             return self._plotImage2D(
                 v, vType=vType, grid=grid, view=view,
                 ax=ax, clim=clim, showIt=showIt,
-                pcolorOpts=pcolorOpts, streamOpts=streamOpts,
+                pcolor_opts=pcolor_opts, streamOpts=streamOpts,
                 gridOpts=gridOpts, range_x=range_x, range_y=range_y,
                 sample_grid=sample_grid, stream_threshold=stream_threshold
             )
@@ -208,14 +212,14 @@ class TensorView(object):
         self, v, vType='CC',
         normal='Z', ind=None, grid=False, view='real',
         ax=None, clim=None, showIt=False,
-        pcolorOpts=None,
+        pcolor_opts=None,
         streamOpts=None,
         gridOpts=None,
         range_x=None,
         range_y=None,
         sample_grid=None,
         stream_threshold=None,
-        stream_thickness=None
+        stream_thickness=None, **other_kwargs
     ):
 
         """
@@ -235,12 +239,15 @@ class TensorView(object):
             q = discretize.utils.mkvc(q)
             A = M.faceDiv * M.cellGrad
             b = Solver(A) * (q)
-            M.plotSlice(M.cellGrad*b, 'F', view='vec', grid=True, showIt=True, pcolorOpts={'alpha':0.8})
+            M.plotSlice(M.cellGrad*b, 'F', view='vec', grid=True, showIt=True, pcolor_opts={'alpha':0.8})
 
         """
         normal = normal.upper()
-        if pcolorOpts is None:
-            pcolorOpts = {}
+        if "pcolorOpts" in other_kwargs:
+            pcolor_opts = other_kwargs["pcolorOpts"]
+            warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+        if pcolor_opts is None:
+            pcolor_opts = {}
         if streamOpts is None:
             streamOpts = {'color':'k'}
         if gridOpts is None:
@@ -257,7 +264,7 @@ class TensorView(object):
                     self.plotSlice(
                         v, vType=vTypeI, normal=normal, ind=ind, grid=grid,
                         view=view, ax=ax, clim=clim, showIt=False,
-                        pcolorOpts=pcolorOpts, streamOpts=streamOpts,
+                        pcolor_opts=pcolor_opts, streamOpts=streamOpts,
                         gridOpts=gridOpts, stream_threshold=stream_threshold,
                         stream_thickness=stream_thickness
                     )
@@ -356,7 +363,7 @@ class TensorView(object):
             v2d, vType=('CCv' if view == 'vec' else 'CC'),
             grid=grid, view=view,
             ax=ax, clim=clim, showIt=showIt,
-            pcolorOpts=pcolorOpts, streamOpts=streamOpts,
+            pcolor_opts=pcolor_opts, streamOpts=streamOpts,
             gridOpts=gridOpts,
             range_x=range_x,
             range_y=range_y,
@@ -375,7 +382,7 @@ class TensorView(object):
     def _plotImage2D(
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
-        pcolorOpts=None,
+        pcolor_opts=None,
         streamOpts=None,
         gridOpts=None,
         range_x=None,
@@ -385,8 +392,8 @@ class TensorView(object):
         stream_thickness=None
     ):
 
-        if pcolorOpts is None:
-            pcolorOpts = {}
+        if pcolor_opts is None:
+            pcolor_opts = {}
         if streamOpts is None:
             streamOpts = {'color': 'k'}
         if gridOpts is None:
@@ -443,7 +450,7 @@ class TensorView(object):
             if clim is None:
                 clim = [v.min(), v.max()]
             v = np.ma.masked_where(np.isnan(v), v)
-            out += (ax.pcolormesh(self.vectorNx, self.vectorNy, v.T, vmin=clim[0], vmax=clim[1], **pcolorOpts), )
+            out += (ax.pcolormesh(self.vectorNx, self.vectorNy, v.T, vmin=clim[0], vmax=clim[1], **pcolor_opts), )
         elif view in ['vec']:
             # Matplotlib seems to not support irregular
             # spaced vectors at the moment. So we will
@@ -541,7 +548,7 @@ class TensorView(object):
             out += (
                 ax.pcolormesh(
                     x, y, np.sqrt(U**2+V**2).T, vmin=clim[0], vmax=clim[1],
-                    **pcolorOpts),
+                    **pcolor_opts),
             )
             out += (
                 ax.streamplot(
@@ -750,8 +757,8 @@ class TensorView(object):
     def plot_3d_slicer(self, v, xslice=None, yslice=None, zslice=None,
                        vType='CC', view='real', axis='xy', transparent=None,
                        clim=None, xlim=None, ylim=None, zlim=None,
-                       aspect='auto', grid=[2, 2, 1], pcolorOpts=None,
-                       fig=None):
+                       aspect='auto', grid=[2, 2, 1], pcolor_opts=None,
+                       fig=None, **other_kwargs):
         """Plot slices of a 3D volume, interactively (scroll wheel).
 
         If called from a notebook, make sure to set
@@ -784,10 +791,14 @@ class TensorView(object):
         else:
             fig.clf()
 
+        if "pcolorOpts" in other_kwargs:
+            pcolor_opts = other_kwargs["pcolorOpts"]
+            warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+
         # Populate figure
         tracker = Slicer(
             self, v, xslice, yslice, zslice, vType, view, axis, transparent,
-            clim, xlim, ylim, zlim, aspect, grid, pcolorOpts
+            clim, xlim, ylim, zlim, aspect, grid, pcolor_opts
         )
 
         # Connect figure to scrolling
@@ -1147,10 +1158,14 @@ class CurviView(object):
     def plotImage(
         self, v, vType='CC', grid=False, view='real',
         ax=None, clim=None, showIt=False,
-        pcolorOpts=None,
+        pcolor_opts=None,
         gridOpts=None,
-        range_x=None, range_y=None
+        range_x=None, range_y=None, **other_kwargs
     ):
+        if "pcolorOpts" in other_kwargs:
+            pcolor_opts = other_kwargs["pcolorOpts"]
+            warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+
         if self.dim == 3:
             raise NotImplementedError('This is not yet done!')
         if view == 'vec':
@@ -1170,22 +1185,22 @@ class CurviView(object):
 
         if ax is None:
             ax = plt.subplot(111)
-        if pcolorOpts is None:
-            pcolorOpts = {}
-        if 'cmap' in pcolorOpts:
-            cm = pcolorOpts['cmap']
+        if pcolor_opts is None:
+            pcolor_opts = {}
+        if 'cmap' in pcolor_opts:
+            cm = pcolor_opts['cmap']
         else:
             cm = plt.get_cmap()
-        if 'vmin' in pcolorOpts:
-            vmin = pcolorOpts['vmin']
+        if 'vmin' in pcolor_opts:
+            vmin = pcolor_opts['vmin']
         else:
             vmin = np.nanmin(I) if clim is None else clim[0]
-        if 'vmax' in pcolorOpts:
-            vmax = pcolorOpts['vmax']
+        if 'vmax' in pcolor_opts:
+            vmax = pcolor_opts['vmax']
         else:
             vmax = np.nanmax(I) if clim is None else clim[1]
-        if 'alpha' in pcolorOpts:
-            alpha = pcolorOpts['alpha']
+        if 'alpha' in pcolor_opts:
+            alpha = pcolor_opts['alpha']
         else:
             alpha = 1.0
         if gridOpts is None:
@@ -1196,8 +1211,8 @@ class CurviView(object):
         cNorm = colors.Normalize(vmin=vmin, vmax=vmax)
         scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=cm)
 
-        if 'edge_color' in pcolorOpts:
-            edge_color = pcolorOpts['edge_color']
+        if 'edge_color' in pcolor_opts:
+            edge_color = pcolor_opts['edge_color']
         else:
             edge_color = gridOpts['color'] if grid else 'none'
         if 'alpha' in gridOpts:
@@ -1304,7 +1319,7 @@ class Slicer(object):
     grid : list of 3 int
         Number of cells occupied by x, y, and z dimension on plt.subplot2grid.
 
-    pcolorOpts : dictionary
+    pcolor_opts : dictionary
         Passed to pcolormesh.
 
     """
@@ -1312,10 +1327,13 @@ class Slicer(object):
     def __init__(self, mesh, v, xslice=None, yslice=None, zslice=None,
                  vType='CC', view='real', axis='xy', transparent=None,
                  clim=None, xlim=None, ylim=None, zlim=None, aspect='auto',
-                 grid=[2, 2, 1], pcolorOpts=None):
+                 grid=[2, 2, 1], pcolor_opts=None, **other_kwargs):
         """Initialize interactive figure."""
 
         # 0. Some checks, not very extensive
+        if "pcolorOpts" in other_kwargs:
+            pcolor_opts = other_kwargs["pcolorOpts"]
+            warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
 
         # (a) Mesh dimensionality
         if mesh.dim != 3:
@@ -1475,9 +1493,9 @@ class Slicer(object):
         self.clpropsw = {'c': 'w', 'lw': 2, 'zorder': 10}
         self.clpropsk = {'c': 'k', 'lw': 1, 'zorder': 11}
 
-        # Add pcolorOpts
-        if pcolorOpts is not None:
-            self.pc_props.update(pcolorOpts)
+        # Add pcolor_opts
+        if pcolor_opts is not None:
+            self.pc_props.update(pcolor_opts)
 
         # Initial draw
         self.update_xy()

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -29,7 +29,7 @@ class TensorView(object):
     # def components(self):
 
     #     plotAll = len(imageType) == 1
-    #     options = {"direction":direction, "numbering":numbering, "annotationColor":annotationColor, "show_it":False}
+    #     options = {"direction":direction, "numbering":numbering, "annotation_color":annotation_color, "show_it":False}
     #     fig = plt.figure(figNum)
     #     # Determine the subplot number: 131, 121
     #     numPlots = 130 if plotAll else len(imageType)//2*10+100
@@ -56,7 +56,7 @@ class TensorView(object):
         pcolor_opts=None,
         stream_opts=None,
         grid_opts=None,
-        numbering=True, annotationColor='w',
+        numbering=True, annotation_color='w',
         range_x=None, range_y=None, sample_grid=None,
         stream_threshold=None, **other_kwargs
     ):
@@ -78,7 +78,7 @@ class TensorView(object):
         3D Inputs:
 
         :param bool numbering: show numbering of slices, 3D only
-        :param str annotationColor: color of annotation, e.g. 'w', 'k', 'b'
+        :param str annotation_color: color of annotation, e.g. 'w', 'k', 'b'
 
         .. plot::
             :include-source:
@@ -96,7 +96,7 @@ class TensorView(object):
             import numpy as np
             M = discretize.TensorMesh([20, 20, 20])
             v = np.sin(M.gridCC[:, 0]*2*np.pi)*np.sin(M.gridCC[:, 1]*2*np.pi)*np.sin(M.gridCC[:, 2]*2*np.pi)
-            M.plotImage(v, annotationColor='k', show_it=True)
+            M.plotImage(v, annotation_color='k', show_it=True)
 
         """
         if "pcolorOpts" in other_kwargs:
@@ -111,6 +111,9 @@ class TensorView(object):
         if "showIt" in other_kwargs:
             show_it = other_kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
+        if "annotationColor" in other_kwargs:
+            show_it = other_kwargs["annotationColor"]
+            warnings.warn("annotationColor has been deprecated, please use annotation_color", DeprecationWarning)
 
         if pcolor_opts is None:
             pcolor_opts = {}
@@ -198,8 +201,8 @@ class TensorView(object):
             gxY = np.kron(np.ones((nX+1, 1)), np.array([0, sum(self.hy)*nY, np.nan])).ravel()
             gyX = np.kron(np.ones((nY+1, 1)), np.array([0, sum(self.hx)*nX, np.nan])).ravel()
             gyY = np.c_[gy, gy, gy+np.nan].ravel()
-            ax.plot(gxX, gxY, annotationColor+'-', linewidth=2)
-            ax.plot(gyX, gyY, annotationColor+'-', linewidth=2)
+            ax.plot(gxX, gxY, annotation_color+'-', linewidth=2)
+            ax.plot(gyX, gyY, annotation_color+'-', linewidth=2)
             ax.axis('tight')
 
             if numbering:
@@ -209,7 +212,7 @@ class TensorView(object):
                         iz = ix + iy*nX
                         if iz < self.nCz:
                             ax.text((ix+1)*(self.vectorNx[-1]-self.x0[0])-pad, (iy)*(self.vectorNy[-1]-self.x0[1])+pad,
-                                     '#{0:.0f}'.format(iz), color=annotationColor, verticalalignment='bottom', horizontalalignment='right', size='x-large')
+                                     '#{0:.0f}'.format(iz), color=annotation_color, verticalalignment='bottom', horizontalalignment='right', size='x-large')
 
         ax.set_title(vType)
         if show_it:

--- a/discretize/base/base_mesh.py
+++ b/discretize/base/base_mesh.py
@@ -140,7 +140,7 @@ class BaseMesh(properties.HasProperties, InterfaceMixins):
             import discretize
             import numpy as np
             mesh = discretize.TensorMesh([np.ones(n) for n in [2,3]])
-            mesh.plotGrid(centers=True, showIt=True)
+            mesh.plotGrid(centers=True, show_it=True)
 
             print(mesh.nC)
         """
@@ -163,7 +163,7 @@ class BaseMesh(properties.HasProperties, InterfaceMixins):
             import discretize
             import numpy as np
             mesh = discretize.TensorMesh([np.ones(n) for n in [2,3]])
-            mesh.plotGrid(nodes=True, showIt=True)
+            mesh.plotGrid(nodes=True, show_it=True)
 
             print(mesh.nN)
         """
@@ -222,7 +222,7 @@ class BaseMesh(properties.HasProperties, InterfaceMixins):
             import discretize
             import numpy as np
             M = discretize.TensorMesh([np.ones(n) for n in [2,3]])
-            M.plotGrid(edges=True, showIt=True)
+            M.plotGrid(edges=True, show_it=True)
         """
         return np.array(
             [x for x in [self.nEx, self.nEy, self.nEz] if x is not None],
@@ -284,7 +284,7 @@ class BaseMesh(properties.HasProperties, InterfaceMixins):
             import discretize
             import numpy as np
             M = discretize.TensorMesh([np.ones(n) for n in [2,3]])
-            M.plotGrid(faces=True, showIt=True)
+            M.plotGrid(faces=True, show_it=True)
         """
         return np.array(
             [x for x in [self.nFx, self.nFy, self.nFz] if x is not None],

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3517,7 +3517,7 @@ cdef class _TreeMesh:
     def plotImage(self, v, vType='CC', grid=False, view='real',
                   ax=None, clim=None, showIt=False,
                   pcolor_opts=None,
-                  gridOpts=None,
+                  grid_opts=None,
                   range_x=None, range_y=None,
                   **other_kwargs,
                   ):
@@ -3569,6 +3569,9 @@ cdef class _TreeMesh:
         if "pcolorOpts" in other_kwargs:
             pcolor_opts = other_kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+        if "gridOpts" in other_kwargs:
+            grid_opts = other_kwargs["gridOpts"]
+            warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
 
         if ax is None:
             ax = plt.subplot(111)
@@ -3591,10 +3594,10 @@ cdef class _TreeMesh:
         else:
             alpha = 1.0
 
-        if gridOpts is None:
-            gridOpts = {'color':'k'}
-        if 'color' not in gridOpts:
-            gridOpts['color'] = 'k'
+        if grid_opts is None:
+            grid_opts = {'color':'k'}
+        if 'color' not in grid_opts:
+            grid_opts['color'] = 'k'
 
         if 'norm' in pcolor_opts:
            cNorm = pcolor_opts['norm']
@@ -3606,9 +3609,9 @@ cdef class _TreeMesh:
         if 'edge_color' in pcolor_opts:
             edge_color = pcolor_opts['edge_color']
         else:
-            edge_color = gridOpts['color'] if grid else 'none'
-        if 'alpha' in gridOpts:
-            edge_alpha = gridOpts['alpha']
+            edge_color = grid_opts['color'] if grid else 'none'
+        if 'alpha' in grid_opts:
+            edge_alpha = grid_opts['alpha']
         else:
             edge_alpha = 1.0
         if edge_color.lower() != 'none':

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3518,7 +3518,7 @@ cdef class _TreeMesh:
         return ax
 
     @requires({'matplotlib': matplotlib})
-    def plotImage(self, v, vType='CC', grid=False, view='real',
+    def plotImage(self, v, v_type='CC', grid=False, view='real',
                   ax=None, clim=None, show_it=False,
                   pcolor_opts=None,
                   grid_opts=None,
@@ -3532,7 +3532,7 @@ cdef class _TreeMesh:
         ----------
         v : array_like
             Array containing the values to plot
-        vType : str, optional
+        v_type : str, optional
             type of value in `v` one of 'CC', 'N', 'Fx', 'Fy', 'Fz', 'Ex', 'Ey', or 'Ez'
         grid : bool, optional
             plot the grid lines
@@ -3550,7 +3550,7 @@ cdef class _TreeMesh:
             pairs of [min, max] values for the x and y ranges
         """
         if self._dim == 3:
-            self.plotSlice(v, vType=vType, grid=grid, view=view,
+            self.plotSlice(v, v_type=v_type, grid=grid, view=view,
                            ax=ax, clim=clim, show_it=show_it,
                            pcolor_opts=pcolor_opts,
                            range_x=range_x, range_y=range_y,
@@ -3561,13 +3561,13 @@ cdef class _TreeMesh:
 
         if view in ['real', 'imag', 'abs']:
             v = getattr(np, view)(v) # e.g. np.real(v)
-        if vType == 'CC':
+        if v_type == 'CC':
             I = v
-        elif vType == 'N':
+        elif v_type == 'N':
             I = self.aveN2CC*v
-        elif vType in ['Fx', 'Fy', 'Ex', 'Ey']:
-            aveOp = 'ave' + vType[0] + '2CCV'
-            ind_xy = {'x': 0, 'y': 1}[vType[1]]
+        elif v_type in ['Fx', 'Fy', 'Ex', 'Ey']:
+            aveOp = 'ave' + v_type[0] + '2CCV'
+            ind_xy = {'x': 0, 'y': 1}[v_type[1]]
             I = (getattr(self, aveOp)*v).reshape(2, self.nC)[ind_xy] # average to cell centers
 
         if "pcolorOpts" in other_kwargs:
@@ -3579,6 +3579,9 @@ cdef class _TreeMesh:
         if "showIt" in other_kwargs:
             show_it = other_kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
+        if "vType" in other_kwargs:
+            show_it = other_kwargs["vType"]
+            warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if ax is None:
             ax = plt.subplot(111)

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3322,7 +3322,7 @@ cdef class _TreeMesh:
         lines=True, cell_line=False,
         faces_x=False, faces_y=False, faces_z=False,
         edges_x=False, edges_y=False, edges_z=False,
-        showIt=False, **kwargs):
+        show_it=False, **kwargs):
         """ Plot the nodel, cell-centered, and staggered grids for 2 and 3 dimensions
         Plots the mesh grid in either 2D or 3D of the TreeMesh
 
@@ -3346,7 +3346,7 @@ cdef class _TreeMesh:
             Plot the center points of the x, y, or z faces
         edges_x, edges_y, edges_z : bool, optional
             Plot the center points of the x, y, or z edges
-        showIt : bool, optional
+        show_it : bool, optional
             whether to call plt.show() within the codes
         color : Color or str, optional
             if lines=True, the color of the lines, defaults to first color.
@@ -3359,6 +3359,10 @@ cdef class _TreeMesh:
             Axes handle for the plot
 
         """
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
+
         if ax is None:
             if(self._dim == 2):
                 ax = plt.subplot(111)
@@ -3508,14 +3512,14 @@ cdef class _TreeMesh:
             ax.set_zlabel('x3')
 
         ax.grid(True)
-        if showIt:
+        if show_it:
             plt.show()
 
         return ax
 
     @requires({'matplotlib': matplotlib})
     def plotImage(self, v, vType='CC', grid=False, view='real',
-                  ax=None, clim=None, showIt=False,
+                  ax=None, clim=None, show_it=False,
                   pcolor_opts=None,
                   grid_opts=None,
                   range_x=None, range_y=None,
@@ -3547,7 +3551,7 @@ cdef class _TreeMesh:
         """
         if self._dim == 3:
             self.plotSlice(v, vType=vType, grid=grid, view=view,
-                           ax=ax, clim=clim, showIt=showIt,
+                           ax=ax, clim=clim, show_it=show_it,
                            pcolor_opts=pcolor_opts,
                            range_x=range_x, range_y=range_y,
                            **other_kwargs)
@@ -3572,6 +3576,9 @@ cdef class _TreeMesh:
         if "gridOpts" in other_kwargs:
             grid_opts = other_kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
+        if "showIt" in other_kwargs:
+            show_it = other_kwargs["showIt"]
+            warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
 
         if ax is None:
             ax = plt.subplot(111)
@@ -3649,7 +3656,7 @@ cdef class _TreeMesh:
         else:
             ax.set_ylim(*self.vectorNy[[0, -1]])
 
-        if showIt:
+        if show_it:
             plt.show()
         return [scalarMap]
 

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3523,7 +3523,7 @@ cdef class _TreeMesh:
                   pcolor_opts=None,
                   grid_opts=None,
                   range_x=None, range_y=None,
-                  **other_kwargs,
+                  **kwargs,
                   ):
         """ Plots an image of values defined on the TreeMesh
         If 3D, this function plots a default slice of the TreeMesh
@@ -3554,7 +3554,7 @@ cdef class _TreeMesh:
                            ax=ax, clim=clim, show_it=show_it,
                            pcolor_opts=pcolor_opts,
                            range_x=range_x, range_y=range_y,
-                           **other_kwargs)
+                           **kwargs)
 
         if view == 'vec':
             raise NotImplementedError('Vector ploting is not supported on TreeMesh (yet)')
@@ -3570,17 +3570,17 @@ cdef class _TreeMesh:
             ind_xy = {'x': 0, 'y': 1}[v_type[1]]
             I = (getattr(self, aveOp)*v).reshape(2, self.nC)[ind_xy] # average to cell centers
 
-        if "pcolorOpts" in other_kwargs:
-            pcolor_opts = other_kwargs["pcolorOpts"]
+        if "pcolorOpts" in kwargs:
+            pcolor_opts = kwargs["pcolorOpts"]
             warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
-        if "gridOpts" in other_kwargs:
-            grid_opts = other_kwargs["gridOpts"]
+        if "gridOpts" in kwargs:
+            grid_opts = kwargs["gridOpts"]
             warnings.warn("gridOpts has been deprecated, please use grid_opts", DeprecationWarning)
-        if "showIt" in other_kwargs:
-            show_it = other_kwargs["showIt"]
+        if "showIt" in kwargs:
+            show_it = kwargs["showIt"]
             warnings.warn("showIt has been deprecated, please use show_it", DeprecationWarning)
-        if "vType" in other_kwargs:
-            show_it = other_kwargs["vType"]
+        if "vType" in kwargs:
+            show_it = kwargs["vType"]
             warnings.warn("vType has been deprecated, please use v_type", DeprecationWarning)
 
         if ax is None:

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3516,7 +3516,7 @@ cdef class _TreeMesh:
     @requires({'matplotlib': matplotlib})
     def plotImage(self, v, vType='CC', grid=False, view='real',
                   ax=None, clim=None, showIt=False,
-                  pcolorOpts=None,
+                  pcolor_opts=None,
                   gridOpts=None,
                   range_x=None, range_y=None,
                   **other_kwargs,
@@ -3538,7 +3538,7 @@ cdef class _TreeMesh:
             The axes handle
         clim : array_like of length 2, or None, optional
             A pair of [min, max] for the Colorbar
-        pcolorOpts : dict, or None
+        pcolor_opts : dict, or None
             options to be passed on to pcolormesh
         gridOpt : dict, or None
             options for the plotting the grid
@@ -3548,7 +3548,7 @@ cdef class _TreeMesh:
         if self._dim == 3:
             self.plotSlice(v, vType=vType, grid=grid, view=view,
                            ax=ax, clim=clim, showIt=showIt,
-                           pcolorOpts=pcolorOpts,
+                           pcolor_opts=pcolor_opts,
                            range_x=range_x, range_y=range_y,
                            **other_kwargs)
 
@@ -3566,24 +3566,28 @@ cdef class _TreeMesh:
             ind_xy = {'x': 0, 'y': 1}[vType[1]]
             I = (getattr(self, aveOp)*v).reshape(2, self.nC)[ind_xy] # average to cell centers
 
+        if "pcolorOpts" in other_kwargs:
+            pcolor_opts = other_kwargs["pcolorOpts"]
+            warnings.warn("pcolorOpts has been deprecated, please use pcolor_opts", DeprecationWarning)
+
         if ax is None:
             ax = plt.subplot(111)
-        if pcolorOpts is None:
-            pcolorOpts = {}
-        if 'cmap' in pcolorOpts:
-            cm = pcolorOpts['cmap']
+        if pcolor_opts is None:
+            pcolor_opts = {}
+        if 'cmap' in pcolor_opts:
+            cm = pcolor_opts['cmap']
         else:
             cm = plt.get_cmap()
-        if 'vmin' in pcolorOpts:
-            vmin = pcolorOpts['vmin']
+        if 'vmin' in pcolor_opts:
+            vmin = pcolor_opts['vmin']
         else:
             vmin = np.nanmin(I) if clim is None else clim[0]
-        if 'vmax' in pcolorOpts:
-            vmax = pcolorOpts['vmax']
+        if 'vmax' in pcolor_opts:
+            vmax = pcolor_opts['vmax']
         else:
             vmax = np.nanmax(I) if clim is None else clim[1]
-        if 'alpha' in pcolorOpts:
-            alpha = pcolorOpts['alpha']
+        if 'alpha' in pcolor_opts:
+            alpha = pcolor_opts['alpha']
         else:
             alpha = 1.0
 
@@ -3592,15 +3596,15 @@ cdef class _TreeMesh:
         if 'color' not in gridOpts:
             gridOpts['color'] = 'k'
 
-        if 'norm' in pcolorOpts:
-           cNorm = pcolorOpts['norm']
+        if 'norm' in pcolor_opts:
+           cNorm = pcolor_opts['norm']
         else:
            cNorm = colors.Normalize(vmin=vmin, vmax=vmax)
 
         scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=cm)
 
-        if 'edge_color' in pcolorOpts:
-            edge_color = pcolorOpts['edge_color']
+        if 'edge_color' in pcolor_opts:
+            edge_color = pcolor_opts['edge_color']
         else:
             edge_color = gridOpts['color'] if grid else 'none'
         if 'alpha' in gridOpts:

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -5,6 +5,7 @@ cimport numpy as np
 from libc.math cimport sqrt, abs, cbrt
 from libcpp.vector cimport vector
 from numpy.math cimport INFINITY
+import warnings
 
 from tree cimport int_t, Tree as c_Tree, PyWrapper, Node, Edge, Face, Cell as c_Cell
 

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3592,8 +3592,10 @@ cdef class _TreeMesh:
         if 'color' not in gridOpts:
             gridOpts['color'] = 'k'
 
-        cNorm = colors.Normalize(
-            vmin=vmin, vmax=vmax)
+        if 'norm' in pcolorOpts:
+           cNorm = pcolorOpts['norm']
+        else:
+           cNorm = colors.Normalize(vmin=vmin, vmax=vmax)
 
         scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=cm)
 

--- a/discretize/utils/meshutils.py
+++ b/discretize/utils/meshutils.py
@@ -141,7 +141,7 @@ def meshTensor(value):
         tx = [(10.0, 10, -1.3), (10.0, 40), (10.0, 10, 1.3)]
         ty = [(10.0, 10, -1.3), (10.0, 40)]
         mesh = discretize.TensorMesh([tx, ty])
-        mesh.plotGrid(showIt=True)
+        mesh.plotGrid(show_it=True)
 
     """
     if type(value) is not list:

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -14,6 +14,7 @@ pep8 friendly names. The older name will still function, but throw a deprecation
 * ``gridOpts`` -> ``grid_opts``
 * ``showIt`` -> ``show_it``
 * ``annotationColor`` -> ``annotation_color``
+* ``vType`` -> ``v_type``
 
 A small release adding the ability to specify the ``norm`` option for
 the ``pcolor_opts`` dictionary argument to ``TreeMesh.plotImage``.

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -10,7 +10,7 @@ This release is renaming a few of the options to the plotting routines to more
 pep8 friendly names. The older name will still function, but throw a deprecation warning
 
 * ``pcolorOpts`` -> ``pcolor_opts``
-*
+* ``streamOpts`` -> ``stream_opts``
 
 A small release adding the ability to specify the ``norm`` option for
 the ``pcolor_opts`` dictionary argument to ``TreeMesh.plotImage``.

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -13,6 +13,7 @@ pep8 friendly names. The older name will still function, but throw a deprecation
 * ``streamOpts`` -> ``stream_opts``
 * ``gridOpts`` -> ``grid_opts``
 * ``showIt`` -> ``show_it``
+* ``annotationColor`` -> ``annotation_color``
 
 A small release adding the ability to specify the ``norm`` option for
 the ``pcolor_opts`` dictionary argument to ``TreeMesh.plotImage``.

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -9,12 +9,12 @@
 This release is renaming a few of the options to the plotting routines to more
 pep8 friendly names. The older name will still function, but throw a deprecation warning
 
-* ``pcolorOpts`` -> ``pcolor_opts``
-* ``streamOpts`` -> ``stream_opts``
-* ``gridOpts`` -> ``grid_opts``
-* ``showIt`` -> ``show_it``
-* ``annotationColor`` -> ``annotation_color``
-* ``vType`` -> ``v_type``
+* ``vType`` → ``v_type``
+* ``pcolorOpts`` → ``pcolor_opts``
+* ``streamOpts`` → ``stream_opts``
+* ``gridOpts`` → ``grid_opts``
+* ``showIt`` → ``show_it``
+* ``annotationColor`` → ``annotation_color``
 
 A small release adding the ability to specify the ``norm`` option for
 the ``pcolor_opts`` dictionary argument to ``TreeMesh.plotImage``.

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -11,6 +11,7 @@ pep8 friendly names. The older name will still function, but throw a deprecation
 
 * ``pcolorOpts`` -> ``pcolor_opts``
 * ``streamOpts`` -> ``stream_opts``
+* ``gridOpts`` -> ``grid_opts``
 
 A small release adding the ability to specify the ``norm`` option for
 the ``pcolor_opts`` dictionary argument to ``TreeMesh.plotImage``.

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -6,4 +6,16 @@
 ``discretize`` 0.4.14 Release Notes
 ===================================
 
-Placeholder
+A small release adding the ability to specify the ``norm`` option for
+the ``pcolorOpts`` dictionary argument to ``TreeMesh.plotImage``.
+
+Contributors
+============
+
+* @jcapriot
+
+
+Pull requests
+=============
+
+* `#211 <https://github.com/simpeg/discretize/pull/211>`__: Add ability to handle "norm" keyword in pcolorOpts on the TreeMesh

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -12,6 +12,7 @@ pep8 friendly names. The older name will still function, but throw a deprecation
 * ``pcolorOpts`` -> ``pcolor_opts``
 * ``streamOpts`` -> ``stream_opts``
 * ``gridOpts`` -> ``grid_opts``
+* ``showIt`` -> ``show_it``
 
 A small release adding the ability to specify the ``norm`` option for
 the ``pcolor_opts`` dictionary argument to ``TreeMesh.plotImage``.

--- a/docs/release/0.4.14-notes.rst
+++ b/docs/release/0.4.14-notes.rst
@@ -6,8 +6,14 @@
 ``discretize`` 0.4.14 Release Notes
 ===================================
 
+This release is renaming a few of the options to the plotting routines to more
+pep8 friendly names. The older name will still function, but throw a deprecation warning
+
+* ``pcolorOpts`` -> ``pcolor_opts``
+*
+
 A small release adding the ability to specify the ``norm`` option for
-the ``pcolorOpts`` dictionary argument to ``TreeMesh.plotImage``.
+the ``pcolor_opts`` dictionary argument to ``TreeMesh.plotImage``.
 
 Contributors
 ============
@@ -18,4 +24,4 @@ Contributors
 Pull requests
 =============
 
-* `#211 <https://github.com/simpeg/discretize/pull/211>`__: Add ability to handle "norm" keyword in pcolorOpts on the TreeMesh
+* `#211 <https://github.com/simpeg/discretize/pull/211>`__: Add ability to handle "norm" keyword in pcolor_opts on the TreeMesh

--- a/docs/release/0.4.15-notes.rst
+++ b/docs/release/0.4.15-notes.rst
@@ -1,0 +1,9 @@
+.. currentmodule:: discretize
+
+.. _0.4.15_notes:
+
+===================================
+``discretize`` 0.4.15 Release Notes
+===================================
+
+Placeholder

--- a/docs/release/index.rst
+++ b/docs/release/index.rst
@@ -4,4 +4,6 @@ Release Notes
 .. toctree::
    :maxdepth: 2
 
+   0.4.14-notes
+   0.4.13-notes
    0.4.12-notes

--- a/examples/plot_slicer_demo.py
+++ b/examples/plot_slicer_demo.py
@@ -120,27 +120,27 @@ beautify(
 )
 
 ###############################################################################
-# 1.4 Set `clim`, use `pcolorOpts` to show grid lines
+# 1.4 Set `clim`, use `pcolor_opts` to show grid lines
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 mesh.plot_3d_slicer(
-    Lpout, clim=[-0.4, 0.2], pcolorOpts={'edgecolor': 'k', 'linewidth': 0.1}
+    Lpout, clim=[-0.4, 0.2], pcolor_opts={'edgecolor': 'k', 'linewidth': 0.1}
 )
 beautify(
     "mesh.plot_3d_slicer(\nLpout, clim=[-0.4, 0.2], "
-    "pcolorOpts={'edgecolor': 'k', 'linewidth': 0.1})"
+    "pcolor_opts={'edgecolor': 'k', 'linewidth': 0.1})"
 )
 
 ###############################################################################
-# 1.5 Use `pcolorOpts` to set `SymLogNorm`, and another `cmap`
+# 1.5 Use `pcolor_opts` to set `SymLogNorm`, and another `cmap`
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 mesh.plot_3d_slicer(
-    Lpout, pcolorOpts={'norm': SymLogNorm(linthresh=0.01),'cmap': 'RdBu_r'}
+    Lpout, pcolor_opts={'norm': SymLogNorm(linthresh=0.01),'cmap': 'RdBu_r'}
 )
 beautify(
     "mesh.plot_3d_slicer(Lpout,"
-    "\npcolorOpts={'norm': SymLogNorm(linthresh=0.01),'cmap': 'RdBu_r'})`"
+    "\npcolor_opts={'norm': SymLogNorm(linthresh=0.01),'cmap': 'RdBu_r'})`"
 )
 
 ###############################################################################

--- a/examples/plot_streamThickness.py
+++ b/examples/plot_streamThickness.py
@@ -69,7 +69,7 @@ print(dataVec.shape)
 
 # Set streamline plotting options
 streamOpts = {'color':'w', 'density':2.0}
-pcolorOpts = {"cmap":"viridis"}
+pcolor_opts = {"cmap":"viridis"}
 
 dat = mesh.plotSlice(
     dataVec, ax=ax, normal='Z', ind=5, vType='CCv', view='vec',

--- a/examples/plot_streamThickness.py
+++ b/examples/plot_streamThickness.py
@@ -73,7 +73,7 @@ pcolor_opts = {"cmap":"viridis"}
 
 dat = mesh.plotSlice(
     dataVec, ax=ax, normal='Z', ind=5, vType='CCv', view='vec',
-    stream_opts=stream_opts, gridOpts={"color":"k", "alpha":0.1}, grid=True,
+    stream_opts=stream_opts, grid_opts={"color":"k", "alpha":0.1}, grid=True,
     clim=None, stream_thickness=3
 )
 

--- a/examples/plot_streamThickness.py
+++ b/examples/plot_streamThickness.py
@@ -72,7 +72,7 @@ stream_opts = {'color':'w', 'density':2.0}
 pcolor_opts = {"cmap":"viridis"}
 
 dat = mesh.plotSlice(
-    dataVec, ax=ax, normal='Z', ind=5, vType='CCv', view='vec',
+    dataVec, ax=ax, normal='Z', ind=5, v_type='CCv', view='vec',
     stream_opts=stream_opts, grid_opts={"color":"k", "alpha":0.1}, grid=True,
     clim=None, stream_thickness=3
 )

--- a/examples/plot_streamThickness.py
+++ b/examples/plot_streamThickness.py
@@ -68,12 +68,12 @@ dataVec = np.hstack([U,V,W])
 print(dataVec.shape)
 
 # Set streamline plotting options
-streamOpts = {'color':'w', 'density':2.0}
+stream_opts = {'color':'w', 'density':2.0}
 pcolor_opts = {"cmap":"viridis"}
 
 dat = mesh.plotSlice(
     dataVec, ax=ax, normal='Z', ind=5, vType='CCv', view='vec',
-    streamOpts=streamOpts, gridOpts={"color":"k", "alpha":0.1}, grid=True,
+    stream_opts=stream_opts, gridOpts={"color":"k", "alpha":0.1}, grid=True,
     clim=None, stream_thickness=3
 )
 

--- a/tests/base/test_tensor_boundary_poisson.py
+++ b/tests/base/test_tensor_boundary_poisson.py
@@ -133,7 +133,7 @@ class Test2D_InhomogeneousDirichlet(discretize.Tests.OrderTest):
         j = McI*(G*xc_ana + P*bc)
         q = D*j
 
-        # self.M.plotImage(j, 'FxFy', showIt=True)
+        # self.M.plotImage(j, 'FxFy', show_it=True)
 
         # Rearrange if we know q to solve for x
         A = D*McI*G

--- a/tests/tree/test_tree.py
+++ b/tests/tree/test_tree.py
@@ -91,7 +91,7 @@ class TestSimpleQuadTree(unittest.TestCase):
         hx, hy = np.r_[1., 2, 3, 4], np.r_[5., 6, 7, 8]
         T = discretize.TreeMesh([hx, hy], levels=2)
         T.refine(lambda xc: 2)
-        # T.plotGrid(showIt=True)
+        # T.plotGrid(show_it=True)
         M = discretize.TensorMesh([hx, hy])
         self.assertEqual(M.nC, T.nC)
         self.assertEqual(M.nF, T.nF)
@@ -139,7 +139,7 @@ class TestOcTree(unittest.TestCase):
         levels = np.array([1, 2])
         M.insert_cells(points, levels)
         M.number()
-        # M.plotGrid(showIt=True)
+        # M.plotGrid(show_it=True)
         self.assertEqual(M.nhFx, 4)
         self.assertTrue(M.nFx, 19)
         self.assertTrue(M.nC, 15)
@@ -159,7 +159,7 @@ class TestOcTree(unittest.TestCase):
         hx, hy, hz = np.r_[1., 2, 3, 4], np.r_[5., 6, 7, 8], np.r_[9., 10, 11, 12]
         M = discretize.TreeMesh([hx, hy, hz], levels=2)
         M.refine(lambda xc: 2)
-        # M.plotGrid(showIt=True)
+        # M.plotGrid(show_it=True)
         Mr = discretize.TensorMesh([hx, hy, hz])
         self.assertEqual(M.nC, Mr.nC)
         self.assertEqual(M.nF, Mr.nF)
@@ -197,7 +197,7 @@ class TestOcTree(unittest.TestCase):
 
         M = discretize.TreeMesh([hx, hy, hz], levels=2)
         M.refine(lambda xc:2)
-        # M.plotGrid(showIt=True)
+        # M.plotGrid(show_it=True)
         Mr = discretize.TensorMesh([hx, hy, hz])
 
 
@@ -307,7 +307,7 @@ class Test3DInterpolation(unittest.TestCase):
 
         M = discretize.TreeMesh([16, 16, 16], levels=4)
         M.refine(function)
-        # M.plotGrid(showIt=True)
+        # M.plotGrid(show_it=True)
         self.M = M
 
     def test_Fx(self):

--- a/tests/tree/test_tree_operators.py
+++ b/tests/tree/test_tree_operators.py
@@ -96,7 +96,7 @@ class TestFaceDivxy2D(discretize.Tests.OrderTest):
 
         err = np.linalg.norm((divF-divF_ana), np.inf)
 
-        # self.M.plotImage(divF-divF_ana, showIt=True)
+        # self.M.plotImage(divF-divF_ana, show_it=True)
 
         return err
 
@@ -155,7 +155,7 @@ class TestFaceDivxyz3D(discretize.Tests.OrderTest):
 
         err = np.linalg.norm((divF-divF_ana), np.inf)
 
-        # self.M.plotImage(divF-divF_ana, showIt=True)
+        # self.M.plotImage(divF-divF_ana, show_it=True)
 
         return err
 

--- a/tutorials/inner_products/1_basic.py
+++ b/tutorials/inner_products/1_basic.py
@@ -203,7 +203,7 @@ ipt = np.pi*sig**2
 fig = plt.figure(figsize=(5, 5))
 ax = fig.add_subplot(111)
 mesh.plotImage(v, ax=ax, vType='F', view='vec',
-               streamOpts={'color': 'w', 'density': 1.0})
+               stream_opts={'color': 'w', 'density': 1.0})
 ax.set_title('v at cell faces')
 
 fig.show()

--- a/tutorials/inner_products/1_basic.py
+++ b/tutorials/inner_products/1_basic.py
@@ -202,7 +202,7 @@ ipt = np.pi*sig**2
 # Plot the vector function
 fig = plt.figure(figsize=(5, 5))
 ax = fig.add_subplot(111)
-mesh.plotImage(v, ax=ax, vType='F', view='vec',
+mesh.plotImage(v, ax=ax, v_type='F', view='vec',
                stream_opts={'color': 'w', 'density': 1.0})
 ax.set_title('v at cell faces')
 

--- a/tutorials/mesh_generation/4_tree_mesh.py
+++ b/tutorials/mesh_generation/4_tree_mesh.py
@@ -67,7 +67,7 @@ mesh = refine_tree_xyz(
 
 mesh.finalize()  # Must finalize tree mesh before use
 
-mesh.plotGrid(showIt=True)
+mesh.plotGrid(show_it=True)
 
 
 ###############################################

--- a/tutorials/operators/1_averaging.py
+++ b/tutorials/operators/1_averaging.py
@@ -173,17 +173,17 @@ ax1.set_title('Variable at cell centers')
 
 # Apply cell centers to faces averaging
 ax2 = fig.add_subplot(222)
-mesh.plotImage(A2*v, ax=ax2, vType='F')
+mesh.plotImage(A2*v, ax=ax2, v_type='F')
 ax2.set_title('Cell centers to faces')
 
 # Use the transpose to go from cell centers to nodes
 ax3 = fig.add_subplot(223)
-mesh.plotImage(A3.T*v, ax=ax3, vType='N')
+mesh.plotImage(A3.T*v, ax=ax3, v_type='N')
 ax3.set_title('Cell centers to nodes using transpose')
 
 # Use the transpose to go from cell centers to faces
 ax4 = fig.add_subplot(224)
-mesh.plotImage(A4.T*v, ax=ax4, vType='F')
+mesh.plotImage(A4.T*v, ax=ax4, v_type='F')
 ax4.set_title('Cell centers to faces using transpose')
 
 fig.show()

--- a/tutorials/operators/2_differential.py
+++ b/tutorials/operators/2_differential.py
@@ -211,7 +211,7 @@ ax1.set_title('u at cell centers')
 
 ax2 = fig.add_subplot(122)
 mesh.plotImage(grad_u, ax=ax2, vType='E', view='vec',
-               streamOpts={'color': 'w', 'density': 1.0})
+               stream_opts={'color': 'w', 'density': 1.0})
 ax2.set_title('gradient of u on edges')
 
 fig.show()
@@ -221,7 +221,7 @@ fig = plt.figure(figsize=(10, 5))
 
 ax1 = fig.add_subplot(121)
 mesh.plotImage(v, ax=ax1, vType='F', view='vec',
-               streamOpts={'color': 'w', 'density': 1.0})
+               stream_opts={'color': 'w', 'density': 1.0})
 ax1.set_title('v at cell faces')
 
 ax2 = fig.add_subplot(122)
@@ -235,7 +235,7 @@ fig = plt.figure(figsize=(10, 5))
 
 ax1 = fig.add_subplot(121)
 mesh.plotImage(w, ax=ax1, vType='E', view='vec',
-               streamOpts={'color': 'w', 'density': 1.0})
+               stream_opts={'color': 'w', 'density': 1.0})
 ax1.set_title('w at cell edges')
 
 ax2 = fig.add_subplot(122)

--- a/tutorials/operators/2_differential.py
+++ b/tutorials/operators/2_differential.py
@@ -206,11 +206,11 @@ curl_w = CURL*w
 fig = plt.figure(figsize=(10, 5))
 
 ax1 = fig.add_subplot(121)
-mesh.plotImage(u, ax=ax1, vType='N')
+mesh.plotImage(u, ax=ax1, v_type='N')
 ax1.set_title('u at cell centers')
 
 ax2 = fig.add_subplot(122)
-mesh.plotImage(grad_u, ax=ax2, vType='E', view='vec',
+mesh.plotImage(grad_u, ax=ax2, v_type='E', view='vec',
                stream_opts={'color': 'w', 'density': 1.0})
 ax2.set_title('gradient of u on edges')
 
@@ -220,7 +220,7 @@ fig.show()
 fig = plt.figure(figsize=(10, 5))
 
 ax1 = fig.add_subplot(121)
-mesh.plotImage(v, ax=ax1, vType='F', view='vec',
+mesh.plotImage(v, ax=ax1, v_type='F', view='vec',
                stream_opts={'color': 'w', 'density': 1.0})
 ax1.set_title('v at cell faces')
 
@@ -234,7 +234,7 @@ fig.show()
 fig = plt.figure(figsize=(10, 5))
 
 ax1 = fig.add_subplot(121)
-mesh.plotImage(w, ax=ax1, vType='E', view='vec',
+mesh.plotImage(w, ax=ax1, v_type='E', view='vec',
                stream_opts={'color': 'w', 'density': 1.0})
 ax1.set_title('w at cell edges')
 

--- a/tutorials/pde/1_poisson.py
+++ b/tutorials/pde/1_poisson.py
@@ -143,5 +143,5 @@ ax2.set_title('Electric Potential')
 
 ax3 = fig.add_subplot(133)
 mesh.plotImage(E, ax=ax3, vType='F', view='vec',
-               streamOpts={'color': 'w', 'density': 1.0})
+               stream_opts={'color': 'w', 'density': 1.0})
 ax3.set_title('Electric Fields')

--- a/tutorials/pde/1_poisson.py
+++ b/tutorials/pde/1_poisson.py
@@ -134,14 +134,14 @@ E = Mf_inv*DIV.T*Mc*phi
 fig = plt.figure(figsize=(14, 4))
 
 ax1 = fig.add_subplot(131)
-mesh.plotImage(rho, vType='CC', ax=ax1)
+mesh.plotImage(rho, v_type='CC', ax=ax1)
 ax1.set_title('Charge Density')
 
 ax2 = fig.add_subplot(132)
-mesh.plotImage(phi, vType='CC', ax=ax2)
+mesh.plotImage(phi, v_type='CC', ax=ax2)
 ax2.set_title('Electric Potential')
 
 ax3 = fig.add_subplot(133)
-mesh.plotImage(E, ax=ax3, vType='F', view='vec',
+mesh.plotImage(E, ax=ax3, v_type='F', view='vec',
                stream_opts={'color': 'w', 'density': 1.0})
 ax3.set_title('Electric Fields')

--- a/tutorials/pde/2_advection_diffusion.py
+++ b/tutorials/pde/2_advection_diffusion.py
@@ -236,7 +236,7 @@ ax = 9*[None]
 ax[0] = fig.add_subplot(332)
 mesh.plotImage(
     u, ax=ax[0], vType='F', view='vec',
-    streamOpts={'color': 'w', 'density': 1.0},
+    stream_opts={'color': 'w', 'density': 1.0},
     clim=[0., 10.]
 )
 ax[0].set_title('Divergence free vector field')

--- a/tutorials/pde/2_advection_diffusion.py
+++ b/tutorials/pde/2_advection_diffusion.py
@@ -235,7 +235,7 @@ ax = 9*[None]
 
 ax[0] = fig.add_subplot(332)
 mesh.plotImage(
-    u, ax=ax[0], vType='F', view='vec',
+    u, ax=ax[0], v_type='F', view='vec',
     stream_opts={'color': 'w', 'density': 1.0},
     clim=[0., 10.]
 )
@@ -261,7 +261,7 @@ for ii in range(300):
 
     if ii+1 in (1, 25, 50, 100, 200, 300):
         ax[n] = fig.add_subplot(3, 3, n+1)
-        mesh.plotImage(p, vType='CC', ax=ax[n], pcolor_opts={'cmap': 'gist_heat_r'})
+        mesh.plotImage(p, v_type='CC', ax=ax[n], pcolor_opts={'cmap': 'gist_heat_r'})
         title_str = 'p at t = ' + str((ii+1)*dt) + ' s'
         ax[n].set_title(title_str)
         n = n+1

--- a/tutorials/pde/2_advection_diffusion.py
+++ b/tutorials/pde/2_advection_diffusion.py
@@ -261,7 +261,7 @@ for ii in range(300):
 
     if ii+1 in (1, 25, 50, 100, 200, 300):
         ax[n] = fig.add_subplot(3, 3, n+1)
-        mesh.plotImage(p, vType='CC', ax=ax[n], pcolorOpts={'cmap': 'gist_heat_r'})
+        mesh.plotImage(p, vType='CC', ax=ax[n], pcolor_opts={'cmap': 'gist_heat_r'})
         title_str = 'p at t = ' + str((ii+1)*dt) + ' s'
         ax[n].set_title(title_str)
         n = n+1


### PR DESCRIPTION
The `TreeMesh.plotImage` function will now respect the `norm` option for the `pcolorOpts` dictionary.

This allows us to make better LogScaled model plots.