### PR TITLE
Correct the range_y in Tree plot_image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ examples/*.tar.gz
 *.dat
 *.dir
 *.bak
+
+# Spyder
+.spyproject/

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,3 @@ examples/*.tar.gz
 *.dat
 *.dir
 *.bak
-
-# Spyder
-.spyproject/

--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -1951,7 +1951,7 @@ class InterfaceMPL(object):
             minx, maxx = self.nodes_x[[0, -1]]
 
         if range_y is not None:
-            miny, maxy = range_x
+            miny, maxy = range_y
         else:
             miny, maxy = self.nodes_y[[0, -1]]
 


### PR DESCRIPTION
In the TreeMesh plot_image method defining the range_y does not result in the expected behaviour.

Instead of using range_y to define the limits of the plot it uses range_x.

I didn't mean to include the change to my .gitignore file in the pull request but don't know how to remove it now.