### PR TITLE
Diagonal tree balance

### DIFF
--- a/discretize/_extensions/tree.cpp
+++ b/discretize/_extensions/tree.cpp
@@ -784,7 +784,6 @@ void Cell::divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool fo
     }
 };
 
-
 void Cell::set_test_function(function func){
     test_func = func;
     if(!is_leaf()){
@@ -852,7 +851,6 @@ Tree::Tree(){
     nz = 0;
     n_dim = 0;
     max_level = 0;
-    diag_balance = false;
 };
 
 void Tree::set_dimension(int_t dim){
@@ -905,10 +903,6 @@ void Tree::set_levels(int_t l_x, int_t l_y, int_t l_z){
             }
         }
     }
-};
-
-void Tree::set_diag_balance(bool diagonal_balance){
-    diag_balance = diagonal_balance;
 };
 
 void Tree::set_xs(double *x, double *y, double *z){
@@ -984,7 +978,7 @@ void Tree::initialize_roots(){
     }
 }
 
-void Tree::insert_cell(double *new_center, int_t p_level){
+void Tree::insert_cell(double *new_center, int_t p_level, bool diagonal_balance){
     // find containing root
     int_t ix = 0;
     int_t iy = 0;
@@ -1000,10 +994,10 @@ void Tree::insert_cell(double *new_center, int_t p_level){
             ++iz;
         }
     }
-    roots[iz][iy][ix]->insert_cell(nodes, new_center, p_level, xs, ys, zs, diag_balance);
+    roots[iz][iy][ix]->insert_cell(nodes, new_center, p_level, xs, ys, zs, diagonal_balance);
 }
 
