### PR TITLE
Cyl vtk

### DIFF
--- a/discretize/base/base_tensor_mesh.py
+++ b/discretize/base/base_tensor_mesh.py
@@ -416,10 +416,13 @@ class BaseTensorMesh(BaseRegularMesh):
 
     @property
     def faces(self):
-        faces = self.faces_x
-        if self.dim > 1:
+        if self.faces_x is not None:
+            faces = self.faces_x
+        else:
+            faces = np.empty((0, self.dim))
+        if self.dim > 1 and self.faces_y is not None:
             faces = np.r_[faces, self.faces_y]
-        if self.dim > 2:
+        if self.dim > 2 and self.faces_z is not None:
             faces = np.r_[faces, self.faces_z]
         return faces
 
@@ -521,10 +524,13 @@ class BaseTensorMesh(BaseRegularMesh):
 
     @property
     def edges(self):
-        edges = self.edges_x
-        if self.dim > 1:
+        if self.edges_x is not None:
+            edges = self.edges_x
+        else:
+            edges = np.empty((0, self.dim))
+        if self.dim > 1 and self.edges_y is not None:
             edges = np.r_[edges, self.edges_y]
-        if self.dim > 2:
+        if self.dim > 2 and self.edges_z is not None:
             edges = np.r_[edges, self.edges_z]
         return edges
 

--- a/discretize/cylindrical_mesh.py
+++ b/discretize/cylindrical_mesh.py
@@ -12,6 +12,7 @@ from discretize.utils import (
     spzeros,
     interpolation_matrix,
     cyl2cart,
+    as_array_n_by_dim,
 )
 from discretize.base import BaseTensorMesh, BaseRectangularMesh
 from discretize.operators import DiffOperators, InnerProducts
@@ -1682,6 +1683,8 @@ class CylindricalMesh(
                 "as this variable does not exist.".format(location_type)
             )
 
+        loc = as_array_n_by_dim(loc, self.dim)
+
         if location_type in ["cell_centers_x", "cell_centers_y", "cell_centers_z"]:
             Q = interpolation_matrix(loc, *self.get_tensor("cell_centers"))
             Z = spzeros(loc.shape[0], self.nC)
