### PR TITLE
Fix legend of example "QuadTree: Hanging Nodes"

### DIFF
--- a/examples/plot_quadtree_hanging.py
+++ b/examples/plot_quadtree_hanging.py
@@ -28,12 +28,12 @@ def run(plotIt=True):
     if plotIt:
         M.plotGrid(nodes=True, centers=True, faces_x=True)
         plt.legend((
-            'Grid',
-            'Cell Centers',
             'Nodes',
             'Hanging Nodes',
+            'Cell Centers',
             'X faces',
-            'Hanging X faces'
+            'Hanging X faces',
+            'Grid',
         ))
 
 if __name__ == '__main__':


### PR DESCRIPTION
http://discretize.simpeg.xyz/en/master/examples/plot_quadtree_hanging.html

Current legend in above link:
![image](https://user-images.githubusercontent.com/8020943/92890932-d862cc00-f417-11ea-811b-a4d2d51602f5.png)

(I wonder why this happened. Maybe the plotting routine changed at some point?)