### PR TITLE
Add dot product test.

### DIFF
--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -692,8 +692,8 @@ def dottest(forward, adjoint, fwd_size, adj_size, fwd_complex=False,
     v = random(adj_size, adj_complex)
 
     # Carry out dot product test.
-    lhs = np.vdot(forward(u), v)  # lhs := v^H * (fwd  * u)
-    rhs = np.vdot(u, adjoint(v))  # rhs := (adj * v)^H * u
+    lhs = np.vdot(v, forward(u))  # lhs := v^H * (fwd  * u)
+    rhs = np.vdot(adjoint(v), u)  # rhs := (adj * v)^H * u
 
     # Check if they are the same.
     passed = np.isclose(rhs, lhs, rtol, atol)

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -641,10 +641,10 @@ def get_quadratic(A, b, c=0):
 def assert_isadjoint(
     forward,
     adjoint,
-    shape_in,
-    shape_out,
-    complex_in=False,
-    complex_out=False,
+    shape_u,
+    shape_v,
+    complex_u=False,
+    complex_v=False,
     clinear=True,
     rtol=1e-6,
     atol=0.0,
@@ -663,22 +663,36 @@ def assert_isadjoint(
 
     Parameters
     ----------
-    forward, adjoint : functions
-        Forward operator and its adjoint operator.
+    forward : function
+        Forward operator.
 
-    shape_in, shape_out : int, tuple of int
-        Shapes of the vectors passed in to and returned from ``forward`` (and
-        vice versa for the ``adjoint``).
+    adjoint : function
+        Adjoint operator.
 
-    complex_in, complex_out : bool, defaults: False, False
-        If True, complex vectors are passed in to and returned from ``forward``
-        (and vice versa for the ``adjoint``).
+    shape_u : int, tuple of int
+        Shape of vector ``u`` passed in to ``forward``; it is accordingly the
+        expected shape of the vector returned from the ``adjoint``.
+
+    shape_v : int, tuple of int
+        Shape of vector ``v`` passed in to ``adjoint``; it is accordingly the
+        expected shape of the vector returned from the ``forward``.
+
+    complex_u : bool, default: False
+        If True, vector ``u`` passed to ``forward`` is a complex vector;
+        accordingly the ``adjoint`` is expected to return a complex vector.
+
+    complex_v : bool, default: False
+        If True, vector ``v`` passed to ``adjoint`` is a complex vector;
+        accordingly the ``forward`` is expected to return a complex vector.
 
     clinear : bool, default: True
         If operator is complex-linear (True) or real-linear (False).
 
-    rtol, atol : float, defaults: 1e-6, 0.0
-        Relative and absolute tolerance.
+    rtol : float, default: 1e-6
+        Relative tolerance.
+
+    atol : float, default: 0.0
+        Absolute tolerance.
 
     assert_error : bool, default: True
         By default this test is an assertion (silent if passed, raising an
@@ -708,8 +722,8 @@ def assert_isadjoint(
         return out
 
     # Create random vectors u and v.
-    u = random(np.product(shape_in), complex_in).reshape(shape_in)
-    v = random(np.product(shape_out), complex_out).reshape(shape_out)
+    u = random(np.product(shape_u), complex_u).reshape(shape_u)
+    v = random(np.product(shape_v), complex_v).reshape(shape_v)
 
     # Carry out dot product test.
     fwd_u = forward(u)

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -637,7 +637,6 @@ def get_quadratic(A, b, c=0):
     return Quadratic
 
 
-# TESTS
 def assert_isadjoint(
     forward,
     adjoint,

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -720,8 +720,9 @@ def dottest(
     if (not passed and raise_error) or verb:
         msg = (
             f"Dot test {'PASSED' if passed else 'FAILED'} ::  "
-            f"{abs(rhs-lhs):.3e} < {atol+rtol*abs(lhs):.3e}  "
-            f"[ abs(rhs-lhs) < atol + rtol * abs(lhs) ]."
+            f"{abs(rhs-lhs):.3e} < {atol+rtol*abs(lhs):.3e}  :: "
+            f"|rhs-lhs| < atol + rtol|lhs|"
+
         )
         if not passed and raise_error:
             raise AssertionError(msg)

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -691,13 +691,20 @@ def assert_isadjoint(
     passed : bool, returned if assert_error=False
         Result of the dot product test.
 
+
+    Raises
+    ------
+    AssertionError
+        If the dot product test fails (only if assert_error=True).
+
+
     """
 
     def random(size, iscomplex):
         """Create random data of size and dtype of <size>."""
-        out = rng.standard_normal(int(np.real(size)))
+        out = rng.standard_normal(size)
         if iscomplex:
-            out = out + 1j * rng.standard_normal(out.size)
+            out = out + 1j * rng.standard_normal(size)
         return out
 
     # Create random vectors u and v.

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -662,10 +662,10 @@ def assert_isadjoint(
 
     Parameters
     ----------
-    forward : function
+    forward : callable
         Forward operator.
 
-    adjoint : function
+    adjoint : callable
         Adjoint operator.
 
     shape_u : int, tuple of int
@@ -701,9 +701,8 @@ def assert_isadjoint(
 
     Returns
     -------
-    passed : bool, returned if assert_error=False
-        Result of the dot product test.
-
+    passed : bool, optional
+        Result of the dot product test; only returned if ``assert_error`` is False.
 
     Raises
     ------

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -708,10 +708,10 @@ def dottest(
     v = random(np.product(adj_shape), adj_complex)
 
     # Carry out dot product test.
-    fwdu = forward(u.reshape(fwd_shape)).ravel(fwd_order)  # fwd * u
-    adjv = adjoint(v.reshape(adj_shape)).ravel(adj_order)  # adj * v
-    lhs = np.vdot(v, fwdu)  # lhs := v^H * (fwd  * u)
-    rhs = np.vdot(adjv, u)  # rhs := (adj * v)^H * u
+    fwd_u = forward(u.reshape(fwd_shape, order=fwd_order)).ravel(fwd_order)
+    adj_v = adjoint(v.reshape(adj_shape, order=adj_order)).ravel(adj_order)
+    lhs = np.vdot(v, fwd_u)  # lhs := v^H * (fwd * u)
+    rhs = np.vdot(adj_v, u)  # rhs := (adj * v)^H * u
 
     # Check if they are the same.
     passed = np.isclose(rhs, lhs, rtol, atol)

--- a/tests/base/test_tests.py
+++ b/tests/base/test_tests.py
@@ -1,0 +1,67 @@
+import pytest
+import discretize
+import numpy as np
+from discretize.tests import dottest
+from discretize.utils import volume_average
+
+
+class TestDottest:
+    def test_defaults(self, capsys):
+        # Use volume_average to test default case.
+
+        h = [[11, 20.5, 33], [222, 111, 333], np.ones(4) * 55.5]
+        mesh1 = discretize.TensorMesh(h, "CCC")
+
+        hx = np.ones(20) * 20
+        mesh2 = discretize.TensorMesh([hx, hx, hx], "CCC")
+
+        P = discretize.utils.volume_average(mesh1, mesh2)
+
+        # return
+        assert dottest(
+            lambda u: P * u,
+            lambda v: P.T * v,
+            mesh1.n_cells,
+            mesh2.n_cells,
+            verb=True,
+        )
+        out, _ = capsys.readouterr()
+        assert "Dot test PASSED" in out
+
+        # raise error
+        with pytest.raises(AssertionError, match="Dot test FAILED "):
+            dottest(
+                lambda u: P * u * 2,  # Add erroneous factor
+                lambda v: P.T * v,
+                mesh1.n_cells,
+                mesh2.n_cells,
+                raise_error=True,
+            )
+
+    def test_shape_order(self):
+        # Def sum operator over axis 1; ravelled in 'F' so needs 'F'-order.
+
+        nt = 3
+
+        def fwd(inp):
+            return np.sum(inp, 1).ravel("F")
+
+        # Def adj of fwd
+        def adj(inp):
+            out = np.expand_dims(inp, 1)
+            return np.tile(out, nt).ravel("F")
+
+        assert dottest(fwd, adj, (4, nt), (4,), fwd_order="F", verb=True)
+
+    def test_complex_clinear(self):
+        # The complex conjugate is self-adjoint, real-linear.
+        assert dottest(
+            np.conj,
+            np.conj,
+            (4, 3),
+            (4, 3),
+            fwd_complex=True,
+            adj_complex=True,
+            clinear=False,
+            verb=True,
+        )

--- a/tests/base/test_tests.py
+++ b/tests/base/test_tests.py
@@ -51,7 +51,7 @@ class TestAssertIsAdjoint:
             out = np.expand_dims(inp, 1)
             return np.tile(out, nt)
 
-        assert_isadjoint(fwd, adj, shape_in=(4, nt), shape_out=(4,))
+        assert_isadjoint(fwd, adj, shape_u=(4, nt), shape_v=(4,))
 
     def test_complex_clinear(self):
         # The complex conjugate is self-adjoint, real-linear.
@@ -60,7 +60,7 @@ class TestAssertIsAdjoint:
             np.conj,
             (4, 3),
             (4, 3),
-            complex_in=True,
-            complex_out=True,
+            complex_u=True,
+            complex_v=True,
             clinear=False,
         )


### PR DESCRIPTION
## Adds the dot product test to the test suite

I was thinking of adding the dot test to `emg3d`, but thought that maybe it lives better in `discretize`, alongside the `OrderTest` and `check_derivative`. As such it is available to any tool that uses `discretize`, including `SimPEG`.

In `SimPEG` there are dozens of places where the dot-test is defined. I think it would be better to only define it once, here in `discretize`, and use always the same definition (avoiding code repetitions and slightly different implementations). However, adding it in `discretize` means that we would probably have to wait at least for 2 minor releases before we can use it in `SimPEG`.

I draw a lot of inspiration from the implementation in PyLops, and we are reworking the `dottest` over there currently (https://github.com/PyLops/pylops/pull/335, https://github.com/PyLops/pylops/pull/336).

Suggestions for further improvements or adaption for `SimPEG`/`discretize`-language/habits/conventions are welcomed!


### Open questions to discuss

- [ ] Defaults for `rtol`, `atol`?
- [ ] Should we have `shape` and `order` variables? Alternatively, we could only support size, and if a particular shape/order is required one has to wrap it like
   ```
   x, y = 10, 20
   dottest(
       fwd=lamda u: my_fwd_op(u.reshape((x, y), order='F')).ravel('F'),
       ...
       fwd_size=x*y,
       ...
   )
   ```
   So it would be possible even when just having `fwd_size` instead of `fwd_shape`, and no `fwd_order` (all the same applies of course to `ajd_...`). But having it inside the functions makes the `dottest` a bit easier to use for various scenarios.
- [ ] Default order is set to `"C"` - would it, with `discretize`, make more sense to set the default order to `"F"`? Or are most operators on 1D vectors anyway?
