### PR TITLE
Dark mode theme for documentation

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -28,3 +28,38 @@ h3{
 .column > h3{
     font-family: "Raleway", Helvetica, Arial, sans-serif;
 }
+
+/* Dark theme tweaking
+Matplotlib images are in png and inverted while other output
+types are assumed to be normal images.
+*/
+html[data-theme=dark] img[src*='.png'] {
+    filter: invert(0.82) brightness(0.8) contrast(1.2);
+}
+
+html[data-theme=dark] img[src*='discretize-logo.png'] {
+    filter: invert(0.82) brightness(0.8) contrast(1.2) hue-rotate(180deg);
+}
+
+html[data-theme=dark] .MathJax_SVG *  {
+    fill: var(--pst-color-text-base);
+}
+
+html[data-theme=dark] #navbar-icon-links i.fa {
+    color: #a6a6a6;
+}
+html[data-theme=dark] #navbar-icon-links i.fab {
+    color: #a6a6a6;
+}
+html[data-theme=dark] #navbar-icon-links i.far {
+    color: #a6a6a6;
+}
+html[data-theme=dark] #navbar-icon-links i.fas {
+    color: #a6a6a6;
+}
+html[data-theme=dark] .navbar-nav>.active>.nav-link {
+    color: #FFFFFF!important;
+}
+html[data-theme=dark] #navbar-main {
+    background: #213a1b!important;
+}


### PR DESCRIPTION
This modifies the CSS sheet to do some fancy dark mode formatting of colors, and images to make things look nice in dark mode!
<img width="1323" alt="Screen Shot 2022-09-01 at 11 58 13 AM" src="https://user-images.githubusercontent.com/16258927/187991813-bb8b26d8-7c93-469d-a794-948ec74da739.png">
<img width="1301" alt="Screen Shot 2022-09-01 at 11 58 59 AM" src="https://user-images.githubusercontent.com/16258927/187991906-9ed5845c-90c4-4b29-b14a-e241f19eeb98.png">