-void Tree::refine_function(function test_func){
+void Tree::refine_function(function test_func, bool diagonal_balance){
     //Must set the test_func of all of the roots before I can start dividing
     for(int_t iz=0; iz<nz_roots; ++iz)
         for(int_t iy=0; iy<ny_roots; ++iy)
@@ -1013,22 +1007,22 @@ void Tree::refine_function(function test_func){
     for(int_t iz=0; iz<nz_roots; ++iz)
         for(int_t iy=0; iy<ny_roots; ++iy)
             for(int_t ix=0; ix<nx_roots; ++ix)
-                roots[iz][iy][ix]->divide(nodes, xs, ys, zs, false, true, diag_balance);
+                roots[iz][iy][ix]->divide(nodes, xs, ys, zs, false, true, diagonal_balance);
 };
 
-void Tree::refine_box(double* x0, double* x1, int_t p_level){
+void Tree::refine_box(double* x0, double* x1, int_t p_level, bool diagonal_balance){
     for(int_t iz=0; iz<nz_roots; ++iz)
         for(int_t iy=0; iy<ny_roots; ++iy)
             for(int_t ix=0; ix<nx_roots; ++ix)
-                roots[iz][iy][ix]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, false, diag_balance);
+                roots[iz][iy][ix]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, false, diagonal_balance);
 };
 
-void Tree::refine_ball(double* center, double r, int_t p_level){
+void Tree::refine_ball(double* center, double r, int_t p_level, bool diagonal_balance){
     double r2 = r*r;
     for(int_t iz=0; iz<nz_roots; ++iz)
         for(int_t iy=0; iy<ny_roots; ++iy)
             for(int_t ix=0; ix<nx_roots; ++ix)
-                roots[iz][iy][ix]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
+                roots[iz][iy][ix]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diagonal_balance);
 };
 
 void Tree::finalize_lists(){

--- a/discretize/_extensions/tree.cpp
+++ b/discretize/_extensions/tree.cpp
@@ -509,14 +509,14 @@ void Cell::divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool fo
             if(diag_balance){
                 Cell *neighbor;
                 if (neighbors[0] != NULL){
-                    // WS
+                    // -x-y
                     if (neighbors[2] != NULL){
                         neighbor = neighbors[0]->neighbors[2];
                         if(neighbor->level < level){
                             neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
                         }
                     }
-                    // WN
+                    // -x+y
                     if (neighbors[3] != NULL){
                         neighbor = neighbors[0]->neighbors[3];
                         if(neighbor->level < level){
@@ -525,18 +525,138 @@ void Cell::divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool fo
                     }
                 }
                 if (neighbors[1] != NULL){
-                    // ES
+                    // +x-y
                     if (neighbors[2] != NULL){
                         neighbor = neighbors[1]->neighbors[2];
                         if(neighbor->level < level){
                             neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
                         }
                     }
-                    // EN
+                    // +x+y
                     if (neighbors[3] != NULL){
                         neighbor = neighbors[1]->neighbors[3];
                         if(neighbor->level < level){
                             neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                        }
+                    }
+                }
+                if(n_dim == 3){
+                    // -z
+                    if (neighbors[4] != NULL){
+                        if (neighbors[0] != NULL){
+                            // -z-x
+                            neighbor = neighbors[4]->neighbors[0];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
+                            // -z-x-y
+                            if (neighbors[2] != NULL){
+                                neighbor = neighbors[4]->neighbors[0]->neighbors[2];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                            // -z-x+y
+                            if (neighbors[3] != NULL){
+                                neighbor = neighbors[4]->neighbors[0]->neighbors[3];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                        }
+                        if (neighbors[1] != NULL){
+                            // -z+x
+                            neighbor = neighbors[4]->neighbors[1];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
+                            // -z+x-y
+                            if (neighbors[2] != NULL){
+                                neighbor = neighbors[4]->neighbors[1]->neighbors[2];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                            // -z+x+y
+                            if (neighbors[3] != NULL){
+                                neighbor = neighbors[4]->neighbors[1]->neighbors[3];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                        }
+                        if (neighbors[2] != NULL){
+                            // -z-y
+                            neighbor = neighbors[4]->neighbors[2];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
+                        }
+                        if (neighbors[3] != NULL){
+                            // -z+y
+                            neighbor = neighbors[4]->neighbors[3];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
+                        }
+                    }
+                    // +z
+                    if (neighbors[5] != NULL){
+                        if (neighbors[0] != NULL){
+                            // +z-x
+                            neighbor = neighbors[5]->neighbors[0];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
+                            // +z-x-y
+                            if (neighbors[2] != NULL){
+                                neighbor = neighbors[5]->neighbors[0]->neighbors[2];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                            // +z-x+y
+                            if (neighbors[3] != NULL){
+                                neighbor = neighbors[5]->neighbors[0]->neighbors[3];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                        }
+                        if (neighbors[1] != NULL){
+                            // +z+x
+                            neighbor = neighbors[5]->neighbors[1];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
+                            // +z+x-y
+                            if (neighbors[2] != NULL){
+                                neighbor = neighbors[5]->neighbors[1]->neighbors[2];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                            // +z+x+y
+                            if (neighbors[3] != NULL){
+                                neighbor = neighbors[5]->neighbors[1]->neighbors[3];
+                                if(neighbor->level < level){
+                                    neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                                }
+                            }
+                        }
+                        if (neighbors[2] != NULL){
+                            // +z-y
+                            neighbor = neighbors[5]->neighbors[2];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
+                        }
+                        if (neighbors[3] != NULL){
+                            // +z+y
+                            neighbor = neighbors[5]->neighbors[3];
+                            if(neighbor->level < level){
+                                neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                            }
                         }
                     }
                 }

--- a/discretize/_extensions/tree.cpp
+++ b/discretize/_extensions/tree.cpp
@@ -375,22 +375,22 @@ void Cell::shift_centers(double *shift){
     }
 }
 
-void Cell::insert_cell(node_map_t& nodes, double *new_cell, int_t p_level, double *xs, double *ys, double *zs){
+void Cell::insert_cell(node_map_t& nodes, double *new_cell, int_t p_level, double *xs, double *ys, double *zs, bool diag_balance){
     //Inserts a cell at min(max_level,p_level) that contains the given point
     if(p_level > level){
         // Need to go look in children,
         // Need to spawn children if i don't have any...
         if(is_leaf()){
-            divide(nodes, xs, ys, zs, true);
+            divide(nodes, xs, ys, zs, true, true, diag_balance);
         }
         int ix = new_cell[0] > children[0]->points[3]->location[0];
         int iy = new_cell[1] > children[0]->points[3]->location[1];
         int iz = n_dim>2 && new_cell[2]>children[0]->points[7]->location[2];
-        children[ix + 2*iy + 4*iz]->insert_cell(nodes, new_cell, p_level, xs, ys, zs);
+        children[ix + 2*iy + 4*iz]->insert_cell(nodes, new_cell, p_level, xs, ys, zs, diag_balance);
     }
 };
 
-void Cell::refine_ball(node_map_t& nodes, double* center, double r2, int_t p_level, double *xs, double *ys, double* zs){
+void Cell::refine_ball(node_map_t& nodes, double* center, double r2, int_t p_level, double *xs, double *ys, double* zs, bool diag_balance){
     // early exit if my level is higher than or equal to target
     if (level >= p_level || level == max_level){
         return;
@@ -415,22 +415,22 @@ void Cell::refine_ball(node_map_t& nodes, double* center, double r2, int_t p_lev
     }
     // if I intersect cell, I will need to be divided (if I'm not already)
     if(is_leaf()){
-        divide(nodes, xs, ys, zs, true);
+        divide(nodes, xs, ys, zs, true, true, diag_balance);
     }
     // recurse into children
-    children[0]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
-    children[1]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
-    children[2]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
-    children[3]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
+    children[0]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
+    children[1]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
+    children[2]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
+    children[3]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
     if (n_dim > 2){
-        children[4]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
-        children[5]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
-        children[6]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
-        children[7]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
+        children[4]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
+        children[5]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
+        children[6]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
+        children[7]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
     }
 }
 
-void Cell::refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, double *xs, double *ys, double* zs, bool enclosed){
+void Cell::refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, double *xs, double *ys, double* zs, bool enclosed, bool diag_balance){
     // early exit if my level is higher than target
     if (level >= p_level || level == max_level){
         return;
@@ -460,22 +460,22 @@ void Cell::refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, 
     }
     // Will only be here if I intersect the box
     if(is_leaf()){
-        divide(nodes, xs, ys, zs, true);
+        divide(nodes, xs, ys, zs, true, true, diag_balance);
     }
     // recurse into children
-    children[0]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
-    children[1]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
-    children[2]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
-    children[3]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
+    children[0]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
+    children[1]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
+    children[2]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
+    children[3]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
     if (n_dim > 2){
-        children[4]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
-        children[5]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
-        children[6]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
-        children[7]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed);
+        children[4]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
+        children[5]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
+        children[6]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
+        children[7]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, enclosed, diag_balance);
     }
 }
 
-void Cell::divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool force, bool balance){
+void Cell::divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool force, bool balance, bool diag_balance){
     bool do_splitting = false;
     if(level == max_level){
         do_splitting = false;
@@ -502,7 +502,42 @@ void Cell::divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool fo
             if(balance){
                 for(int_t i = 0; i < 2*n_dim; ++i){
                     if(neighbors[i] != NULL && neighbors[i]->level < level){
-                        neighbors[i]->divide(nodes, xs, ys, zs, true);
+                        neighbors[i]->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                    }
+                }
+            }
+            if(diag_balance){
+                Cell *neighbor;
+                if (neighbors[0] != NULL){
+                    // WS
+                    if (neighbors[2] != NULL){
+                        neighbor = neighbors[0]->neighbors[2];
+                        if(neighbor->level < level){
+                            neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                        }
+                    }
+                    // WN
+                    if (neighbors[3] != NULL){
+                        neighbor = neighbors[0]->neighbors[3];
+                        if(neighbor->level < level){
+                            neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                        }
+                    }
+                }
+                if (neighbors[1] != NULL){
+                    // ES
+                    if (neighbors[2] != NULL){
+                        neighbor = neighbors[1]->neighbors[2];
+                        if(neighbor->level < level){
+                            neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                        }
+                    }
+                    // EN
+                    if (neighbors[3] != NULL){
+                        neighbor = neighbors[1]->neighbors[3];
+                        if(neighbor->level < level){
+                            neighbor->divide(nodes, xs, ys, zs, true, balance, diag_balance);
+                        }
                     }
                 }
             }
@@ -623,7 +658,7 @@ void Cell::divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool fo
     if(!force){
         if(!is_leaf()){
             for(int_t i = 0; i < (1<<n_dim); ++i){
-                children[i]->divide(nodes, xs, ys, zs);
+                children[i]->divide(nodes, xs, ys, zs, force, balance, diag_balance);
             }
         }
     }
@@ -697,6 +732,7 @@ Tree::Tree(){
     nz = 0;
     n_dim = 0;
     max_level = 0;
+    diag_balance = false;
 };
 
 void Tree::set_dimension(int_t dim){
@@ -749,6 +785,10 @@ void Tree::set_levels(int_t l_x, int_t l_y, int_t l_z){
             }
         }
     }
+};
+
+void Tree::set_diag_balance(bool diagonal_balance){
+    diag_balance = diagonal_balance;
 };
 
 void Tree::set_xs(double *x, double *y, double *z){
@@ -840,7 +880,7 @@ void Tree::insert_cell(double *new_center, int_t p_level){
             ++iz;
         }
     }
-    roots[iz][iy][ix]->insert_cell(nodes, new_center, p_level, xs, ys, zs);
+    roots[iz][iy][ix]->insert_cell(nodes, new_center, p_level, xs, ys, zs, diag_balance);
 }
 
 void Tree::refine_function(function test_func){
@@ -853,14 +893,14 @@ void Tree::refine_function(function test_func){
     for(int_t iz=0; iz<nz_roots; ++iz)
         for(int_t iy=0; iy<ny_roots; ++iy)
             for(int_t ix=0; ix<nx_roots; ++ix)
-                roots[iz][iy][ix]->divide(nodes, xs, ys, zs);
+                roots[iz][iy][ix]->divide(nodes, xs, ys, zs, false, true, diag_balance);
 };
 
 void Tree::refine_box(double* x0, double* x1, int_t p_level){
     for(int_t iz=0; iz<nz_roots; ++iz)
         for(int_t iy=0; iy<ny_roots; ++iy)
             for(int_t ix=0; ix<nx_roots; ++ix)
-                roots[iz][iy][ix]->refine_box(nodes, x0, x1, p_level, xs, ys, zs);
+                roots[iz][iy][ix]->refine_box(nodes, x0, x1, p_level, xs, ys, zs, false, diag_balance);
 };
 
 void Tree::refine_ball(double* center, double r, int_t p_level){
@@ -868,7 +908,7 @@ void Tree::refine_ball(double* center, double r, int_t p_level){
     for(int_t iz=0; iz<nz_roots; ++iz)
         for(int_t iy=0; iy<ny_roots; ++iy)
             for(int_t ix=0; ix<nx_roots; ++ix)
-                roots[iz][iy][ix]->refine_ball(nodes, center, r2, p_level, xs, ys, zs);
+                roots[iz][iy][ix]->refine_ball(nodes, center, r2, p_level, xs, ys, zs, diag_balance);
 };
 
 void Tree::finalize_lists(){

--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -120,15 +120,15 @@ class Cell{
 
     bool inline is_leaf(){ return children[0]==NULL;};
     void spawn(node_map_t& nodes, Cell *kids[8], double* xs, double *ys, double *zs);
-    void divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool force=false, bool balance=true);
+    void divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool force=false, bool balance=true, bool diag_balance=false);
     void set_neighbor(Cell* other, int_t direction);
     void set_test_function(function func);
     void build_cell_vector(cell_vec_t& cells);
     void find_overlapping_cells(int_vec_t& cells, double xm, double xp, double ym, double yp, double zm, double zp);
 
-    void insert_cell(node_map_t &nodes, double *new_center, int_t p_level, double* xs, double *ys, double *zs);
-    void refine_ball(node_map_t& nodes, double* center, double r2, int_t p_level, double *xs, double *ys, double* zs);
-    void refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, double *xs, double *ys, double* zs, bool enclosed=false);
+    void insert_cell(node_map_t &nodes, double *new_center, int_t p_level, double* xs, double *ys, double *zs, bool diag_balance=false);
+    void refine_ball(node_map_t& nodes, double* center, double r2, int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false);
+    void refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, double *xs, double *ys, double* zs, bool enclosed=false, bool diag_balance=false);
 
     Cell* containing_cell(double, double, double);
     void shift_centers(double * shift);
@@ -144,6 +144,7 @@ class Tree{
     double *xs;
     double *ys;
     double *zs;
+    bool diag_balance;
 
     std::vector<Cell *> cells;
     node_map_t nodes;
@@ -158,6 +159,7 @@ class Tree{
 
     void set_dimension(int_t dim);
     void set_levels(int_t l_x, int_t l_y, int_t l_z);
+    void set_diag_balance(bool diagonal_balance);
     void set_xs(double *x , double *y, double *z);
     void initialize_roots();
     void refine_function(function test_func);

--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -98,7 +98,6 @@ class Face{
         Face(Node& p1, Node& p2, Node& p3, Node& p4);
 };
 
-
 class Cell{
   public:
     int_t n_dim;
@@ -111,24 +110,23 @@ class Cell{
     long long int index; // non root parents will have a -1 value
     double location[3];
     double volume;
-    function test_func;
 
     Cell();
-    Cell(Node *pts[4], int_t ndim, int_t maxlevel, function func);
+    Cell(Node *pts[4], int_t ndim, int_t maxlevel);//, function func);
     Cell(Node *pts[4], Cell *parent);
     ~Cell();
 
     bool inline is_leaf(){ return children[0]==NULL;};
     void spawn(node_map_t& nodes, Cell *kids[8], double* xs, double *ys, double *zs);
-    void divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool force=false, bool balance=true, bool diag_balance=false);
+    void divide(node_map_t& nodes, double* xs, double* ys, double* zs, bool balance=true, bool diag_balance=false);
     void set_neighbor(Cell* other, int_t direction);
-    void set_test_function(function func);
     void build_cell_vector(cell_vec_t& cells);
     void find_overlapping_cells(int_vec_t& cells, double xm, double xp, double ym, double yp, double zm, double zp);
 
     void insert_cell(node_map_t &nodes, double *new_center, int_t p_level, double* xs, double *ys, double *zs, bool diag_balance=false);
     void refine_ball(node_map_t& nodes, double* center, double r2, int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false);
     void refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, double *xs, double *ys, double* zs, bool enclosed=false, bool diag_balance=false);
+    void refine_func(node_map_t& nodes, function test_func, double *xs, double *ys, double* zs, bool diag_balance=false);
 
     Cell* containing_cell(double, double, double);
     void shift_centers(double * shift);

--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -144,7 +144,6 @@ class Tree{
     double *xs;
     double *ys;
     double *zs;
-    bool diag_balance;
 
     std::vector<Cell *> cells;
     node_map_t nodes;
@@ -159,16 +158,15 @@ class Tree{
 
     void set_dimension(int_t dim);
     void set_levels(int_t l_x, int_t l_y, int_t l_z);
-    void set_diag_balance(bool diagonal_balance);
     void set_xs(double *x , double *y, double *z);
     void initialize_roots();
-    void refine_function(function test_func);
-    void refine_ball(double *center, double r, int_t p_level);
-    void refine_box(double* x0, double* x1, int_t p_level);
+    void refine_function(function test_func, bool diagonal_balance=false);
+    void refine_ball(double *center, double r, int_t p_level, bool diagonal_balance=false);
+    void refine_box(double* x0, double* x1, int_t p_level, bool diagonal_balance=false);
     void number();
     void finalize_lists();
 
-    void insert_cell(double *new_center, int_t p_level);
+    void insert_cell(double *new_center, int_t p_level, bool diagonal_balance=false);
 
     Cell* containing_cell(double, double, double);
     int_vec_t find_overlapping_cells(double xm, double xp, double ym, double yp, double zm, double zp);

--- a/discretize/_extensions/tree.pxd
+++ b/discretize/_extensions/tree.pxd
@@ -70,6 +70,7 @@ cdef extern from "tree.h":
     cdef cppclass Tree:
         int_t n_dim
         int_t max_level, nx, ny, nz
+        bool diag_balance
 
         vector[Cell *] cells
         node_map_t nodes
@@ -83,6 +84,7 @@ cdef extern from "tree.h":
 
         void set_dimension(int_t)
         void set_levels(int_t, int_t, int_t)
+        void set_diag_balance(bool)
         void set_xs(double*, double*, double*)
         void refine_function(PyWrapper *)
         void refine_ball(double*, double, int_t)

--- a/discretize/_extensions/tree.pxd
+++ b/discretize/_extensions/tree.pxd
@@ -70,7 +70,6 @@ cdef extern from "tree.h":
     cdef cppclass Tree:
         int_t n_dim
         int_t max_level, nx, ny, nz
-        bool diag_balance
 
         vector[Cell *] cells
         node_map_t nodes
@@ -84,14 +83,13 @@ cdef extern from "tree.h":
 
         void set_dimension(int_t)
         void set_levels(int_t, int_t, int_t)
-        void set_diag_balance(bool)
         void set_xs(double*, double*, double*)
-        void refine_function(PyWrapper *)
-        void refine_ball(double*, double, int_t)
-        void refine_box(double*, double*, int_t)
+        void refine_function(PyWrapper *, bool)
+        void refine_ball(double*, double, int_t, bool)
+        void refine_box(double*, double*, int_t, bool)
         void number()
         void initialize_roots()
-        void insert_cell(double *new_center, int_t p_level);
+        void insert_cell(double *new_center, int_t p_level, bool)
         void finalize_lists()
         Cell * containing_cell(double, double, double)
         vector[int_t] find_overlapping_cells(double xm, double xp, double ym, double yp, double zm, double zp)

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -5658,7 +5658,12 @@ cdef class _TreeMesh:
                                       zs[indArr[:, 2]]))
         else:
             points = np.column_stack((xs[indArr[:, 0]], ys[indArr[:, 1]]))
-        self.insert_cells(points, levels)
+        # Set diagonal balance as false. If the state itself came from a diagonally
+        # balanced tree, those cells will naturally be included in the state information
+        # itself (no need to re-enforce that balancing). This then also allows
+        # us to support reading in older TreeMesh that are not diagonally balanced when
+        # we switch the default to be a diagonally balanced tree.
+        self.insert_cells(points, levels, diagonal_balance=False)
 
     def __getitem__(self, key):
         if isinstance(key, slice):

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -5,6 +5,7 @@ cimport cython
 cimport numpy as np
 from libc.stdlib cimport malloc, free
 from libcpp.vector cimport vector
+from libcpp cimport bool
 from numpy.math cimport INFINITY
 
 from .tree cimport int_t, Tree as c_Tree, PyWrapper, Node, Edge, Face, Cell as c_Cell
@@ -337,7 +338,7 @@ cdef class _TreeMesh:
         self.wrapper = new PyWrapper()
         self.tree = new c_Tree()
 
-    def __init__(self, h, origin):
+    def __init__(self, h, origin, bool diagonal_balance=False):
         super().__init__(h=h, origin=origin)
         def is_pow2(num):
             return ((num & (num - 1)) == 0) and num != 0
@@ -378,6 +379,7 @@ cdef class _TreeMesh:
 
         self.tree.set_dimension(self._dim)
         self.tree.set_levels(self.ls[0], self.ls[1], self.ls[2])
+        self.tree.set_diag_balance(diagonal_balance)
         self.tree.set_xs(&self._xs[0], &self._ys[0], &self._zs[0])
         self.tree.initialize_roots()
         self._finalized = False

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -137,6 +137,10 @@ class TreeMesh(
           each axis is the first node location ('0'), in the center ('C') or the last
           node location ('N') (see Examples).
 
+    diagonal_balance : bool, optional
+        Whether to balance cells along the diagonal of the tree during construction.
+        This will effect all calls to refine the tree.
+
     Examples
     --------
     Here we generate a basic 2D tree mesh.
@@ -199,10 +203,10 @@ class TreeMesh(
     _items = {"h", "origin", "cell_state"}
 
     # inheriting stuff from BaseTensorMesh that isn't defined in _QuadTree
-    def __init__(self, h=None, origin=None, **kwargs):
+    def __init__(self, h=None, origin=None, diagonal_balance=False, **kwargs):
         if "x0" in kwargs:
             origin = kwargs.pop("x0")
-        super().__init__(h=h, origin=origin)
+        super().__init__(h=h, origin=origin, diagonal_balance=diagonal_balance)
 
         cell_state = kwargs.pop("cell_state", None)
         cell_indexes = kwargs.pop("cell_indexes", None)

--- a/tests/tree/test_tree_balancing.py
+++ b/tests/tree/test_tree_balancing.py
@@ -1,0 +1,127 @@
+import discretize
+import numpy as np
+
+
+def check_for_diag_unbalance(mesh):
+    avg = mesh.average_node_to_cell.T.tocsr()
+    bad_nodes = []
+    for i in range(mesh.n_nodes):
+        cells_around_node = avg[i, :].indices
+        levels = np.atleast_1d(mesh.cell_levels_by_index(cells_around_node))
+        level_diff = max(levels)-min(levels)
+        if level_diff >= 2:
+            bad_nodes.append(i)
+    bad_nodes = np.asarray(bad_nodes)
+    return bad_nodes
+
+
+def test_insert_cells_2D():
+    mesh1 = discretize.TreeMesh([64, 64])
+    mesh1.insert_cells([0.09, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.09, 0.91], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.91], -1)
+
+    bad_nodes = check_for_diag_unbalance(mesh1)
+    assert len(bad_nodes) == 8
+
+    mesh2 = discretize.TreeMesh([64, 64], diagonal_balance=True)
+    mesh2.insert_cells([0.09, 0.09], -1, finalize=False)
+    mesh2.insert_cells([0.09, 0.91], -1, finalize=False)
+    mesh2.insert_cells([0.91, 0.09], -1, finalize=False)
+    mesh2.insert_cells([0.91, 0.91], -1)
+
+    bad_nodes = check_for_diag_unbalance(mesh2)
+    assert len(bad_nodes) == 0
+
+
+def test_insert_cells_3D():
+    mesh1 = discretize.TreeMesh([64, 64, 64])
+    mesh1.insert_cells([0.09, 0.09, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.09, 0.91, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.09, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.91, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.09, 0.09, 0.91], -1, finalize=False)
+    mesh1.insert_cells([0.09, 0.91, 0.91], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.09, 0.91], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.91, 0.91], -1)
+
+    bad_nodes = check_for_diag_unbalance(mesh1)
+    assert len(bad_nodes) == 64
+
+    mesh2 = discretize.TreeMesh([64, 64, 64], diagonal_balance=True)
+    mesh2.insert_cells([0.09, 0.09, 0.09], -1, finalize=False)
+    mesh2.insert_cells([0.09, 0.91, 0.09], -1, finalize=False)
+    mesh2.insert_cells([0.91, 0.09, 0.09], -1, finalize=False)
+    mesh2.insert_cells([0.91, 0.91, 0.09], -1, finalize=False)
+    mesh2.insert_cells([0.09, 0.09, 0.91], -1, finalize=False)
+    mesh2.insert_cells([0.09, 0.91, 0.91], -1, finalize=False)
+    mesh2.insert_cells([0.91, 0.09, 0.91], -1, finalize=False)
+    mesh2.insert_cells([0.91, 0.91, 0.91], -1)
+
+    bad_nodes = check_for_diag_unbalance(mesh2)
+    assert len(bad_nodes) == 0
+
+
+def test_refine():
+    mesh1 = discretize.TreeMesh([64, 64])
+
+    def refine(cell):
+        if np.sqrt(((np.r_[cell.center] - 0.5) ** 2).sum()) < 0.2:
+            return 5
+        return 2
+
+    mesh1.refine(refine)
+    bad_nodes = check_for_diag_unbalance(mesh1)
+
+    assert len(bad_nodes) == 4
+
+    mesh2 = discretize.TreeMesh([64, 64], diagonal_balance=True)
+    mesh2.refine(refine)
+    bad_nodes = check_for_diag_unbalance(mesh2)
+
+    assert len(bad_nodes) == 0
+
+
+def test_refine_box():
+    mesh1 = discretize.TreeMesh([64, 64])
+    mesh1.refine_box([0.4, 0.4], [0.6, 0.6], -1)
+    bad_nodes = check_for_diag_unbalance(mesh1)
+
+    assert len(bad_nodes) == 8
+
+    mesh2 = discretize.TreeMesh([64, 64], diagonal_balance=True)
+    mesh2.refine_box([0.4, 0.4], [0.6, 0.6], -1)
+    bad_nodes = check_for_diag_unbalance(mesh2)
+
+    assert len(bad_nodes) == 0
+
+
+def test_refine_ball():
+    mesh1 = discretize.TreeMesh([64, 64])
+    mesh1.refine_ball([0.5, 0.5], [0.1], -1)
+    bad_nodes = check_for_diag_unbalance(mesh1)
+
+    assert len(bad_nodes) == 12
+
+    mesh2 = discretize.TreeMesh([64, 64], diagonal_balance=True)
+    mesh2.refine_ball([0.5, 0.5], [0.1], -1)
+    bad_nodes = check_for_diag_unbalance(mesh2)
+
+    assert len(bad_nodes) == 0
+
+
+def test_balance_out_unbalance_in():
+    mesh1 = discretize.TreeMesh([64, 64], diagonal_balance=True)
+    mesh1.insert_cells([0.09, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.09, 0.91], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.09], -1, finalize=False)
+    mesh1.insert_cells([0.91, 0.91], -1)
+
+    bad_nodes = check_for_diag_unbalance(mesh1)
+    assert len(bad_nodes) == 0
+
+    srl = mesh1.to_dict()
+    mesh2 = discretize.TreeMesh.deserialize(srl)
+
+    assert mesh1.equals(mesh2)


### PR DESCRIPTION
This adds support to build tree meshes that are balanced along diagonals in addition to along axis directions.

This is equivalent to the types of meshes that the UBC-GIF codes create.

Without diagonal balancing:
![image](https://user-images.githubusercontent.com/16258927/200681052-a321f9ff-52e7-4bd8-873b-946b549aae6b.png)

With diagonal balancing:
![image](https://user-images.githubusercontent.com/16258927/200681082-f7b2c33f-690c-4b0a-9d3c-a0895af34fdd.png)

