### PR TITLE
Update mpl_mod.py

### DIFF
--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -2165,7 +2165,7 @@ class InterfaceMPL(object):
                 vecs[:, 1],
                 **quiver_opts,
             )
-            out = (qvr,)
+            out = (out, qvr,)
 
         return out
 


### PR DESCRIPTION
include the pcolor output when a quiver plot is used on the treemesh