@@ -1707,7 +1710,8 @@ class CylindricalMesh(
             if zeros_outside:
                 indZeros = np.logical_not(self.is_inside(loc))
                 Q[indZeros, :] = 0
-            Q = Q * self._deflation_matrix('nodes', as_ones=True)
+            Q = Q * self._deflation_matrix('nodes', as_ones=True).T
+            return Q
 
         return self._getInterpolationMat(loc, location_type, zeros_outside)
 

--- a/discretize/cylindrical_mesh.py
+++ b/discretize/cylindrical_mesh.py
@@ -1201,6 +1201,34 @@ class CylindricalMesh(
     def boundary_nodes(self):
         return self.nodes[self._is_boundary_node]
 
+    @property
+    def _is_boundary_edge(self):
+        # top and bottom radial edges are on the boundary
+        is_br = np.zeros(self._shape_total_edges_x, dtype=bool, order='F')
+        is_br[:, :, [0, -1]] = True
+        is_br = is_br.reshape(-1, order='F')
+        is_bt = np.zeros(self._shape_total_edges_y, dtype=bool, order='F')
+        # outside theta edges are on boundary
+        is_bt[-1] = True
+        # top and bottom theta edges are on boundary
+        is_bt[:, :, [0, -1]] = True
+        is_bt = is_bt.reshape(-1, order='F')
+        # outside z edges are on boundaries
+        is_bz = np.zeros(self._shape_total_edges_z, dtype=bool, order="F")
+        is_bz[-1] = True
+        is_bz = is_bz.reshape(-1, order="F")
+
+        is_b = np.r_[
+            is_br[~self._ishanging_edges_x],
+            is_bt[~self._ishanging_edges_y],
+            is_bz[~self._ishanging_edges_z]
+        ]
+        return is_b
+
+    @property
+    def boundary_edges(self):
+        return self.edges[self._is_boundary_edge]
+
     ####################################################
     # Operators
     ####################################################
@@ -1532,6 +1560,11 @@ class CylindricalMesh(
     def project_node_to_boundary_node(self):
         P = speye(self.n_nodes)
         return P[self._is_boundary_node]
+
+    @property
+    def project_edge_to_boundary_edge(self):
+        P = speye(self.n_edges)
+        return P[self._is_boundary_edge]
 
     ####################################################
     # Deflation Matrices

--- a/discretize/cylindrical_mesh.py
+++ b/discretize/cylindrical_mesh.py
@@ -1703,7 +1703,7 @@ class CylindricalMesh(
         location_type = self._parse_location_type(location_type)
 
         if self.is_symmetric and location_type in ["edges_x", "edges_z", "faces_y"]:
-            raise Exception(
+            raise KeyError(
                 "Symmetric CylindricalMesh does not support {0!s} interpolation, "
                 "as this variable does not exist.".format(location_type)
             )
@@ -1726,8 +1726,7 @@ class CylindricalMesh(
                 Q[indZeros, :] = 0
 
             return Q.tocsr()
-
-        if location_type == 'nodes':
+        elif location_type == 'nodes':
             if self.is_symmetric and self.dim == 3:
                 rtz = [self.nodes_x, self.nodes_z]
                 loc = loc[:, [0, -1]]
@@ -1742,8 +1741,8 @@ class CylindricalMesh(
             if not self.is_symmetric:
                 Q = Q * self._deflation_matrix('nodes', as_ones=True).T
             return Q
-
-        return self._getInterpolationMat(loc, location_type, zeros_outside)
+        else:
+            return self._getInterpolationMat(loc, location_type, zeros_outside)
 
     def cartesian_grid(self, location_type="cell_centers", theta_shift=None, **kwargs):
         """

--- a/discretize/cylindrical_mesh.py
+++ b/discretize/cylindrical_mesh.py
@@ -1186,6 +1186,21 @@ class CylindricalMesh(
         normals[n1:n1+n2] *= -1
         return normals
 
+    @property
+    def _is_boundary_node(self):
+        is_b = np.zeros(self._shape_total_nodes, dtype=bool, order='F')
+        # outward rs are boundary:
+        is_b[-1] = True
+        # top and bottom zs are boundary
+        is_b[:, :, [0, -1]] = True
+        is_b = is_b.reshape(-1, order='F')
+        is_b = is_b[~self._ishanging_nodes]
+        return is_b
+
+    @property
+    def boundary_nodes(self):
+        return self.nodes[self._is_boundary_node]
+
     ####################################################
     # Operators
     ####################################################
@@ -1512,6 +1527,11 @@ class CylindricalMesh(
     def project_face_to_boundary_face(self):
         P = speye(self.n_faces)
         return P[self._is_boundary_face]
+
+    @property
+    def project_node_to_boundary_node(self):
+        P = speye(self.n_nodes)
+        return P[self._is_boundary_node]
 
     ####################################################
     # Deflation Matrices

--- a/discretize/cylindrical_mesh.py
+++ b/discretize/cylindrical_mesh.py
@@ -1699,6 +1699,16 @@ class CylindricalMesh(
 
             return Q.tocsr()
 
+        if location_type == 'nodes':
+            rtz = [self.nodes_x, self._nodes_y_full]
+            if self.dim == 3:
+                rtz.append(self.nodes_z)
+            Q = interpolation_matrix(loc, *rtz)
+            if zeros_outside:
+                indZeros = np.logical_not(self.is_inside(loc))
+                Q[indZeros, :] = 0
+            Q = Q * self._deflation_matrix('nodes', as_ones=True)
+
         return self._getInterpolationMat(loc, location_type, zeros_outside)
 
     def cartesian_grid(self, location_type="cell_centers", theta_shift=None, **kwargs):

--- a/discretize/mixins/vtk_mod.py
+++ b/discretize/mixins/vtk_mod.py
@@ -54,6 +54,7 @@ and PVGeo_:
 """
 import os
 import numpy as np
+from discretize.utils import cyl2cart
 
 # from ..utils import cyl2cart
 
@@ -385,15 +386,128 @@ class InterfaceVTK(object):
         )
 
     def __cyl_mesh_to_vtk(mesh, models=None):
-        """This treats the CylindricalMesh defined in cylindrical coordinates
-        :math:`(r, \theta, z)` and transforms it to cartesian coordinates.
+        """
+        Constructs an vtkUnstructuredGrid made of rational Bezier hexahedrons and wedges.
+        Wedges happen on the very internal layer about r=0, and hexs occur elsewhere.
         """
         # # Points
-        # ptsMat = cyl2cart(mesh.gridN)
-        # return InterfaceVTK.__create_structured_grid(ptsMat, mesh.shape_cells, models=models)
-        raise NotImplementedError(
-            "`CylindricalMesh`s are not currently supported for VTK conversion."
+        P = mesh._deflation_matrix('nodes', as_ones=True).T.tocsr()
+
+        # calculate control points
+        dphis_half = mesh.h[1]/2
+        phi_controls = mesh.nodes_y + dphis_half
+        if mesh.nodes_x[0] == 0.0:
+            Rs, Phis, Zs = np.meshgrid(mesh.nodes_x[1:], phi_controls, mesh.nodes_z, indexing='ij')
+        else:
+            Rs, Phis, Zs = np.meshgrid(mesh.nodes_x, phi_controls, mesh.nodes_z, indexing='ij')
+        Rs /= np.cos(dphis_half)[None, :, None]
+
+        control_nodes = np.c_[Rs.reshape(-1, order='F'), Phis.reshape(-1, order='F'), Zs.reshape(-1, order='F')]
+
+        cells = np.arange(mesh.n_cells).reshape(mesh.shape_cells, order="F")
+        if mesh.nodes_x[0] == 0.0:
+            wedge_cells = cells[0].reshape(-1, order='F')
+            hex_cells = (cells[1:]).reshape(-1, order='F')
+        else:
+            hex_cells = cells.reshape(-1, order='F')
+
+        # Hex Cells...
+        # calculate indices
+        ir, it, iz = np.unravel_index(hex_cells, shape=mesh.shape_cells, order='F')
+
+        irs = np.stack([ir, ir, ir+1, ir+1, ir, ir, ir+1, ir+1], axis=-1)
+        its = np.stack([it+1, it, it, it+1, it+1, it, it, it+1], axis=-1)
+        izs = np.stack([iz, iz, iz, iz, iz+1, iz+1, iz+1, iz+1], axis=-1)
+        i_hex_nodes = np.ravel_multi_index((irs, its, izs), mesh._shape_total_nodes, order='F')
+        i_hex_nodes = (P.indices[i_hex_nodes])
+
+        if mesh.nodes_x[0] == 0.0:
+            irs = np.stack([ir-1, ir, ir-1, ir], axis=-1)
+        else:
+            irs = np.stack([ir, ir+1, ir, ir+1], axis=-1)
+        its = np.stack([it, it, it, it], axis=-1)
+        izs = np.stack([iz, iz, iz+1, iz+1], axis=-1)
+        i_hex_control_nodes = np.ravel_multi_index((irs, its, izs), Rs.shape, order='F')
+
+        if mesh.nodes_x[0] == 0.0:
+            # Wedge Cells nodes
+            # put control points along radial edge for halfway points on the edges...
+            Phis, Zs = np.meshgrid(mesh.nodes_y, mesh.nodes_z, indexing='ij')
+            Rhalfs = np.full_like(Phis, mesh.nodes_x[1]*0.5)
+            wedge_control_nodes = np.c_[Rhalfs.reshape(-1, order='F'), Phis.reshape(-1, order='F'), Zs.reshape(-1, order='F')]
+
+            # indices for wedge nodes: for cell 0
+            ir, it, iz = np.unravel_index(wedge_cells, shape=mesh.shape_cells, order='F')
+            irs = np.stack([ir, ir+1, ir+1, ir, ir+1, ir+1], axis=-1)
+            its = np.stack([it, it, it+1, it, it, it+1], axis=-1)
+            izs = np.stack([iz, iz, iz, iz+1, iz+1, iz+1], axis=-1)
+            i_wedge_nodes = np.ravel_multi_index((irs, its, izs), mesh._shape_total_nodes, order='F')
+            i_wedge_nodes = (P.indices[i_wedge_nodes])
+
+            its = np.stack([it, it+1, it, it+1], axis=-1)
+            izs = np.stack([iz, iz, iz+1, iz+1], axis=-1)
+            # wrap mode for the duplicated wedge control nodes
+            i_wscn = np.ravel_multi_index((its, izs), Rhalfs.shape, order='F', mode='wrap') + len(control_nodes)
+
+            irs = np.stack([ir, ir], axis=-1)
+            its = np.stack([it, it], axis=-1)
+            izs = np.stack([iz, iz+1], axis=-1)
+            i_wccn = np.ravel_multi_index((irs, its, izs), Rs.shape, order='F')
+            i_wedge_control_nodes = np.c_[i_wscn[:, 0], i_wccn[:, 0], i_wscn[:, 1], i_wscn[:, 2], i_wccn[:, 1], i_wscn[:, 3]]
+        ####
+        # assemble cells
+        cell_types = np.empty(mesh.n_cells, dtype=np.uint8)
+        cell_types[hex_cells] = _vtk.VTK_BEZIER_HEXAHEDRON
+
+        cell_con = np.empty((mesh.n_cells, 13), dtype=int)
+        cell_con[:, 0] = 12
+        cell_con[hex_cells, 1:9] = i_hex_nodes
+        cell_con[hex_cells, 9:] = i_hex_control_nodes + mesh.n_nodes
+        nodes_cyl = np.r_[mesh.nodes, control_nodes]
+
+        # calculate weights for control points
+        control_weights = (
+            np.sin(np.pi/2 - dphis_half)[None, :, None]
+            * np.ones((mesh.shape_nodes[0]-1, mesh.shape_nodes[2]))[:, None, :]
         )
+        rational_weights = np.r_[np.ones(mesh.n_nodes), control_weights.reshape(-1, order='F')]
+
+        higher_order_degrees = np.empty((mesh.n_cells, 3))
+        higher_order_degrees[hex_cells, :] = [2, 1, 1]
+
+        if mesh.nodes_x[0] == 0.0:
+            cell_types[wedge_cells] = _vtk.VTK_BEZIER_WEDGE
+            cell_con[wedge_cells, 1:7] = i_wedge_nodes
+            cell_con[wedge_cells, 7:] = i_wedge_control_nodes + mesh.n_nodes
+            nodes_cyl = np.r_[nodes_cyl, wedge_control_nodes]
+            rational_weights = np.r_[rational_weights, np.ones(len(wedge_control_nodes))]
+            higher_order_degrees[wedge_cells] = [2, 2, 1]
+
+        nodes = cyl2cart(nodes_cyl)
+
+        vtk_pts = _vtk.vtkPoints()
+        vtk_pts.SetData(_nps.numpy_to_vtk(nodes, deep=True))
+
+        cells = _vtk.vtkCellArray()
+        cells.SetNumberOfCells(mesh.n_cells)
+        cells.SetCells(
+            mesh.n_cells,
+            _nps.numpy_to_vtk(cell_con.reshape(-1), deep=True, array_type=_vtk.VTK_ID_TYPE),
+        )
+        cell_types = _nps.numpy_to_vtk(cell_types, deep=True)
+
+        output = _vtk.vtkUnstructuredGrid()
+        output.SetPoints(vtk_pts)
+        output.SetCells(cell_types, cells)
+
+        vtk_rational_weights = _nps.numpy_to_vtk(rational_weights)
+        vtk_higher_order_degrees = _nps.numpy_to_vtk(higher_order_degrees)
+
+        output.GetPointData().SetRationalWeights(vtk_rational_weights)
+        output.GetCellData().SetHigherOrderDegrees(vtk_higher_order_degrees)
+        # Assign the model('s) to the object
+        return assign_cell_data(output, models=models)
+
 
     def to_vtk(mesh, models=None):
         """Convert mesh (and models) to corresponding VTK or PyVista data object
@@ -418,7 +532,7 @@ class InterfaceVTK(object):
             "tensor": InterfaceVTK.__tensor_mesh_to_vtk,
             "curv": InterfaceVTK.__curvilinear_mesh_to_vtk,
             "simplex": InterfaceVTK.__simplex_mesh_to_vtk,
-            # TODO: 'CylindricalMesh' : InterfaceVTK.__cyl_mesh_to_vtk,
+            "cyl" : InterfaceVTK.__cyl_mesh_to_vtk,
         }
         key = mesh._meshType.lower()
         try:

--- a/discretize/mixins/vtk_mod.py
+++ b/discretize/mixins/vtk_mod.py
@@ -410,6 +410,11 @@ class InterfaceVTK(object):
         # # Points
         P = mesh._deflation_matrix('nodes', as_ones=True).T.tocsr()
 
+        if np.any(mesh.h[1] >= np.pi):
+            raise NotImplementedError(
+                "Exporting cylindrical meshes to vtk with angles larger than 180 degrees"
+                " is not yet supported."
+            )
         # calculate control points
         dphis_half = mesh.h[1]/2
         phi_controls = mesh.nodes_y + dphis_half

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -123,10 +123,16 @@ def setup_mesh(mesh_type, nC, nDim):
 
     elif "CylindricalMesh" in mesh_type or "CylMesh" in mesh_type:
         if "uniform" in mesh_type:
-            h = [nC, nC, nC]
+            if "symmetric" in mesh_type:
+                h = [nC, 1, nC]
+            else:
+                h = [nC, nC, nC]
         elif "random" in mesh_type:
             h1 = np.random.rand(nC) * nC * 0.5 + nC * 0.5
-            h2 = np.random.rand(nC) * nC * 0.5 + nC * 0.5
+            if "symmetric" in mesh_type:
+                h2 = [2 * np.pi, ]
+            else:
+                h2 = np.random.rand(nC) * nC * 0.5 + nC * 0.5
             h3 = np.random.rand(nC) * nC * 0.5 + nC * 0.5
             h = [hi / np.sum(hi) for hi in [h1, h2, h3]]  # normalize
             h[1] = h[1] * 2 * np.pi
@@ -138,7 +144,10 @@ def setup_mesh(mesh_type, nC, nDim):
             max_h = max([np.max(hi) for hi in [mesh.h[0], mesh.h[2]]])
         elif nDim == 3:
             mesh = CylindricalMesh(h)
-            max_h = max([np.max(hi) for hi in mesh.h])
+            if "symmetric" in mesh_type:
+                max_h = max([np.max(hi) for hi in [mesh.h[0], mesh.h[2]]])
+            else:
+                max_h = max([np.max(hi) for hi in mesh.h])
 
     elif "Curv" in mesh_type:
         if "uniform" in mesh_type:

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -43,7 +43,7 @@ try:
     import getpass
 
     name = getpass.getuser()[0].upper() + getpass.getuser()[1:]
-except Exception as e:
+except Exception:
     name = "You"
 
 happiness = [
@@ -140,8 +140,11 @@ def setup_mesh(mesh_type, nC, nDim):
             raise Exception("Unexpected mesh_type")
 
         if nDim == 2:
-            mesh = CylindricalMesh([h[0], 1, h[2]])
-            max_h = max([np.max(hi) for hi in [mesh.h[0], mesh.h[2]]])
+            mesh = CylindricalMesh([h[0], h[1]])
+            if "symmetric" in mesh_type:
+                max_h = np.max(mesh.h[0])
+            else:
+                max_h = max([np.max(hi) for hi in mesh.h])
         elif nDim == 3:
             mesh = CylindricalMesh(h)
             if "symmetric" in mesh_type:

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -559,7 +559,7 @@ class TreeMesh(
         location_type = self._parse_location_type(location_type)
 
         if self.dim == 2 and "z" in location_type:
-            raise Exception("Unable to interpolate from Z edges/faces in 2D")
+            raise NotImplementedError("Unable to interpolate from Z edges/faces in 2D")
 
         locs = np.require(np.atleast_2d(locs), dtype=np.float64, requirements="C")
 

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -539,7 +539,7 @@ class TreeMesh(
         return self._cell_levels_by_indexes(indices)
 
     def get_interpolation_matrix(
-        self, locs, location_type="CC", zeros_outside=False, **kwargs
+        self, locs, location_type="cell_centers", zeros_outside=False, **kwargs
     ):
         if "locType" in kwargs:
             warnings.warn(
@@ -556,9 +556,21 @@ class TreeMesh(
             )
             zeros_outside = kwargs["zerosOutside"]
         locs = as_array_n_by_dim(locs, self.dim)
-        if location_type not in ["N", "CC", "Ex", "Ey", "Ez", "Fx", "Fy", "Fz"]:
-            raise Exception(
-                "location_type must be one of N, CC, Ex, Ey, Ez, Fx, Fy, or Fz"
+        location_type = self._parse_location_type(location_type)
+        if location_type not in [
+            "nodes",
+            "faces",
+            "faces_x",
+            "faces_y",
+            "faces_z",
+            "edges",
+            "edges_x",
+            "edges_y",
+            "edges_z",
+            "cell_centers",
+        ]:
+            raise ValueError(
+                "Location must be a grid location, not {}".format(location_type)
             )
 
         if self.dim == 2 and location_type in ["Ez", "Fz"]:
@@ -566,13 +578,13 @@ class TreeMesh(
 
         locs = np.require(np.atleast_2d(locs), dtype=np.float64, requirements="C")
 
-        if location_type == "N":
+        if location_type == "nodes":
             Av = self._getNodeIntMat(locs, zeros_outside)
-        elif location_type in ["Ex", "Ey", "Ez"]:
-            Av = self._getEdgeIntMat(locs, zeros_outside, location_type[1])
-        elif location_type in ["Fx", "Fy", "Fz"]:
-            Av = self._getFaceIntMat(locs, zeros_outside, location_type[1])
-        elif location_type in ["CC"]:
+        elif location_type in ["edges_x", "edges_y", "edges_z"]:
+            Av = self._getEdgeIntMat(locs, zeros_outside, location_type[-1])
+        elif location_type in ["faces_x", "faces_y", "faces_z"]:
+            Av = self._getFaceIntMat(locs, zeros_outside, location_type[-1])
+        elif location_type in ["cell_centers"]:
             Av = self._getCellIntMat(locs, zeros_outside)
         return Av
 

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -557,24 +557,9 @@ class TreeMesh(
             zeros_outside = kwargs["zerosOutside"]
         locs = as_array_n_by_dim(locs, self.dim)
         location_type = self._parse_location_type(location_type)
-        if location_type not in [
-            "nodes",
-            "faces",
-            "faces_x",
-            "faces_y",
-            "faces_z",
-            "edges",
-            "edges_x",
-            "edges_y",
-            "edges_z",
-            "cell_centers",
-        ]:
-            raise ValueError(
-                "Location must be a grid location, not {}".format(location_type)
-            )
 
-        if self.dim == 2 and location_type in ["Ez", "Fz"]:
-            raise Exception("Unable to interpolate from Z edges/face in 2D")
+        if self.dim == 2 and "z" in location_type:
+            raise Exception("Unable to interpolate from Z edges/faces in 2D")
 
         locs = np.require(np.atleast_2d(locs), dtype=np.float64, requirements="C")
 
@@ -586,6 +571,10 @@ class TreeMesh(
             Av = self._getFaceIntMat(locs, zeros_outside, location_type[-1])
         elif location_type in ["cell_centers"]:
             Av = self._getCellIntMat(locs, zeros_outside)
+        else:
+            raise ValueError(
+                "Location must be a grid location, not {}".format(location_type)
+            )
         return Av
 
     @property

--- a/discretize/unstructured_mesh.py
+++ b/discretize/unstructured_mesh.py
@@ -856,10 +856,7 @@ class SimplexMesh(BaseMesh, SimplexMeshIO, InterfaceMixins):
 
     @property
     def average_cell_to_face(self):
-        ind_ptr = 3*np.arange(self.n_cells + 1)
-        col_inds = self._simplex_faces.reshape(-1)
-        Aij = np.ones(len(col_inds))
-        A = sp.csr_matrix((Aij, col_inds, ind_ptr), shape=(self.n_cells, self.n_faces)).T
+        A = self.average_face_to_cell.T
         row_sum = np.asarray(A.sum(axis=-1))[:, 0]
         row_sum[row_sum == 0.0] = 1.0
         A = sp.diags(1.0/row_sum) @ A

--- a/discretize/unstructured_mesh.py
+++ b/discretize/unstructured_mesh.py
@@ -855,6 +855,17 @@ class SimplexMesh(BaseMesh, SimplexMeshIO, InterfaceMixins):
         return sp.csr_matrix((Aij.reshape(-1), col_inds.reshape(-1), row_ptr), shape=(n_cells, n_edges))
 
     @property
+    def average_cell_to_face(self):
+        ind_ptr = 3*np.arange(self.n_cells + 1)
+        col_inds = self._simplex_faces.reshape(-1)
+        Aij = np.ones(len(col_inds))
+        A = sp.csr_matrix((Aij, col_inds, ind_ptr), shape=(self.n_cells, self.n_faces)).T
+        row_sum = np.asarray(A.sum(axis=-1))[:, 0]
+        row_sum[row_sum == 0.0] = 1.0
+        A = sp.diags(1.0/row_sum) @ A
+        return A
+
+    @property
     def stencil_cell_gradient(self):
         # An operator that differences cells on each side of a face
         # in the direction of the face normal

--- a/discretize/utils/coordinate_utils.py
+++ b/discretize/utils/coordinate_utils.py
@@ -179,7 +179,7 @@ def cart2cyl(grid, vec=None):
     --------
     cartesian_to_cylindrical
     """
-    return cylindrical_to_cartesian(grid, vec)
+    return cartesian_to_cylindrical(grid, vec)
 
 
 def rotation_matrix_from_normals(v0, v1, tol=1e-20):

--- a/tests/base/test_interpolation.py
+++ b/tests/base/test_interpolation.py
@@ -223,29 +223,91 @@ class TestInterpolationSymCyl(discretize.tests.OrderTest):
 
     def test_orderCC(self):
         self.type = "CC"
-        self.name = "Interpolation 2D CYLMESH: CC"
-        self.orderTest()
-
-    def test_orderN(self):
-        self.type = "N"
-        self.name = "Interpolation 2D CYLMESH: N"
+        self.name = "Interpolation 3D Symmetric CYLMESH: CC"
         self.orderTest()
 
     def test_orderFx(self):
         self.type = "Fx"
-        self.name = "Interpolation 2D CYLMESH: Fx"
+        self.name = "Interpolation 3D Symmetric CYLMESH: Fx"
         self.orderTest()
 
     def test_orderFz(self):
         self.type = "Fz"
-        self.name = "Interpolation 2D CYLMESH: Fz"
+        self.name = "Interpolation 3D Symmetric CYLMESH: Fz"
         self.orderTest()
 
     def test_orderEy(self):
         self.type = "Ey"
-        self.name = "Interpolation 2D CYLMESH: Ey"
+        self.name = "Interpolation 3D Symmetric CYLMESH: Ey"
         self.orderTest()
 
+class TestInterpolationCyl(discretize.tests.OrderTest):
+    name = "Interpolation Cylindrical 3D"
+    LOCS = np.c_[
+        np.random.rand(20) * 0.6 + 0.2, 2*np.pi*(np.random.rand(20) * 0.6 + 0.2), np.random.rand(20) * 0.6 + 0.2
+    ]
+    meshTypes = ["uniformCylMesh", "randomCylMesh"]  # MESHTYPES +
+    meshDimension = 3
+    meshSizes = [8, 16, 32, 64]
+
+    def getError(self):
+        func = lambda x, y, z: np.cos(2 * np.pi * x) + np.cos(y) + np.cos(2 * np.pi * z)
+        ana = func(*self.LOCS.T)
+        mesh = self.M
+
+        if "F" in self.type:
+            v = func(*mesh.faces.T)
+        elif "E" in self.type:
+            v = func(*mesh.edges.T)
+        elif "CC" == self.type:
+            v = func(*mesh.cell_centers.T)
+        elif "N" == self.type:
+            v = func(*mesh.nodes.T)
+
+        comp = mesh.getInterpolationMat(self.LOCS, self.type) * v
+
+        err = np.linalg.norm((comp - ana), np.inf)
+        return err
+
+    def test_orderCC(self):
+        self.type = "CC"
+        self.name = "Interpolation 3D CYLMESH: CC"
+        self.orderTest()
+
+    def test_orderN(self):
+        self.type = "N"
+        self.name = "Interpolation 3D CYLMESH: N"
+        self.orderTest()
+
+    def test_orderFx(self):
+        self.type = "Fx"
+        self.name = "Interpolation 3D CYLMESH: Fx"
+        self.orderTest()
+
+    def test_orderFy(self):
+        self.type = "Fy"
+        self.name = "Interpolation 3D CYLMESH: Fy"
+        self.orderTest()
+
+    def test_orderFz(self):
+        self.type = "Fz"
+        self.name = "Interpolation 3D CYLMESH: Fz"
+        self.orderTest()
+
+    def test_orderEx(self):
+        self.type = "Ex"
+        self.name = "Interpolation 3D CYLMESH: Ex"
+        self.orderTest()
+
+    def test_orderEy(self):
+        self.type = "Ey"
+        self.name = "Interpolation 3D CYLMESH: Ey"
+        self.orderTest()
+
+    def test_orderEz(self):
+        self.type = "Ez"
+        self.name = "Interpolation 3D CYLMESH: Ez"
+        self.orderTest()
 
 class TestInterpolation3D(discretize.tests.OrderTest):
     name = "Interpolation"

--- a/tests/base/test_interpolation.py
+++ b/tests/base/test_interpolation.py
@@ -181,9 +181,9 @@ class TestInterpolationSymCyl(discretize.tests.OrderTest):
     LOCS = np.c_[
         np.random.rand(4) * 0.6 + 0.2, np.zeros(4), np.random.rand(4) * 0.6 + 0.2
     ]
-    meshTypes = ["uniformCylMesh"]  # MESHTYPES +
+    meshTypes = ["uniform_symmetric_CylMesh"]  # MESHTYPES +
     tolerance = 0.6
-    meshDimension = 2
+    meshDimension = 3
     meshSizes = [32, 64, 128, 256]
 
     def getError(self):

--- a/tests/base/test_interpolation.py
+++ b/tests/base/test_interpolation.py
@@ -159,7 +159,7 @@ class TestInterpolation2d(discretize.tests.OrderTest):
         self.orderTest()
 
 
-class TestInterpolation2dCyl_Simple(unittest.TestCase):
+class TestInterpolationSymmetricCyl_Simple(unittest.TestCase):
     def test_simpleInter(self):
         M = discretize.CylMesh([4, 1, 1])
         locs = np.r_[0, 0, 0.5]
@@ -176,8 +176,8 @@ class TestInterpolation2dCyl_Simple(unittest.TestCase):
         self.assertRaises(Exception, lambda: M.getInterpolationMat(locs, "Ez"))
 
 
-class TestInterpolation2dCyl(discretize.tests.OrderTest):
-    name = "Interpolation 2D"
+class TestInterpolationSymCyl(discretize.tests.OrderTest):
+    name = "Interpolation Symmetric 3D"
     LOCS = np.c_[
         np.random.rand(4) * 0.6 + 0.2, np.zeros(4), np.random.rand(4) * 0.6 + 0.2
     ]

--- a/tests/boundaries/test_boundary_integrals.py
+++ b/tests/boundaries/test_boundary_integrals.py
@@ -213,7 +213,7 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
         "sphereCurv",
         ]
     meshDimension = 3
-    expectedOrders = [2, 1, 2, 2, 2, 0, 2]
+    expectedOrders = [2, 1, 2, 2, 2, 0]
     meshSizes = [4, 8, 16, 32]
 
     def getError(self):
@@ -304,7 +304,6 @@ class Test3DCylindricalBoundary(discretize.tests.OrderTest):
             discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
             true_val = -7 * np.pi/6
 
-        #print(discrete_val, true_val)
         return np.abs(discrete_val - true_val)
 
     def test_orderWeakCellGradIntegral(self):

--- a/tests/boundaries/test_boundary_integrals.py
+++ b/tests/boundaries/test_boundary_integrals.py
@@ -286,7 +286,7 @@ class Test3DCylindricalBoundary(discretize.tests.OrderTest):
         "uniformCylindricalMesh",
         ]
     meshDimension = 3
-    expectedOrders = [2,]
+    expectedOrders = [2, ]
     meshSizes = [8, 16, 32, 64]
 
     def getError(self):
@@ -319,4 +319,9 @@ class Test3DCylindricalBoundary(discretize.tests.OrderTest):
     def test_orderWeakCellGradIntegral(self):
         self.name = "3D - weak cell gradient integral w/boundary"
         self.myTest = "cell_grad"
+        self.orderTest()
+
+    def test_orderWeakEdgeDivIntegral(self):
+        self.name = "3D - weak edge divergence integral w/boundary"
+        self.myTest = "edge_div"
         self.orderTest()

--- a/tests/boundaries/test_boundary_integrals.py
+++ b/tests/boundaries/test_boundary_integrals.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 import discretize
+from discretize.utils import cart2cyl, cyl2cart
 
 
 def u(*args):
@@ -14,6 +15,11 @@ def u(*args):
     return x**3 + y**2 + z**4
 
 
+def u_cyl(*args):
+    xyz = cyl2cart(np.stack(args, axis=-1))
+    return u(*xyz.T)
+
+
 def v(*args):
     if len(args) == 1:
         x = args[0]
@@ -25,12 +31,24 @@ def v(*args):
     return np.c_[2*x**2, 3*y**3, -4*z**2]
 
 
+def v_cyl(*args):
+    xyz = cyl2cart(np.stack(args, axis=-1))
+    xyz_vec = v(*xyz.T)
+    return cart2cyl(xyz, xyz_vec)
+
+
 def w(*args):
     if len(args) == 2:
         x, y = args
         return np.c_[(y - 2)**2, (x + 2)**2]
     x, y, z = args
     return np.c_[(y-2)**2 + z**2, (x+2)**2 - (z-4)**2, y**2-x**2]
+
+
+def w_cyl(*args):
+    xyz = cyl2cart(np.stack(args, axis=-1))
+    xyz_vec = w(*xyz.T)
+    return cart2cyl(xyz, xyz_vec)
 
 # mesh will be on [0, 1] square
 
@@ -54,6 +72,11 @@ def w(*args):
 # int_V grad_u dot v dV = -4/15
 # int_V u div_v dV = 27/20
 # int_v curl_w dot v dV = 17/6
+
+# 3D Cylindrical Values
+# int_V grad_u dot v dV = -7 * np.pi/6
+# int_V u div_v dV = -31 * np.pi/120
+# int_v curl_w dot v dV = -85 * np.pi/6
 
 
 class Test1DBoundaryIntegral(discretize.tests.OrderTest):
@@ -187,10 +210,10 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
         "uniformTree",
         "uniformCurv",
         "rotateCurv",
-        "sphereCurv"
+        "sphereCurv",
         ]
     meshDimension = 3
-    expectedOrders = [2, 1, 2, 2, 2, 0]
+    expectedOrders = [2, 1, 2, 2, 2, 0, 2]
     meshSizes = [4, 8, 16, 32]
 
     def getError(self):
@@ -254,4 +277,37 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
     def test_orderWeakFaceCurlIntegral(self):
         self.name = "3D - weak face curl integral w/boundary"
         self.myTest = "face_curl"
+        self.orderTest()
+
+
+class Test3DCylindricalBoundary(discretize.tests.OrderTest):
+    name = "3D Cylindrical Boundary Integrals"
+    meshTypes = [
+        "uniformCylindricalMesh",
+        ]
+    meshDimension = 3
+    expectedOrders = [2,]
+    meshSizes = [8, 16, 32, 64]
+
+    def getError(self):
+        mesh = self.M
+        if self.myTest == "cell_grad":
+            # Functions:
+            u_cc = u_cyl(*mesh.cell_centers.T)
+            v_f = mesh.project_face_vector(v_cyl(*mesh.faces.T))
+            u_bf = u_cyl(*mesh.boundary_faces.T)
+
+            D = mesh.face_divergence
+            M_c = sp.diags(mesh.cell_volumes)
+            M_bf = mesh.boundary_face_scalar_integral
+
+            discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
+            true_val = -7 * np.pi/6
+
+        #print(discrete_val, true_val)
+        return np.abs(discrete_val - true_val)
+
+    def test_orderWeakCellGradIntegral(self):
+        self.name = "3D - weak cell gradient integral w/boundary"
+        self.myTest = "cell_grad"
         self.orderTest()

--- a/tests/boundaries/test_boundary_integrals.py
+++ b/tests/boundaries/test_boundary_integrals.py
@@ -303,7 +303,17 @@ class Test3DCylindricalBoundary(discretize.tests.OrderTest):
 
             discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
             true_val = -7 * np.pi/6
+        elif self.myTest == "edge_div":
+            u_n = u_cyl(*mesh.nodes.T)
+            v_e = mesh.project_edge_vector(v_cyl(*mesh.edges.T))
+            v_bn = v_cyl(*mesh.boundary_nodes.T).reshape(-1, order='F')
 
+            M_e = mesh.get_edge_inner_product()
+            G = mesh.nodal_gradient
+            M_bn = mesh.boundary_node_vector_integral
+
+            true_val = -31 * np.pi/120
+            discrete_val = -(u_n.T @ G.T) @ M_e @ v_e + u_n.T @ (M_bn @ v_bn)
         return np.abs(discrete_val - true_val)
 
     def test_orderWeakCellGradIntegral(self):

--- a/tests/cyl/test_cyl.py
+++ b/tests/cyl/test_cyl.py
@@ -7,7 +7,7 @@ from discretize import tests, utils
 np.random.seed(13)
 
 
-class TestCyl2DMesh(unittest.TestCase):
+class TestCylSymmetricMesh(unittest.TestCase):
     def setUp(self):
         hx = np.r_[1, 1, 0.5]
         hz = np.r_[2, 1]
@@ -318,7 +318,7 @@ class TestCyl2DMesh(unittest.TestCase):
         self.assertTrue(np.all(self.mesh.gridCC == mesh.gridCC))
 
 
-MESHTYPES = ["uniformCylMesh"]
+MESHTYPES = ["uniform_symmetric_CylMesh"]
 call2 = lambda fun, xyz: fun(xyz[:, 0], xyz[:, 2])
 call3 = lambda fun, xyz: fun(xyz[:, 0], xyz[:, 1], xyz[:, 2])
 cyl_row2 = lambda g, xfun, yfun: np.c_[call2(xfun, g), call2(yfun, g)]
@@ -333,7 +333,7 @@ cylF2 = lambda M, fx, fy: np.vstack(
 class TestFaceDiv2D(tests.OrderTest):
     name = "FaceDiv"
     meshTypes = MESHTYPES
-    meshDimension = 2
+    meshDimension = 3
 
     def getError(self):
 
@@ -361,7 +361,7 @@ class TestFaceDiv2D(tests.OrderTest):
 class TestEdgeCurl2D(tests.OrderTest):
     name = "EdgeCurl"
     meshTypes = MESHTYPES
-    meshDimension = 2
+    meshDimension = 3
 
     def getError(self):
         # To Recreate or change the functions:
@@ -461,7 +461,7 @@ class TestAveragingSimple(unittest.TestCase):
 class TestAveE2CC(tests.OrderTest):
     name = "aveE2CC"
     meshTypes = MESHTYPES
-    meshDimension = 2
+    meshDimension = 3
     meshSizes = [8, 16, 32, 64]
 
     def getError(self):
@@ -483,7 +483,7 @@ class TestAveE2CC(tests.OrderTest):
 class TestAveE2CCV(tests.OrderTest):
     name = "aveE2CCV"
     meshTypes = MESHTYPES
-    meshDimension = 2
+    meshDimension = 3
     meshSizes = [8, 16, 32, 64]
 
     def getError(self):
@@ -505,7 +505,7 @@ class TestAveE2CCV(tests.OrderTest):
 class TestAveF2CCV(tests.OrderTest):
     name = "aveF2CCV"
     meshTypes = MESHTYPES
-    meshDimension = 2
+    meshDimension = 3
 
     def getError(self):
 
@@ -533,7 +533,7 @@ class TestAveF2CCV(tests.OrderTest):
 class TestAveF2CC(tests.OrderTest):
     name = "aveF2CC"
     meshTypes = MESHTYPES
-    meshDimension = 2
+    meshDimension = 3
 
     def getError(self):
 
@@ -557,7 +557,7 @@ class TestInnerProducts2D(tests.OrderTest):
     """Integrate an function over a unit cube domain using edgeInnerProducts and faceInnerProducts."""
 
     meshTypes = MESHTYPES
-    meshDimension = 2
+    meshDimension = 3
     meshSizes = [4, 8, 16, 32, 64, 128]
 
     def getError(self):

--- a/tests/cyl/test_cyl3D.py
+++ b/tests/cyl/test_cyl3D.py
@@ -72,14 +72,23 @@ class TestCyl3DGeometries(unittest.TestCase):
 def test_boundary_items():
     mesh = discretize.CylindricalMesh([3, 4, 5])
 
+    # Nodes
     is_bn = (mesh.nodes[:, 0] == 1) | (mesh.nodes[:, 2] == 0) | (mesh.nodes[:, 2] == 1)
     np.testing.assert_equal(mesh.boundary_nodes, mesh.nodes[is_bn])
+    P_bn = mesh.project_node_to_boundary_node
+    np.testing.assert_equal(mesh.boundary_nodes, P_bn @ mesh.nodes)
 
+    # Edges
     is_be = (mesh.edges[:, 0] == 1) | (mesh.edges[:, 2] == 0) | (mesh.edges[:, 2] == 1)
     np.testing.assert_equal(mesh.boundary_edges, mesh.edges[is_be])
+    P_be = mesh.project_edge_to_boundary_edge
+    np.testing.assert_equal(mesh.boundary_edges, P_be @ mesh.edges)
 
+    # Faces
     is_bf = (mesh.faces[:, 0] == 1) | (mesh.faces[:, 2] == 0) | (mesh.faces[:, 2] == 1)
     np.testing.assert_equal(mesh.boundary_faces, mesh.faces[is_bf])
+    P_bf = mesh.project_face_to_boundary_face
+    np.testing.assert_equal(mesh.boundary_faces, P_bf @ mesh.faces)
 
 # ----------------------- Test Grids and Counting --------------------------- #
 

--- a/tests/cyl/test_cyl3D.py
+++ b/tests/cyl/test_cyl3D.py
@@ -69,6 +69,18 @@ class TestCyl3DGeometries(unittest.TestCase):
         )
 
 
+def test_boundary_items():
+    mesh = discretize.CylindricalMesh([3, 4, 5])
+
+    is_bn = (mesh.nodes[:, 0] == 1) | (mesh.nodes[:, 2] == 0) | (mesh.nodes[:, 2] == 1)
+    np.testing.assert_equal(mesh.boundary_nodes, mesh.nodes[is_bn])
+
+    is_be = (mesh.edges[:, 0] == 1) | (mesh.edges[:, 2] == 0) | (mesh.edges[:, 2] == 1)
+    np.testing.assert_equal(mesh.boundary_edges, mesh.edges[is_be])
+
+    is_bf = (mesh.faces[:, 0] == 1) | (mesh.faces[:, 2] == 0) | (mesh.faces[:, 2] == 1)
+    np.testing.assert_equal(mesh.boundary_faces, mesh.faces[is_bf])
+
 # ----------------------- Test Grids and Counting --------------------------- #
 
 

--- a/tests/cyl/test_cylOperators.py
+++ b/tests/cyl/test_cylOperators.py
@@ -268,6 +268,7 @@ class TestAveF2CC(tests.OrderTest):
     def test_order(self):
         self.orderTest()
 
+
 class TestAveCC2F(tests.OrderTest):
     name = "aveCC2F"
     meshTypes = ["uniformCylindricalMesh"]
@@ -303,6 +304,7 @@ class TestAveCC2F(tests.OrderTest):
         self.full = True
         self.orderTest()
 
+
 class TestAveN2F(tests.OrderTest):
     name = "aveN2F"
     meshTypes = MESHTYPES
@@ -324,6 +326,7 @@ class TestAveN2F(tests.OrderTest):
 
     def test_order(self):
         self.orderTest()
+
 
 class FaceInnerProductFctsIsotropic(object):
     def fcts(self):

--- a/tests/cyl/test_cyl_innerproducts.py
+++ b/tests/cyl/test_cyl_innerproducts.py
@@ -280,21 +280,6 @@ class TestCylFaceInnerProductsDiagAnisotropic_Order(tests.OrderTest):
         self.orderTest()
 
 
-class TestCylEdgeInnerProducts_Order(tests.OrderTest):
-
-    meshTypes = ["uniform_symmetric_CylMesh"]
-    meshDimension = 3
-
-    def getError(self):
-        fct = EdgeInnerProductFunctionsDiagAnisotropic()
-        sig, ht = fct.vectors(self.M)
-        Msig = self.M.getEdgeInnerProduct(sig)
-        return float(fct.sol()) - ht.T.dot(Msig.dot(ht))
-
-    def test_order(self):
-        self.orderTest()
-
-
 class TestCylInnerProducts_Deriv(unittest.TestCase):
     def setUp(self):
         n = 2

--- a/tests/cyl/test_cyl_innerproducts.py
+++ b/tests/cyl/test_cyl_innerproducts.py
@@ -237,8 +237,8 @@ class TestCylInnerProducts_simple(unittest.TestCase):
 
 class TestCylFaceInnerProducts_Order(tests.OrderTest):
 
-    meshTypes = ["uniformCylMesh"]
-    meshDimension = 2
+    meshTypes = ["uniform_symmetric_CylMesh"]
+    meshDimension = 3
 
     def getError(self):
         fct = FaceInnerProductFctsIsotropic()
@@ -252,8 +252,8 @@ class TestCylFaceInnerProducts_Order(tests.OrderTest):
 
 class TestCylEdgeInnerProducts_Order(tests.OrderTest):
 
-    meshTypes = ["uniformCylMesh"]
-    meshDimension = 2
+    meshTypes = ["uniform_symmetric_CylMesh"]
+    meshDimension = 3
 
     def getError(self):
         fct = EdgeInnerProductFctsIsotropic()
@@ -267,8 +267,8 @@ class TestCylEdgeInnerProducts_Order(tests.OrderTest):
 
 class TestCylFaceInnerProductsDiagAnisotropic_Order(tests.OrderTest):
 
-    meshTypes = ["uniformCylMesh"]
-    meshDimension = 2
+    meshTypes = ["uniform_symmetric_CylMesh"]
+    meshDimension = 3
 
     def getError(self):
         fct = FaceInnerProductFunctionsDiagAnisotropic()
@@ -282,8 +282,8 @@ class TestCylFaceInnerProductsDiagAnisotropic_Order(tests.OrderTest):
 
 class TestCylEdgeInnerProducts_Order(tests.OrderTest):
 
-    meshTypes = ["uniformCylMesh"]
-    meshDimension = 2
+    meshTypes = ["uniform_symmetric_CylMesh"]
+    meshDimension = 3
 
     def getError(self):
         fct = EdgeInnerProductFunctionsDiagAnisotropic()

--- a/tests/cyl/test_cyl_io.py
+++ b/tests/cyl/test_cyl_io.py
@@ -1,0 +1,33 @@
+import numpy as np
+import discretize
+import pytest
+import os
+
+def test_convert_to_vtk():
+    mesh = discretize.CylindricalMesh([20, 15, 10])
+    vtk_mesh = mesh.to_vtk()
+
+def test_bad_convert():
+    mesh = discretize.CylindricalMesh([20, 2, 10])
+    with pytest.raises(NotImplementedError):
+        mesh.to_vtk()
+
+    mesh = discretize.CylindricalMesh([20, 1, 10])
+    with pytest.raises(NotImplementedError):
+        mesh.to_vtk()
+
+def test_serialize():
+    mesh = discretize.CylindricalMesh([20, 10, 3])
+    mesh.save('test.cyl')
+    mesh2 = discretize.load_mesh('test.cyl')
+    assert mesh.equals(mesh2)
+
+@pytest.fixture(autouse=True)
+def cleanup_files(monkeypatch):
+    files = ['test.cyl']
+    yield
+    for file in files:
+        try:
+            os.remove(file)
+        except:
+            pass

--- a/tests/simplex/test_interpolation.py
+++ b/tests/simplex/test_interpolation.py
@@ -300,6 +300,14 @@ class TestAveraging(discretize.tests.OrderTest):
         self.expectedOrders = 2
         self.orderTest()
 
+    def test_AvgCC2F_2D(self):
+        self.source_type = "CC"
+        self.target_type = "F"
+        self.name = "average_cell_to_face 2D"
+        self.meshDimension = 2
+        self.expectedOrders = 1
+        self.orderTest()
+
     # 3D
     def test_AvgN2CC_3D(self):
         self.source_type = "N"
@@ -347,6 +355,14 @@ class TestAveraging(discretize.tests.OrderTest):
         self.name = "average_face_to_cell 3D"
         self.meshDimension = 3
         self.expectedOrders = 2
+        self.orderTest()
+
+    def test_AvgCC2F_3D(self):
+        self.source_type = "CC"
+        self.target_type = "F"
+        self.name = "average_cell_to_face 3D"
+        self.meshDimension = 3
+        self.expectedOrders = 1
         self.orderTest()
 
 
@@ -435,3 +451,25 @@ class TestVectorAveraging3D(discretize.tests.OrderTest):
         self.name = "average_face_to_cell_vector 2D"
         self.expectedOrders = 1
         self.orderTest()
+
+
+def test_cell_to_face_extrap():
+    # 2D
+    points, simplices = example_simplex_mesh((10, 10))
+    mesh = discretize.SimplexMesh(points, simplices)
+
+    v = np.ones(len(mesh))
+
+    Fv = mesh.average_cell_to_face @ v
+
+    np.testing.assert_equal(1.0, Fv)
+
+    # 3D
+    points, simplices = example_simplex_mesh((4, 4, 4))
+    mesh = discretize.SimplexMesh(points, simplices)
+
+    v = np.ones(len(mesh))
+
+    Fv = mesh.average_cell_to_face @ v
+
+    np.testing.assert_equal(1.0, Fv)


### PR DESCRIPTION
This adds some missing operators for the cylindrical mesh, as well as 60x speedups for deflation matrix creation when `as_ones=False`.

This also adds support for exporting cylindrical meshes to a VTK format making using of their rational bezier cells, in an unstructured mesh.