### PR TITLE
zeros_outside

### DIFF
--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -1203,7 +1203,7 @@ class InterfaceMPL(object):
             U, V = self.reshape(v.reshape((self.nC, -1), order="F"), "CC", "CC", "M")
 
             tMi = self.__class__(h=[hx, hy], origin=np.r_[origin_x, origin_y])
-            P = self.get_interpolation_matrix(tMi.gridCC, "CC", zerosOutside=True)
+            P = self.get_interpolation_matrix(tMi.gridCC, "CC", zeros_outside=True)
 
             Ui = tMi.reshape(P * mkvc(U), "CC", "CC", "M")
             Vi = tMi.reshape(P * mkvc(V), "CC", "CC", "M")

--- a/tests/base/test_interpolation.py
+++ b/tests/base/test_interpolation.py
@@ -83,12 +83,12 @@ class TestOutliersInterp1D(unittest.TestCase):
     def test_outliers(self):
         M = discretize.TensorMesh([4])
         Q = M.getInterpolationMat(
-            np.array([[0], [0.126], [0.127]]), "CC", zerosOutside=True
+            np.array([[0], [0.126], [0.127]]), "CC", zeros_outside=True
         )
         x = np.arange(4) + 1
         self.assertTrue(np.linalg.norm(Q * x - np.r_[1, 1.004, 1.008]) < TOL)
         Q = M.getInterpolationMat(
-            np.array([[-1], [0.126], [0.127]]), "CC", zerosOutside=True
+            np.array([[-1], [0.126], [0.127]]), "CC", zeros_outside=True
         )
         self.assertTrue(np.linalg.norm(Q * x - np.r_[0, 1.004, 1.008]) < TOL)
 


### PR DESCRIPTION
Calling `plot_slice` with a `TensorMesh` currently results in the following warning:

```
/path/to/conda/env/lib/python3.9/site-packages/discretize/base/base_tensor_mesh.py:785: FutureWarning: The zerosOutside keyword argument has been deprecated, please use zeros_outside. This will be removed in discretize 1.0.0
  warnings.warn(
```

This is an internal problem, and should not happen.