### PR TITLE
Improve load time

### DIFF
--- a/discretize/mixins/__init__.py
+++ b/discretize/mixins/__init__.py
@@ -27,33 +27,28 @@ Other Optional Classes
 
   Slicer
 """
+import importlib
 from .mesh_io import TensorMeshIO, TreeMeshIO, SimplexMeshIO
 
 AVAILABLE_MIXIN_CLASSES = []
 SIMPLEX_MIXIN_CLASSES = []
 
-try:
+if importlib.util.find_spec("vtk"):
     from .vtk_mod import InterfaceVTK
 
     AVAILABLE_MIXIN_CLASSES.append(InterfaceVTK)
-except ImportError as err:
-    pass
 
-try:
+if importlib.util.find_spec("omf"):
     from .omf_mod import InterfaceOMF
 
     AVAILABLE_MIXIN_CLASSES.append(InterfaceOMF)
-except ImportError as err:
-    pass
 
 # keep this one last in defaults in case anything else wants to overwrite
 # plot commands
-try:
+if importlib.util.find_spec("matplotlib"):
     from .mpl_mod import Slicer, InterfaceMPL
 
     AVAILABLE_MIXIN_CLASSES.append(InterfaceMPL)
-except ImportError as err:
-    pass
 
 # # Python 3 friendly
 class InterfaceMixins(*AVAILABLE_MIXIN_CLASSES):

--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -3,13 +3,18 @@ import warnings
 from discretize.utils import mkvc, ndgrid
 from discretize.utils.code_utils import deprecate_method
 
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.widgets import Slider
-from matplotlib.collections import PolyCollection, LineCollection
-from matplotlib import rc_params
-from mpl_toolkits.mplot3d.art3d import Line3DCollection
 import discretize
+
+def load_matplotlib():
+    """Lazy load principal matplotlib routines.
+
+    This is not beautiful. But if matplotlib is installed, but never used, it
+    reduces load time significantly.
+    """
+    import matplotlib
+    import matplotlib.pyplot as plt
+    return matplotlib, plt
+    _, plt = load_matplotlib()
 
 
 class InterfaceMPL(object):
@@ -135,6 +140,8 @@ class InterfaceMPL(object):
         >>> M.plot_grid()
         >>> plt.show()
         """
