### PR TITLE
Allow np.int_

### DIFF
--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -2089,15 +2089,14 @@ class InterfaceMPL(object):
         szSliceDim = len(self.h[normalInd])
         if ind is None:
             ind = szSliceDim // 2
+        if not isinstance(ind, (np.integer, int)):
+            raise ValueError("ind must be an integer")
 
         cc_tensor = [None, None, None]
         for i in range(3):
             cc_tensor[i] = np.cumsum(np.r_[self.origin[i], self.h[i]])
             cc_tensor[i] = (cc_tensor[i][1:] + cc_tensor[i][:-1]) * 0.5
         slice_loc = cc_tensor[normalInd][ind]
-
-        if not isinstance(ind, (np.integer, int)):
-            raise ValueError("ind must be an integer")
 
         # create a temporary TreeMesh with the slice through
         temp_mesh = discretize.TreeMesh(h2d, x2d)

--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -1310,7 +1310,7 @@ class InterfaceMPL(object):
         szSliceDim = self.shape_cells[dim_ind]  #: Size of the sliced dimension
         if ind is None:
             ind = szSliceDim // 2
-        if not isinstance(ind, (np.int_, int)):
+        if not isinstance(ind, (np.integer, int)):
             raise TypeError("ind must be an integer")
 
         def getIndSlice(v):
@@ -2096,7 +2096,7 @@ class InterfaceMPL(object):
             cc_tensor[i] = (cc_tensor[i][1:] + cc_tensor[i][:-1]) * 0.5
         slice_loc = cc_tensor[normalInd][ind]
 
-        if not isinstance(ind, (np.int_, int)):
+        if not isinstance(ind, (np.integer, int)):
             raise ValueError("ind must be an integer")
 
         # create a temporary TreeMesh with the slice through

--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -1310,7 +1310,7 @@ class InterfaceMPL(object):
         szSliceDim = self.shape_cells[dim_ind]  #: Size of the sliced dimension
         if ind is None:
             ind = szSliceDim // 2
-        if not isinstance(ind, int):
+        if not isinstance(ind, (np.int_, int)):
             raise TypeError("ind must be an integer")
 
         def getIndSlice(v):
@@ -2096,7 +2096,7 @@ class InterfaceMPL(object):
             cc_tensor[i] = (cc_tensor[i][1:] + cc_tensor[i][:-1]) * 0.5
         slice_loc = cc_tensor[normalInd][ind]
 
-        if not isinstance(ind, int):
+        if not isinstance(ind, (np.int_, int)):
             raise ValueError("ind must be an integer")
 
         # create a temporary TreeMesh with the slice through


### PR DESCRIPTION
We should allow numpy int's in the plotting, as matplotlib handels them just fine.

We could also clean up some of the code on the way, such as `int(np.argmi(...))` could be simplified with `np.argmin()`, as it returns a `np.int_`.

Currently it simply fails (for no good reasons). -- Thoughts? (Maybe we should not check at all, and let matplotlib fail if it doesn't work, duck typing.)