### PR TITLE
Syntax and bug fixes

### DIFF
--- a/discretize/CylMesh.py
+++ b/discretize/CylMesh.py
@@ -1523,7 +1523,7 @@ class CylMesh(
         values = list(hang.values())
         entries = np.ones(len(values))
 
-        if asOnes and len(hang) > 0:
+        if not asOnes and len(hang) > 0:
             repeats = set(values)
             repeat_locs = [
                 (np.r_[values] == repeat).nonzero()[0]

--- a/discretize/CylMesh.py
+++ b/discretize/CylMesh.py
@@ -121,7 +121,7 @@ class CylMesh(
         int
             Number of nodes in the x-direction
         """
-        # if self.isSymmetric is True:
+        # if self.isSymmetric:
         #     return self.nCx
         return self._ntNx
 
@@ -133,7 +133,7 @@ class CylMesh(
         int
             Number of total y nodes (prior to deflating)
         """
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return 1
         return self.nCy + 1
 
@@ -145,7 +145,7 @@ class CylMesh(
         int
             Number of nodes in the y-direction
         """
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return 0
         return self.nCy
 
@@ -336,7 +336,7 @@ class CylMesh(
         int
             Number of z-edges
         """
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return self.vnEz.prod()
         return (np.r_[self.nNx-1, self.nNy, self.nCz]).prod() + self.nCz
 
@@ -348,14 +348,14 @@ class CylMesh(
     @property
     def vectorCCy(self):
         """Cell-centered grid vector (1D) in the y direction."""
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return np.r_[0, self.hy[:-1]]
         return np.r_[0, self.hy[:-1].cumsum()] + self.hy*0.5
 
     @property
     def vectorNx(self):
         """Nodal grid vector (1D) in the x direction."""
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return self.hx.cumsum()
         return np.r_[0, self.hx].cumsum()
 
@@ -371,7 +371,7 @@ class CylMesh(
     @property
     def vectorNy(self):
         """Nodal grid vector (1D) in the y direction."""
-        # if self.isSymmetric is True:
+        # if self.isSymmetric:
         #     # There aren't really any nodes, but all the grids need
         #     # somewhere to live, why not zero?!
         #     return np.r_[0]
@@ -478,7 +478,7 @@ class CylMesh(
         numpy.ndarray
             vector of edge lengths :math:`(r, \\theta, z)`
         """
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return self.edgeEy
             # return 2*pi*self.gridN[:, 0]
         else:
@@ -536,7 +536,7 @@ class CylMesh(
             area of y-faces
         """
         if getattr(self, '_areaFy', None) is None:
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 raise Exception(
                     'There are no y-faces on the Cyl Symmetric mesh'
                 )
@@ -603,7 +603,7 @@ class CylMesh(
             face areas
         """
         # if getattr(self, '_area', None) is None:
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return np.r_[self.areaFx, self.areaFz]
         else:
             return np.r_[self.areaFx, self.areaFy, self.areaFz]
@@ -1024,7 +1024,7 @@ class CylMesh(
             grid locations of radial faces
         """
         if getattr(self, '_gridFx', None) is None:
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 return super(CylMesh, self).gridFx
             else:
                 self._gridFx = self._gridFxFull[~self._ishangingFx, :]
@@ -1049,7 +1049,7 @@ class CylMesh(
             grid locations of azimuthal faces
         """
         if getattr(self, '_gridEy', None) is None:
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 return self._gridEyFull
             else:
                 self._gridEy = self._gridEyFull[~self._ishangingEy, :]
@@ -1076,7 +1076,7 @@ class CylMesh(
             grid locations of radial faces
         """
         if getattr(self, '_gridEz', None) is None:
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 self._gridEz = None
             else:
                 self._gridEz = self._gridEzFull[~self._ishangingEz, :]
@@ -1095,7 +1095,7 @@ class CylMesh(
             # Compute faceDivergence operator on faces
             D1 = self.faceDivx
             D3 = self.faceDivz
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 D = sp.hstack((D1, D3), format="csr")
             elif self.nCy > 1:
                 D2 = self.faceDivy
@@ -1205,26 +1205,26 @@ class CylMesh(
 
     # @property
     # def _nodalGradStencilx(self):
-    #     if self.isSymmetric is True:
+    #     if self.isSymmetric:
     #         return None
     #     return kron3(speye(self.nNz), speye(self.nNy), ddx(self.nCx))
 
     # @property
     # def _nodalGradStencily(self):
-    #     if self.isSymmetric is True:
+    #     if self.isSymmetric:
     #         None
     #         # return kron3(speye(self.nNz), ddx(self.nCy), speye(self.nNx)) * self._deflationMatrix('Ey')
     #     return kron3(speye(self.nNz), ddx(self.nCy), speye(self.nNx))
 
     # @property
     # def _nodalGradStencilz(self):
-    #     if self.isSymmetric is True:
+    #     if self.isSymmetric:
     #         return None
     #     return kron3(ddx(self.nCz), speye(self.nNy), speye(self.nNx))
 
     # @property
     # def _nodalGradStencil(self):
-    #     if self.isSymmetric is True:
+    #     if self.isSymmetric:
     #         return None
     #     else:
     #         G = self._deflationMatrix('E').T * sp.vstack((
@@ -1237,7 +1237,7 @@ class CylMesh(
     @property
     def nodalGrad(self):
         """Construct gradient operator (nodes to edges)."""
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return None
         raise NotImplementedError('nodalGrad not yet implemented')
 
@@ -1260,7 +1260,7 @@ class CylMesh(
             A = self.area
             E = self.edge
 
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 # 1D Difference matricies
                 dr = sp.spdiags(
                     (np.ones((self.nCx+1, 1))*[-1, 1]).T, [-1, 0],
@@ -1358,7 +1358,7 @@ class CylMesh(
         if getattr(self, '_aveE2CC', None) is None:
             # The number of cell centers in each direction
             # n = self.vnC
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 self._aveE2CC = self.aveEy2CC
             else:
                 self._aveE2CC = 1./self.dim * sp.hstack(
@@ -1377,7 +1377,7 @@ class CylMesh(
         scipy.sparse.csr_matrix
             matrix that averages from edges to cell centered vectors
         """
-        if self.isSymmetric is True:
+        if self.isSymmetric:
             return self.aveE2CC
         else:
             if getattr(self, '_aveE2CCV', None) is None:
@@ -1445,7 +1445,7 @@ class CylMesh(
         """
         if getattr(self, '_aveF2CC', None) is None:
             n = self.vnC
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 self._aveF2CC = 0.5*(
                     sp.hstack((self.aveFx2CC, self.aveFz2CC), format="csr")
                 )
@@ -1470,7 +1470,7 @@ class CylMesh(
         """
         if getattr(self, '_aveF2CCV', None) is None:
             # n = self.vnC
-            if self.isSymmetric is True:
+            if self.isSymmetric:
                 self._aveF2CCV = sp.block_diag(
                     (self.aveFx2CC, self.aveFz2CC), format="csr"
                 )
@@ -1523,7 +1523,7 @@ class CylMesh(
         values = list(hang.values())
         entries = np.ones(len(values))
 
-        if asOnes is False and len(hang) > 0:
+        if asOnes and len(hang) > 0:
             repeats = set(values)
             repeat_locs = [
                 (np.r_[values] == repeat).nonzero()[0]

--- a/discretize/DiffOperators.py
+++ b/discretize/DiffOperators.py
@@ -697,7 +697,7 @@ class DiffOperators(object):
             BC = [['neumann', 'dirichlet'], 'dirichlet', 'dirichlet']
         """
 
-        if discretization is not 'CC':
+        if discretization != 'CC':
             raise NotImplementedError(
                 'Boundary conditions only implemented'
                 'for CC discretization.'
@@ -797,7 +797,7 @@ class DiffOperators(object):
         when mixed boundary condition is used
         """
 
-        if discretization is not 'CC':
+        if discretization != 'CC':
             raise NotImplementedError('Boundary conditions only implemented'
                                       'for CC discretization.')
 

--- a/discretize/TreeMesh.py
+++ b/discretize/TreeMesh.py
@@ -628,7 +628,7 @@ class TreeMesh(_TreeMesh, BaseTensorMesh, InnerProducts, TreeMeshIO):
         tm_gridboost[:, normalInd] = slice_loc
 
         # interpolate values to self.gridCC if not 'CC'
-        if v_type is not 'CC':
+        if v_type != 'CC':
             aveOp = 'ave' + v_type + '2CC'
             Av = getattr(self, aveOp)
             if v.size == Av.shape[1]:

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -877,7 +877,7 @@ class CylView(object):
                         mirror_data = mkvc(self.aveE2CCV * mirror_data)
                 args = (val,) + args[1:]
 
-        if mirror is True:
+        if mirror:
             # create a mirrored mesh
             hx = np.hstack([np.flipud(self.hx), self.hx])
             x00 = self.x0[0] - self.hx.sum()

--- a/discretize/base/base_mesh.py
+++ b/discretize/base/base_mesh.py
@@ -404,7 +404,7 @@ class BaseMesh(properties.HasProperties, InterfaceMixins):
         with open(f, 'w') as outfile:
             json.dump(self.serialize(), outfile)
 
-        if verbose is True:
+        if verbose:
             print('Saved {}'.format(f))
 
         return f

--- a/discretize/base/base_tensor_mesh.py
+++ b/discretize/base/base_tensor_mesh.py
@@ -343,7 +343,7 @@ class BaseTensorMesh(BaseMesh):
 
         loc = utils.asArray_N_x_Dim(loc, self.dim)
 
-        if zerosOutside is False:
+        if not zerosOutside:
             assert np.all(self.isInside(loc)), "Points outside of mesh"
         else:
             indZeros = np.logical_not(self.isInside(loc))

--- a/discretize/mixins/vtkModule.py
+++ b/discretize/mixins/vtkModule.py
@@ -411,7 +411,7 @@ class InterfaceVTK(object):
         # Check the extension of the filename
         fname = os.path.join(directory, filename)
         ext = os.path.splitext(fname)[1]
-        if ext is '':
+        if ext == '':
             fname = fname + '.vtu'
         elif ext not in '.vtu':
             raise IOError('{:s} is an incorrect extension, has to be .vtu'.format(ext))
@@ -445,7 +445,7 @@ class InterfaceVTK(object):
         # Check the extension of the filename
         fname = os.path.join(directory, filename)
         ext = os.path.splitext(fname)[1]
-        if ext is '':
+        if ext == '':
             fname = fname + '.vts'
         elif ext not in '.vts':
             raise IOError('{:s} is an incorrect extension, has to be .vts'.format(ext))
@@ -479,7 +479,7 @@ class InterfaceVTK(object):
         # Check the extension of the filename
         fname = os.path.join(directory, filename)
         ext = os.path.splitext(fname)[1]
-        if ext is '':
+        if ext == '':
             fname = fname + '.vtr'
         elif ext not in '.vtr':
             raise IOError('{:s} is an incorrect extension, has to be .vtr'.format(ext))

--- a/discretize/tree_ext.pyx
+++ b/discretize/tree_ext.pyx
@@ -3754,11 +3754,15 @@ cdef class _TreeMesh:
     @cython.cdivision(True)
     def _vol_avg_from_tree(self, _TreeMesh meshin, values=None, output=None):
         # first check if they have the same tensor base, as it makes it a lot easier...
-        cdef int_t same_base = (
-          np.allclose(self.vectorNx, meshin.vectorNx)
-          and np.allclose(self.vectorNy, meshin.vectorNy)
-          and (self.dim == 2 or np.allclose(self.vectorNz, meshin.vectorNz))
-        )
+        cdef int_t same_base
+        try:
+            same_base = (
+                np.allclose(self.vectorNx, meshin.vectorNx)
+                and np.allclose(self.vectorNy, meshin.vectorNy)
+                and (self.dim == 2 or np.allclose(self.vectorNz, meshin.vectorNz))
+            )
+        except ValueError:
+            same_base = False
         cdef c_Cell * out_cell
         cdef c_Cell * in_cell
 
@@ -3936,11 +3940,15 @@ cdef class _TreeMesh:
         cdef double[:] xF
 
         # first check if they have the same tensor base, as it makes it a lot easier...
-        cdef int_t same_base = (
-          np.allclose(self.vectorNx, out_tens_mesh.vectorNx)
-          and np.allclose(self.vectorNy, out_tens_mesh.vectorNy)
-          and (self.dim == 2 or np.allclose(self.vectorNz, out_tens_mesh.vectorNz))
-        )
+        cdef int_t same_base
+        try:
+            same_base = (
+                np.allclose(self.vectorNx, out_tens_mesh.vectorNx)
+                and np.allclose(self.vectorNy, out_tens_mesh.vectorNy)
+                and (self.dim == 2 or np.allclose(self.vectorNz, out_tens_mesh.vectorNz))
+            )
+        except ValueError:
+            same_base = False
 
         if same_base:
             in_cell_inds = self._get_containing_cell_indexes(out_tens_mesh.gridCC)
@@ -4076,11 +4084,16 @@ cdef class _TreeMesh:
         cdef double[:] xF
 
         # first check if they have the same tensor base, as it makes it a lot easier...
-        cdef int_t same_base = (
-          np.allclose(self.vectorNx, in_tens_mesh.vectorNx)
-          and np.allclose(self.vectorNy, in_tens_mesh.vectorNy)
-          and (self.dim == 2 or np.allclose(self.vectorNz, in_tens_mesh.vectorNz))
-        )
+        cdef int_t same_base
+        try:
+            same_base = (
+                np.allclose(self.vectorNx, in_tens_mesh.vectorNx)
+                and np.allclose(self.vectorNy, in_tens_mesh.vectorNy)
+                and (self.dim == 2 or np.allclose(self.vectorNz, in_tens_mesh.vectorNz))
+            )
+        except ValueError:
+            same_base = False
+
 
         if same_base:
             out_cell_inds = self._get_containing_cell_indexes(in_tens_mesh.gridCC)

--- a/discretize/utils/codeutils.py
+++ b/discretize/utils/codeutils.py
@@ -1,11 +1,7 @@
 from __future__ import print_function, division
 import numpy as np
-import sys
-
 
 scalarTypes = (complex, float, int, np.number)
-if sys.version_info < (3,):
-    scalarTypes += (long, )
 
 def isScalar(f):
     if isinstance(f, scalarTypes):

--- a/discretize/utils/io_utils.py
+++ b/discretize/utils/io_utils.py
@@ -57,7 +57,7 @@ def download(
                 if verbose:
                     print("overwriting {}".format(download))
             else:
-                while os.path.exists is True:
+                while os.path.exists(download):
                     download = rename_path(download)
 
                 if verbose:

--- a/discretize/utils/io_utils.py
+++ b/discretize/utils/io_utils.py
@@ -60,14 +60,14 @@ def download(
     # check if the directory already exists
     for i, download in enumerate(downloadpath):
         if os.path.exists(download):
-            if overwrite is True:
-                if verbose is True:
+            if overwrite:
+                if verbose:
                     print("overwriting {}".format(download))
-            elif overwrite is False:
-                while os.path.exists is True:
+            else:
+                while os.path.exists:
                     download = rename_path(download)
 
-                if verbose is True:
+                if verbose:
                     print(
                         "file already exists, new file is called {}".format(
                             download

--- a/discretize/utils/io_utils.py
+++ b/discretize/utils/io_utils.py
@@ -57,7 +57,7 @@ def download(
                 if verbose:
                     print("overwriting {}".format(download))
             else:
-                while os.path.exists:
+                while os.path.exists is True:
                     download = rename_path(download)
 
                 if verbose:

--- a/discretize/utils/io_utils.py
+++ b/discretize/utils/io_utils.py
@@ -1,6 +1,5 @@
-import urllib
+from urllib.request import urlretrieve
 import os
-import sys
 
 def download(
     url, folder='.', overwrite=False, verbose=True
@@ -36,12 +35,6 @@ def download(
         return os.path.sep.join(
             splitfullpath[:-1] + newnamesplit[:-1] + [newname]
         )
-
-    # grab the correct url retriever
-    if sys.version_info < (3,):
-        urlretrieve = urllib.urlretrieve
-    else:
-        urlretrieve = urllib.request.urlretrieve
 
     # ensure we are working with absolute paths and home directories dealt with
     folder = os.path.abspath(os.path.expanduser(folder))

--- a/discretize/utils/matutils.py
+++ b/discretize/utils/matutils.py
@@ -494,7 +494,7 @@ class Identity(object):
     _positive = True
 
     def __init__(self, positive=True):
-        self._positive = positive is True
+        self._positive = positive
 
     def __pos__(self):
         return self

--- a/discretize/utils/meshutils.py
+++ b/discretize/utils/meshutils.py
@@ -89,11 +89,11 @@ def random_model(shape, seed=None, anisotropy=None, its=100, bounds=None):
     np.random.seed(seed)
     mr = np.random.rand(*shape)
     if anisotropy is None:
-        if len(shape) is 1:
+        if len(shape) == 1:
             smth = np.array([1, 10., 1], dtype=float)
-        elif len(shape) is 2:
+        elif len(shape) == 2:
             smth = np.array([[1, 7, 1], [2, 10, 2], [1, 7, 1]], dtype=float)
-        elif len(shape) is 3:
+        elif len(shape) == 3:
             kernal = np.array([1, 4, 1], dtype=float).reshape((1, 3))
             smth = np.array(sp.kron(sp.kron(kernal, kernal.T).todense()[:], kernal).todense()).reshape((3, 3, 3))
     else:

--- a/discretize/utils/meshutils.py
+++ b/discretize/utils/meshutils.py
@@ -9,11 +9,7 @@ import discretize
 from scipy.spatial import cKDTree, Delaunay
 from scipy import interpolate
 
-import sys
-if sys.version_info < (3,):
-    num_types = [int, long, float]
-else:
-    num_types = [int, float]
+num_types = [int, float]
 
 
 def exampleLrmGrid(nC, exType):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 from datetime import datetime
 import discretize
@@ -354,15 +353,8 @@ sphinx_gallery_conf = {
     'doc_module': 'discretize',
     # 'reference_url': {'discretize': None},
 }
-# Do not run or scrape `pyvista` examples on Python 2 because sphinx gallery
-# doesn't support custom scrapers. But also, data was pickled in Python 3
-if sys.version_info[0] >= 3:
-    # Requires pyvista>=0.18.0 and Python 3
-    sphinx_gallery_conf["image_scrapers"] = (pyvista.Scraper(), 'matplotlib')
-else:
-    # Don't run pyvista examples at all on Python 2
-    # Primarily because data used for it was pickled in Python 3
-    sphinx_gallery_conf["filename_pattern"] = r"plot_(?!pyvista)\.py",
+sphinx_gallery_conf["image_scrapers"] = (pyvista.Scraper(), 'matplotlib')
+
 
 # Documents to append as an appendix to all manuals.
 #texinfo_appendices = []

--- a/docs/release/0.5.1-notes.rst
+++ b/docs/release/0.5.1-notes.rst
@@ -21,4 +21,4 @@ Contributors
 Pull requests
 =============
 
-* `#223 <https://github.com/simpeg/discretize/pull/212>`__: Syntax and bug fixes
+* `#223 <https://github.com/simpeg/discretize/pull/223>`__: Syntax and bug fixes

--- a/docs/release/0.5.1-notes.rst
+++ b/docs/release/0.5.1-notes.rst
@@ -1,0 +1,24 @@
+.. currentmodule:: discretize
+
+.. _0.5.1_notes:
+
+===================================
+``discretize`` 0.5.1 Release Notes
+===================================
+
+A small patch to fix a bug in the volume averaging operator when using
+meshes with different shaped bases, to address `#222 <https://github.com/simpeg/discretize/issues/222>`__.
+
+There are also a few deprecated syntax updates for comparisons with literals.
+`#221 <https://github.com/simpeg/discretize/issues/221>`__.
+
+Contributors
+============
+
+* @jcapriot
+
+
+Pull requests
+=============
+
+* `#223 <https://github.com/simpeg/discretize/pull/212>`__: Syntax and bug fixes

--- a/examples/plot_cyl_mirror.py
+++ b/examples/plot_cyl_mirror.py
@@ -37,7 +37,7 @@ def run(plotIt=True):
     )
     sigma[sphere_ind] = sig_sphere  # sphere
 
-    if plotIt is False:
+    if not plotIt:
         return
 
     # Plot a cross section through the mesh

--- a/examples/plot_slicer_demo.py
+++ b/examples/plot_slicer_demo.py
@@ -19,11 +19,6 @@ import numpy as np
 import tarfile
 import matplotlib.pyplot as plt
 from matplotlib.colors import SymLogNorm
-import sys
-
-if sys.version_info[0] < 3:
-    print("This example only runs on Python 3")
-    sys.exit(0)
 
 ###############################################################################
 # Download and load data
@@ -192,4 +187,3 @@ beautify(
 )
 
 plt.show()
-

--- a/tests/base/test_operators.py
+++ b/tests/base/test_operators.py
@@ -571,7 +571,7 @@ class MimeticProperties(unittest.TestCase):
             print(
                 "Testing Div * Curl on {} : |Div Curl v| / |v| = {} "
                 "... {}".format(
-                    meshType, rel_err, 'FAIL' if passed is False else 'ok'
+                    meshType, rel_err, 'FAIL' if not passed else 'ok'
                 )
             )
 
@@ -588,7 +588,7 @@ class MimeticProperties(unittest.TestCase):
             print(
                 "Testing Curl * Grad on {} : |Curl Grad v| / |v|= {} "
                 "... {}".format(
-                    meshType, rel_err, 'FAIL' if passed is False else 'ok'
+                    meshType, rel_err, 'FAIL' if not passed else 'ok'
                 )
             )
 

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -12,7 +12,6 @@ from discretize.utils import (
 )
 from discretize.Tests import checkDerivative
 import discretize
-import sys
 
 TOL = 1e-8
 
@@ -211,8 +210,6 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertTrue(isScalar(1.))
         self.assertTrue(isScalar(1))
         self.assertTrue(isScalar(1j))
-        if sys.version_info < (3, ):
-            self.assertTrue(isScalar(long(1)))
         self.assertTrue(isScalar(np.r_[1.]))
         self.assertTrue(isScalar(np.r_[1]))
         self.assertTrue(isScalar(np.r_[1j]))

--- a/tests/base/test_volume_avg.py
+++ b/tests/base/test_volume_avg.py
@@ -286,6 +286,161 @@ class TestVolumeAverage(unittest.TestCase):
             print(vol1, vol2)
             self.assertAlmostEqual(vol1, vol2)
 
+    def test_tensor_to_tensor_sub(self):
+        h1 = np.ones(32)
+        h2 = np.ones(16)
+
+        h1s = []
+        h2s = []
+        for i in range(3):
+            print(f"Tensor to smaller Tensor {i+1}D: ", end="")
+            h1s.append(h1)
+            h2s.append(h2)
+            mesh1 = discretize.TensorMesh(h1s)
+            mesh2 = discretize.TensorMesh(h2s)
+
+            in_put = np.random.rand(mesh1.nC)
+            out_put = np.empty(mesh2.nC)
+            # test the three ways of calling...
+            out1 = volume_average(mesh1, mesh2, in_put, out_put)
+            assert_array_equal(out1, out_put)
+
+            out2 = volume_average(mesh1, mesh2, in_put)
+            assert_allclose(out1, out2)
+
+            Av = volume_average(mesh1, mesh2)
+            out3 = Av@in_put
+            assert_allclose(out1, out3)
+
+            # get cells in extent of smaller mesh
+            cells = mesh1.gridCC < [16]*(i+1)
+            if i > 0:
+                cells = np.all(cells, axis=1)
+
+            vol1 = np.sum(mesh1.vol[cells]*in_put[cells])
+            vol2 = np.sum(mesh2.vol*out3)
+            print(vol1, vol2)
+            self.assertAlmostEqual(vol1, vol2)
+
+    def test_tree_to_tree_sub(self):
+        h1 = np.ones(32)
+        h2 = np.ones(16)
+
+        h1s = [h1]
+        h2s = [h2]
+        insert_1 = [12]
+        insert_2 = [4]
+        for i in range(1, 3):
+            print(f"Tree to smaller Tree {i+1}D: ", end="")
+            h1s.append(h1)
+            h2s.append(h2)
+            insert_1.append(12)
+            insert_2.append(4)
+            mesh1 = discretize.TreeMesh(h1s)
+            mesh1.insert_cells([insert_1], [4])
+            mesh2 = discretize.TreeMesh(h2s)
+            mesh2.insert_cells([insert_2], [4])
+
+            in_put = np.random.rand(mesh1.nC)
+            out_put = np.empty(mesh2.nC)
+            # test the three ways of calling...
+            out1 = volume_average(mesh1, mesh2, in_put, out_put)
+            assert_array_equal(out1, out_put)
+
+            out2 = volume_average(mesh1, mesh2, in_put)
+            assert_allclose(out1, out2)
+
+            Av = volume_average(mesh1, mesh2)
+            out3 = Av@in_put
+            assert_allclose(out1, out3)
+
+            # get cells in extent of smaller mesh
+            cells = mesh1.gridCC < [16]*(i+1)
+            if i > 0:
+                cells = np.all(cells, axis=1)
+
+            vol1 = np.sum(mesh1.vol[cells]*in_put[cells])
+            vol2 = np.sum(mesh2.vol*out3)
+            print(vol1, vol2)
+            self.assertAlmostEqual(vol1, vol2)
+
+    def test_tree_to_tensor_sub(self):
+        h1 = np.ones(32)
+        h2 = np.ones(16)
+
+        h1s = [h1]
+        insert_1 = [12]
+        h2s = [h2]
+        for i in range(1, 3):
+            print(f"Tree to smaller Tensor {i+1}D: ", end="")
+            h1s.append(h1)
+            h2s.append(h2)
+            insert_1.append(12)
+            mesh1 = discretize.TreeMesh(h1s)
+            mesh1.insert_cells([insert_1], [4])
+            mesh2 = discretize.TensorMesh(h2s)
+
+            in_put = np.random.rand(mesh1.nC)
+            out_put = np.empty(mesh2.nC)
+            # test the three ways of calling...
+            out1 = volume_average(mesh1, mesh2, in_put, out_put)
+            assert_array_equal(out1, out_put)
+
+            out2 = volume_average(mesh1, mesh2, in_put)
+            assert_allclose(out1, out2)
+
+            Av = volume_average(mesh1, mesh2)
+            out3 = Av@in_put
+            assert_allclose(out1, out3)
+
+            # get cells in extent of smaller mesh
+            cells = mesh1.gridCC < [16]*(i+1)
+            if i > 0:
+                cells = np.all(cells, axis=1)
+
+            vol1 = np.sum(mesh1.vol[cells]*in_put[cells])
+            vol2 = np.sum(mesh2.vol*out3)
+            print(vol1, vol2)
+            self.assertAlmostEqual(vol1, vol2)
+
+    def test_tensor_to_tree_sub(self):
+        h1 = np.ones(32)
+        h2 = np.ones(16)
+
+        h1s = [h1]
+        h2s = [h2]
+        insert_2 = [4]
+        for i in range(1, 3):
+            print(f"Tensor to smaller Tree {i+1}D: ", end="")
+            h1s.append(h1)
+            h2s.append(h2)
+            insert_2.append(4)
+            mesh1 = discretize.TensorMesh(h1s)
+            mesh2 = discretize.TreeMesh(h2s)
+            mesh2.insert_cells([insert_2], [4])
+
+            in_put = np.random.rand(mesh1.nC)
+            out_put = np.empty(mesh2.nC)
+            # test the three ways of calling...
+            out1 = volume_average(mesh1, mesh2, in_put, out_put)
+            assert_array_equal(out1, out_put)
+
+            out2 = volume_average(mesh1, mesh2, in_put)
+            assert_allclose(out1, out2)
+
+            Av = volume_average(mesh1, mesh2)
+            out3 = Av@in_put
+            assert_allclose(out1, out3)
+
+            # get cells in extent of smaller mesh
+            cells = mesh1.gridCC < [16]*(i+1)
+            if i > 0:
+                cells = np.all(cells, axis=1)
+
+            vol1 = np.sum(mesh1.vol[cells]*in_put[cells])
+            vol2 = np.sum(mesh2.vol*out3)
+            print(vol1, vol2)
+            self.assertAlmostEqual(vol1, vol2)
 
 
 if __name__ == '__main__':

--- a/tests/cyl/test_cylOperators.py
+++ b/tests/cyl/test_cylOperators.py
@@ -514,7 +514,7 @@ class MimeticProperties(unittest.TestCase):
             print(
                 "Testing Div * Curl on {} : |Div Curl v| / |v| = {} "
                 "... {}".format(
-                    meshType, rel_err, 'FAIL' if passed is False else 'ok'
+                    meshType, rel_err, 'FAIL' if not passed else 'ok'
                 )
             )
 
@@ -531,7 +531,7 @@ class MimeticProperties(unittest.TestCase):
     #         print(
     #             "Testing Curl * Grad on {} : |Curl Grad v| / |v|= {} "
     #             "... {}".format(
-    #                 meshType, rel_err, 'FAIL' if passed is False else 'ok'
+    #                 meshType, rel_err, 'FAIL' if not passed else 'ok'
     #             )
     #         )
 


### PR DESCRIPTION
Patch for #221 and #222.

For some reason I was expecting allclose to return False if the arrays were of different length.

In addition, there are a few syntax fixes for comparisons to True/False which is generally frowned upon in pep8, and syntax fixes for comparisons to literals.