+        matplotlib, plt = load_matplotlib()
+        from matplotlib import rc_params  # lazy loaded
         mesh_type = self._meshType.lower()
         plotters = {
             "tree": self.__plot_grid_tree,
@@ -272,6 +279,8 @@ class InterfaceMPL(object):
         >>> M.plot_image(v, annotation_color='k')
         >>> plt.show()
         """
+        matplotlib, plt = load_matplotlib()
+
         mesh_type = self._meshType.lower()
         plotters = {
             "tree": self.__plot_image_tree,
@@ -507,6 +516,8 @@ class InterfaceMPL(object):
         >>> plt.show()
 
         """
+        matplotlib, plt = load_matplotlib()
+
         mesh_type = self._meshType.lower()
         plotters = {
             "tree": self.__plot_slice_tree,
@@ -717,6 +728,8 @@ class InterfaceMPL(object):
         first.
 
         """
+        _, plt = load_matplotlib()
+
         mesh_type = self._meshType.lower()
         if mesh_type != "tensor":
             raise NotImplementedError(
@@ -1132,6 +1145,7 @@ class InterfaceMPL(object):
         stream_thickness=None,
     ):
         """Common function for plotting an image of a TensorMesh"""
+        matplotlib, plt = load_matplotlib()
 
         if ax is None:
             plt.figure()
@@ -1388,6 +1402,8 @@ class InterfaceMPL(object):
 
     # CylindricalMesh plotting
     def __plotCylTensorMesh(self, plotType, *args, **kwargs):
+        matplotlib, plt = load_matplotlib()
+
         if not self.is_symmetric:
             raise NotImplementedError("We have not yet implemented this type of view.")
         if plotType not in ["plot_image", "plot_grid"]:
@@ -1472,6 +1488,8 @@ class InterfaceMPL(object):
         return out
 
     def __plot_grid_cyl(self, *args, **kwargs):
+        _, plt = load_matplotlib()
+
         if self.is_symmetric:
             return self.__plotCylTensorMesh("plot_grid", *args, **kwargs)
 
@@ -1786,6 +1804,9 @@ class InterfaceMPL(object):
         edges_z=False,
         **kwargs,
     ):
+        from matplotlib.collections import LineCollection  # Lazy loaded
+        from mpl_toolkits.mplot3d.art3d import Line3DCollection  # Lazy loaded
+
         if faces:
             faces_x = faces_y = True
             if self.dim == 3:
@@ -1959,6 +1980,8 @@ class InterfaceMPL(object):
         quiver_opts=None,
         **kwargs,
     ):
+        from matplotlib.collections import PolyCollection  # lazy loaded
+
         if self.dim == 3:
             raise NotImplementedError(
                 "plotImage is not implemented for 3D TreeMesh, please use plotSlice"
@@ -2396,6 +2419,8 @@ class Slicer(object):
         **kwargs,
     ):
         """Initialize interactive figure."""
+        _, plt = load_matplotlib()
+        from matplotlib.widgets import Slider  # Lazy loaded
 
         # 0. Some checks, not very extensive
         if "pcolorOpts" in kwargs:
@@ -2660,6 +2685,7 @@ class Slicer(object):
 
     def onscroll(self, event):
         """Update index and data when scrolling."""
+        _, plt = load_matplotlib()
 
         # Get scroll direction
         if event.button == "up":

--- a/discretize/mixins/omf_mod.py
+++ b/discretize/mixins/omf_mod.py
@@ -1,6 +1,10 @@
-import omf
 import numpy as np
 import discretize
+
+def omf():
+    """Lazy loading omf."""
+    import omf
+    return omf
 
 
 def ravel_data_array(arr, nx, ny, nz):
@@ -161,7 +165,7 @@ class InterfaceOMF(object):
         if models is None:
             models = {}
         # Make the geometry
-        geometry = omf.VolumeGridGeometry()
+        geometry = omf().VolumeGridGeometry()
         # Set tensors
         tensors = mesh.h
         if len(tensors) < 1:
@@ -203,13 +207,13 @@ class InterfaceOMF(object):
         # Make sure the geometry is built correctly
         geometry.validate()
         # Make the volume elemet (the OMF object)
-        omfmesh = omf.VolumeElement(
+        omfmesh = omf().VolumeElement(
             geometry=geometry,
         )
         # Add model data arrays onto the cells of the mesh
         omfmesh.data = []
         for name, arr in models.items():
-            data = omf.ScalarData(
+            data = omf().ScalarData(
                 name=name,
                 array=ravel_data_array(arr, *mesh.shape_cells),
                 location="cells",
@@ -305,7 +309,7 @@ class InterfaceOMF(object):
         """
         element.validate()
         converters = {
-            omf.VolumeElement.__name__: InterfaceOMF._omf_volume_to_tensor,
+            omf().VolumeElement.__name__: InterfaceOMF._omf_volume_to_tensor,
         }
         key = element.__class__.__name__
         try:

--- a/discretize/mixins/vtk_mod.py
+++ b/discretize/mixins/vtk_mod.py
@@ -57,16 +57,23 @@ import numpy as np
 
 # from ..utils import cyl2cart
 
-import vtk as _vtk
-import vtk.util.numpy_support as _nps
-from vtk import VTK_VERSION as _vtk_version
-from vtk import vtkXMLRectilinearGridWriter as _vtkRectWriter
-from vtk import vtkXMLUnstructuredGridWriter as _vtkUnstWriter
-from vtk import vtkXMLStructuredGridWriter as _vtkStrucWriter
-from vtk import vtkXMLRectilinearGridReader as _vtkRectReader
-from vtk import vtkXMLUnstructuredGridReader as _vtkUnstReader
-
 import warnings
+
+
+def load_vtk(extra=None):
+    """Lazy load principal VTK routines.
+
+    This is not beautiful. But if VTK is installed, but never used, it reduces
+    load time significantly.
+    """
+    import vtk as _vtk
+    import vtk.util.numpy_support as _nps
+    if extra:
+        if isinstance(extra, str):
+            extra = [extra, ]
+        return _vtk, _nps, *[getattr(vtk, e) for e in extra]
+    else:
+        return _vtk, _nps
 
 
 def assign_cell_data(vtkDS, models=None):
@@ -82,6 +89,8 @@ def assign_cell_data(vtkDS, models=None):
         Name('s) and array('s). Match number of cells
 
     """
+    _, _nps = load_vtk()
+
     nc = vtkDS.GetNumberOfCells()
     if models is not None:
         for name, mod in models.items():
@@ -192,6 +201,8 @@ class InterfaceVTK(object):
             Name('s) and array('s). Match number of cells
 
         """
+        _vtk, _nps = load_vtk()
+
         # Make the data parts for the vtu object
         # Points
         ptsMat = np.vstack((mesh.gridN, mesh.gridhN))
@@ -257,6 +268,8 @@ class InterfaceVTK(object):
             Name('s) and array('s). Match number of cells
 
         """
+        _vtk, _nps = load_vtk()
+
         # Make the data parts for the vtu object
         # Points
         pts = mesh.nodes
@@ -282,10 +295,11 @@ class InterfaceVTK(object):
         # Assign the model('s) to the object
         return assign_cell_data(output, models=models)
 
-
     @staticmethod
     def __create_structured_grid(ptsMat, dims, models=None):
         """An internal helper to build out structured grids"""
+        _vtk, _nps = load_vtk()
+
         # Adjust if result was 2D:
         if ptsMat.shape[1] == 2:
             # Figure out which dim is null
@@ -335,6 +349,8 @@ class InterfaceVTK(object):
             Name('s) and array('s). Match number of cells
 
         """
+        _vtk, _nps = load_vtk()
+
         # Deal with dimensionalities
         if mesh.dim >= 1:
             vX = mesh.nodes_x
@@ -461,6 +477,10 @@ class InterfaceVTK(object):
         directory : str
             directory where the UBC GIF file lives
         """
+        _vtk, _, _vtk_version, _vtkUnstWriter = load_vtk(
+                ('VTK_VERSION', 'vtkXMLUnstructuredGridWriter')
+        )
+
         if not isinstance(vtkUnstructGrid, _vtk.vtkUnstructuredGrid):
             raise RuntimeError(
                 "`_save_unstructured_grid` can only handle `vtkUnstructuredGrid` objects. `%s` is not supported."
@@ -495,6 +515,10 @@ class InterfaceVTK(object):
         directory : str
             directory where the UBC GIF file lives
         """
+        _vtk, _, _vtk_version,  _vtkStrucWriter = load_vtk(
+                ('VTK_VERSION', 'vtkXMLStructuredGridWriter')
+        )
+
         if not isinstance(vtkStructGrid, _vtk.vtkStructuredGrid):
             raise RuntimeError(
                 "`_save_structured_grid` can only handle `vtkStructuredGrid` objects. `{}` is not supported.".format(
@@ -530,6 +554,8 @@ class InterfaceVTK(object):
         directory : str
             directory where the UBC GIF file lives
         """
+        _vtk, _, _vtkRectWriter = load_vtk('vtkXMLRectilinearGridWriter')
+
         if not isinstance(vtkRectGrid, _vtk.vtkRectilinearGrid):
             raise RuntimeError(
                 "`_save_rectilinear_grid` can only handle `vtkRectilinearGrid` objects. `{}` is not supported.".format(
@@ -619,6 +645,8 @@ class InterfaceTensorread_vtk(object):
         discretize.TensorMesh
             A discretize tensor mesh
         """
+        _, _nps = load_vtk()
+
         # Sort information
         hx = np.abs(np.diff(_nps.vtk_to_numpy(vtrGrid.GetXCoordinates())))
         xR = _nps.vtk_to_numpy(vtrGrid.GetXCoordinates())[0]
@@ -714,6 +742,8 @@ class InterfaceSimplexReadVTK:
         discretize.SimplexMesh
             A discretize tensor mesh
         """
+        _, _nps = load_vtk()
+
         # check if all of the cells are the same type
         cell_types = np.unique(_nps.vtk_to_numpy(vtuGrid.GetCellTypesArray()))
         if len(cell_types) > 1:
@@ -768,6 +798,8 @@ class InterfaceSimplexReadVTK:
             A dictionary containing the models. The keys correspond to the names of the
             models.
         """
+        _, _, _vtkUnstReader = load_vtk('vtkXMLUnstructuredGridReader')
+
         fname = os.path.join(directory, file_name)
         # Read the file
         vtuReader = _vtkUnstReader()

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -39,13 +39,6 @@ from . import TreeMesh as Tree
 import unittest
 import inspect
 
-# matplotlib is a soft dependencies for discretize
-try:
-    import matplotlib
-    import matplotlib.pyplot as plt
-except ImportError:
-    matplotlib = False
-
 try:
     import getpass
 
@@ -503,6 +496,14 @@ def check_derivative(
     ========================= PASS! =========================
     Once upon a time, a happy little test passed.
     """
+
+    # matplotlib is a soft dependencies for discretize,
+    # lazy-loaded to decrease load time of discretize.
+    try:
+        import matplotlib
+        import matplotlib.pyplot as plt
+    except ImportError:
+        matplotlib = False
 
     print("{0!s} checkDerivative {1!s}".format("=" * 20, "=" * 20))
     print(

--- a/tests/base/test_tests.py
+++ b/tests/base/test_tests.py
@@ -1,5 +1,6 @@
 import pytest
 import discretize
+import subprocess
 import numpy as np
 from discretize.utils import volume_average
 from discretize.tests import assert_isadjoint
@@ -64,3 +65,17 @@ class TestAssertIsAdjoint:
             complex_v=True,
             clinear=False,
         )
+
+
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason="Not Linux.")
+def test_import_time():
+    # Relevant for the CLI: How long does it take to import?
+    cmd = ["time", "-f", "%U", "python", "-c", "import discretize"]
+    # Run it twice, just in case.
+    subprocess.run(cmd)
+    subprocess.run(cmd)
+    # Capture it
+    out = subprocess.run(cmd, capture_output=True)
+
+    # Currently we check t < 0.5s.
+    assert float(out.stderr.decode("utf-8")[:-1]) < 0.5


### PR DESCRIPTION
# Improve loadtime

## Motivation

`matplotlib`, `vtk`, and `omf` are soft dependencies. However, if they are installed they are, currently, loaded whether or not the mixins are used. This adds significantly to the load overhead (>1s).

This might seem irrelevant. However, for packages that use discretize and provide a command-line interface, it means their application takes an unnecessary second extra to start up.

## Implementation

This commit
- makes them load lazily, only loading if they are actually used;
- implements a simple load-test, ensuring that the load-time of discretize is below a defined threshold (currently 0.5s).

## Other thoughts

The remaining big portions of import-time are:
1. `numpy`: Any package using discretize is most likely also using numpy, so that is a not an issue.
2. Some submodules of `scipy`: However, SciPy will, starting with `v1.9.0`, lazy-load its submodules, so this will fix itself down the road. We will just have to change how we access it (for the interested, see SciPy-PR #15230).

## Screenshots

```
python -Ximporttime -c "import discretize" 2> discretize.log
tuna discretize.log
```

Assuming you have `matplotlib`, `vtk`, and `omf` installed, this is the current load time: Loading discretize takes almost 1.5s, of which roughly 75% are spent on importing `matplotlib`, `vtk`, and `omf`, even if they are never used.

![main](https://user-images.githubusercontent.com/8020943/180619746-c1c61760-6fdf-49ad-a28f-d712438ad516.png)

This is how it looks with this PR: The load time is down from ~1.5s to ~0.33s.
![improved](https://user-images.githubusercontent.com/8020943/180619777-f448c010-6216-4eeb-8848-abbb88fa0761.png)
