### PR TITLE
More tree refine functions

### DIFF
--- a/discretize/Tests/__init__.py
+++ b/discretize/Tests/__init__.py
@@ -3,4 +3,6 @@ from discretize.utils.code_utils import deprecate_module
 
 # note this needs to be a module with an __init__ so we can avoid name clash
 # with tests.py in the discretize directory on systems that are agnostic to Case.
-deprecate_module("discretize.Tests", "discretize.tests", removal_version="1.0.0", future_warn=True)
+deprecate_module(
+    "discretize.Tests", "discretize.tests", removal_version="1.0.0", future_warn=True
+)

--- a/discretize/View.py
+++ b/discretize/View.py
@@ -1,7 +1,10 @@
 from discretize.utils.code_utils import deprecate_module
 
 deprecate_module(
-    "discretize.View", "discretize.mixins.mpl_mod", removal_version="1.0.0", future_warn=True
+    "discretize.View",
+    "discretize.mixins.mpl_mod",
+    removal_version="1.0.0",
+    future_warn=True,
 )
 try:
     from discretize.mixins.mpl_mod import Slicer

--- a/discretize/__init__.py
+++ b/discretize/__init__.py
@@ -76,4 +76,5 @@ except ImportError:
     # warning here, but this case *should* be rare. discretize should be
     # installed properly!
     from datetime import datetime
-    __version__ = 'unknown-'+datetime.today().strftime('%Y%m%d')
+
+    __version__ = "unknown-" + datetime.today().strftime("%Y%m%d")

--- a/discretize/_extensions/tree.cpp
+++ b/discretize/_extensions/tree.cpp
@@ -562,15 +562,15 @@ void Cell::refine_triangle(
         }
     }
     // first do the 3 edge cross tests that apply in 2D and 3D
-    std::pair<double, double> res;
 
     // edge 0 cross z_hat
     //p0 = e0[1] * v0[0] - e0[0] * v0[1];
     p1 = e0[1] * v1[0] - e0[0] * v1[1];
     p2 = e0[1] * v2[0] - e0[0] * v2[1];
-    res = std::minmax({p1, p2});
+    pmin = std::min(p1, p2);
+    pmax = std::max(p1, p2);
     rad = std::abs(e0[1]) * half[0] + std::abs(e0[0]) * half[1];
-    if (res.first > rad || res.second < -rad){
+    if (pmin > rad || pmax < -rad){
         return;
     }
 
@@ -578,9 +578,10 @@ void Cell::refine_triangle(
     p0 = e1[1] * v0[0] - e1[0] * v0[1];
     p1 = e1[1] * v1[0] - e1[0] * v1[1];
     //p2 = e1[1] * v2[0] - e1[0] * v2[1];
-    res = std::minmax({p0, p1});
+    pmin = std::min(p0, p1);
+    pmax = std::max(p0, p1);
     rad = std::abs(e1[1]) * half[0] + std::abs(e1[0]) * half[1];
-    if (res.first > rad || res.second < -rad){
+    if (pmin > rad || pmax < -rad){
         return;
     }
 
@@ -588,9 +589,10 @@ void Cell::refine_triangle(
     //p0 = e2[1] * v0[0] - e2[0] * v0[1];
     p1 = e2[1] * v1[0] - e2[0] * v1[1];
     p2 = e2[1] * v2[0] - e2[0] * v2[1];
-    res = std::minmax({p1, p2});
+    pmin = std::min(p1, p2);
+    pmax = std::max(p1, p2);
     rad = std::abs(e2[1]) * half[0] + std::abs(e2[0]) * half[1];
-    if (res.first > rad || res.second < -rad){
+    if (pmin > rad || pmax < -rad){
         return;
     }
 
@@ -599,54 +601,60 @@ void Cell::refine_triangle(
         p0 = e0[2] * v0[1] - e0[1] * v0[2];
         //p1 = e0[2] * v1[1] - e0[1] * v1[2];
         p2 = e0[2] * v2[1] - e0[1] * v2[2];
-        res = std::minmax({p0, p2});
+        pmin = std::min(p0, p2);
+        pmax = std::max(p0, p2);
         rad = std::abs(e0[2]) * half[1] + std::abs(e0[1]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
         // edge 0 cross y_hat
         p0 = -e0[2] * v0[0] + e0[0] * v0[2];
         //p1 = -e0[2] * v1[0] + e0[0] * v1[2];
         p2 = -e0[2] * v2[0] + e0[0] * v2[2];
-        res = std::minmax({p0, p2});
+        pmin = std::min(p0, p2);
+        pmax = std::max(p0, p2);
         rad = std::abs(e0[2]) * half[0] + std::abs(e0[0]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
         // edge 1 cross x_hat
         p0 = e1[2] * v0[1] - e1[1] * v0[2];
         //p1 = e1[2] * v1[1] - e1[1] * v1[2];
         p2 = e1[2] * v2[1] - e1[1] * v2[2];
-        res = std::minmax({p0, p2});
+        pmin = std::min(p0, p2);
+        pmax = std::max(p0, p2);
         rad = std::abs(e1[2]) * half[1] + std::abs(e1[1]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
         // edge 1 cross y_hat
         p0 = -e1[2] * v0[0] + e1[0] * v0[2];
         //p1 = -e1[2] * v1[0] + e1[0] * v1[2];
         p2 = -e1[2] * v2[0] + e1[0] * v2[2];
-        res = std::minmax({p0, p2});
+        pmin = std::min(p0, p2);
+        pmax = std::max(p0, p2);
         rad = std::abs(e1[2]) * half[0] + std::abs(e1[0]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
         // edge 2 cross x_hat
         p0 = e2[2] * v0[1] - e2[1] * v0[2];
         p1 = e2[2] * v1[1] - e2[1] * v1[2];
         //p2 = e2[2] * v2[1] - e2[1] * v2[2];
-        res = std::minmax({p0, p1});
+        pmin = std::min(p0, p1);
+        pmax = std::max(p0, p1);
         rad = std::abs(e2[2]) * half[1] + std::abs(e2[1]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
         // edge 2 cross y_hat
         p0 = -e2[2] * v0[0] + e2[0] * v0[2];
         p1 = -e2[2] * v1[0] + e2[0] * v1[2];
         //p2 = -e2[2] * v2[0] + e2[0] * v2[2];
-        res = std::minmax({p0, p1});
+        pmin = std::min(p0, p1);
+        pmax = std::max(p0, p1);
         rad = std::abs(e2[2]) * half[0] + std::abs(e2[0]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
 
@@ -692,18 +700,17 @@ void Cell::refine_tetra(
     }
     // then check to see if I intersect the segment
     double v0[3], v1[3], v2[3], v3[3], half[3];
-    double vmin, vmax;
     double p0, p1, p2, p3, pmin, pmax, rad;
-    std::pair<double, double> res;
     for(int_t i=0; i < n_dim; ++i){
         v0[i] = x0[i] - location[i];
         v1[i] = x1[i] - location[i];
         v2[i] = x2[i] - location[i];
         v3[i] = x3[i] - location[i];
         half[i] = location[i] - points[0]->location[i];
-        res = std::minmax({v0[i], v1[i], v2[i], v3[i]});
+        pmin = std::min(std::min(std::min(v0[i], v1[i]), v2[i]), v3[i]);
+        pmax = std::max(std::max(std::max(v0[i], v1[i]), v2[i]), v3[i]);
         // Bounding box check
-        if (vmin > half[i] || vmax < -half[i]){
+        if (pmin > half[i] || pmax < -half[i]){
             return;
         }
     }
@@ -716,9 +723,10 @@ void Cell::refine_tetra(
         p1 = edge_tans[i][2] * v1[1] - edge_tans[i][1] * v1[2];
         p2 = edge_tans[i][2] * v2[1] - edge_tans[i][1] * v2[2];
         p3 = edge_tans[i][2] * v3[1] - edge_tans[i][1] * v3[2];
-        res = std::minmax({p0, p1, p2, p3});
+        pmin = std::min(std::min(std::min(p0, p1), p2), p3);
+        pmax = std::max(std::max(std::max(p0, p1), p2), p3);
         rad = std::abs(edge_tans[i][2]) * half[1] + std::abs(edge_tans[i][1]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
 
@@ -726,9 +734,10 @@ void Cell::refine_tetra(
         p1 = -edge_tans[i][2] * v1[0] + edge_tans[i][0] * v1[2];
         p2 = -edge_tans[i][2] * v2[0] + edge_tans[i][0] * v2[2];
         p3 = -edge_tans[i][2] * v3[0] + edge_tans[i][0] * v3[2];
-        res = std::minmax({p0, p1, p2, p3});
+        pmin = std::min(std::min(std::min(p0, p1), p2), p3);
+        pmax = std::max(std::max(std::max(p0, p1), p2), p3);
         rad = std::abs(edge_tans[i][2]) * half[0] + std::abs(edge_tans[i][0]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
 
@@ -736,9 +745,10 @@ void Cell::refine_tetra(
         p1 = edge_tans[i][1] * v1[0] - edge_tans[i][0] * v1[1];
         p2 = edge_tans[i][1] * v2[0] - edge_tans[i][0] * v2[1];
         p3 = edge_tans[i][1] * v3[0] - edge_tans[i][0] * v3[1];
-        res = std::minmax({p0, p1, p2, p3});
+        pmin = std::min(std::min(std::min(p0, p1), p2), p3);
+        pmax = std::max(std::max(std::max(p0, p1), p2), p3);
         rad = std::abs(edge_tans[i][1]) * half[0] + std::abs(edge_tans[i][0]) * half[1];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
     }
@@ -749,9 +759,10 @@ void Cell::refine_tetra(
         p1 = axis[0] * v1[0] + axis[1] * v1[1] + axis[2] * v1[2];
         p2 = axis[0] * v2[0] + axis[1] * v2[1] + axis[2] * v2[2];
         p3 = axis[0] * v3[0] + axis[1] * v3[1] + axis[2] * v3[2];
-        res = std::minmax({p0, p1, p2, p3});
+        pmin = std::min(std::min(std::min(p0, p1), p2), p3);
+        pmax = std::max(std::max(std::max(p0, p1), p2), p3);
         rad = std::abs(axis[0]) * half[0] + std::abs(axis[1]) * half[1] + std::abs(axis[2]) * half[2];
-        if (res.first > rad || res.second < -rad){
+        if (pmin > rad || pmax < -rad){
             return;
         }
     }

--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -128,6 +128,10 @@ class Cell{
     void refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, double *xs, double *ys, double* zs, bool enclosed=false, bool diag_balance=false);
     void refine_line(node_map_t& nodes, double* x0, double* x1, double* diff_inv, int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false);
     void refine_func(node_map_t& nodes, function test_func, double *xs, double *ys, double* zs, bool diag_balance=false);
+    void refine_triangle(node_map_t& nodes,
+      double* x0, double* x1, double* x2, double* e0, double* e1, double* e2, double* t_norm,
+      int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false
+    );
 
     Cell* containing_cell(double, double, double);
     void shift_centers(double * shift);
@@ -163,6 +167,7 @@ class Tree{
     void refine_ball(double *center, double r, int_t p_level, bool diagonal_balance=false);
     void refine_box(double* x0, double* x1, int_t p_level, bool diagonal_balance=false);
     void refine_line(double* x0, double* x1, int_t p_level, bool diag_balance=false);
+    void refine_triangle(double* x0, double* x1, double* x2, int_t p_level, bool diag_balance=false);
     void number();
     void finalize_lists();
 

--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -132,6 +132,12 @@ class Cell{
       double* x0, double* x1, double* x2, double* e0, double* e1, double* e2, double* t_norm,
       int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false
     );
+    void refine_tetra(
+      node_map_t& nodes,
+      double* x0, double* x1, double* x2, double* x3,
+      double edge_tans[6][3], double face_normals[4][3],
+      int_t p_level, double *xs, double *ys, double* zs, bool diag_balance
+    );
 
     Cell* containing_cell(double, double, double);
     void shift_centers(double * shift);
@@ -167,7 +173,12 @@ class Tree{
     void refine_ball(double *center, double r, int_t p_level, bool diagonal_balance=false);
     void refine_box(double* x0, double* x1, int_t p_level, bool diagonal_balance=false);
     void refine_line(double* x0, double* x1, int_t p_level, bool diag_balance=false);
-    void refine_triangle(double* x0, double* x1, double* x2, int_t p_level, bool diag_balance=false);
+    void refine_triangle(
+        double* x0, double* x1, double* x2, int_t p_level, bool diag_balance=false
+    );
+    void refine_tetra(
+        double* x0, double* x1, double* x2, double* x3, int_t p_level, bool diag_balance=false
+    );
     void number();
     void finalize_lists();
 

--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -126,6 +126,7 @@ class Cell{
     void insert_cell(node_map_t &nodes, double *new_center, int_t p_level, double* xs, double *ys, double *zs, bool diag_balance=false);
     void refine_ball(node_map_t& nodes, double* center, double r2, int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false);
     void refine_box(node_map_t& nodes, double* x0, double* x1, int_t p_level, double *xs, double *ys, double* zs, bool enclosed=false, bool diag_balance=false);
+    void refine_line(node_map_t& nodes, double* x0, double* x1, double* diff_inv, int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false);
     void refine_func(node_map_t& nodes, function test_func, double *xs, double *ys, double* zs, bool diag_balance=false);
 
     Cell* containing_cell(double, double, double);
@@ -161,6 +162,7 @@ class Tree{
     void refine_function(function test_func, bool diagonal_balance=false);
     void refine_ball(double *center, double r, int_t p_level, bool diagonal_balance=false);
     void refine_box(double* x0, double* x1, int_t p_level, bool diagonal_balance=false);
+    void refine_line(double* x0, double* x1, int_t p_level, bool diag_balance=false);
     void number();
     void finalize_lists();
 

--- a/discretize/_extensions/tree.pxd
+++ b/discretize/_extensions/tree.pxd
@@ -88,6 +88,7 @@ cdef extern from "tree.h":
         void refine_ball(double*, double, int_t, bool)
         void refine_box(double*, double*, int_t, bool)
         void refine_line(double*, double*, int_t, bool)
+        void refine_triangle(double*, double*, double*, int_t, bool)
         void number()
         void initialize_roots()
         void insert_cell(double *new_center, int_t p_level, bool)

--- a/discretize/_extensions/tree.pxd
+++ b/discretize/_extensions/tree.pxd
@@ -87,6 +87,7 @@ cdef extern from "tree.h":
         void refine_function(PyWrapper *, bool)
         void refine_ball(double*, double, int_t, bool)
         void refine_box(double*, double*, int_t, bool)
+        void refine_line(double*, double*, int_t, bool)
         void number()
         void initialize_roots()
         void insert_cell(double *new_center, int_t p_level, bool)

--- a/discretize/_extensions/tree.pxd
+++ b/discretize/_extensions/tree.pxd
@@ -89,6 +89,7 @@ cdef extern from "tree.h":
         void refine_box(double*, double*, int_t, bool)
         void refine_line(double*, double*, int_t, bool)
         void refine_triangle(double*, double*, double*, int_t, bool)
+        void refine_tetra(double*, double*, double*, double*, int_t, bool)
         void number()
         void initialize_roots()
         void insert_cell(double *new_center, int_t p_level, bool)

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -827,6 +827,85 @@ cdef class _TreeMesh:
             self.finalize()
 
     @cython.cdivision(True)
+    def refine_tetrahedron(self, tetra, levels, finalize=True, diagonal_balance=None):
+        """Refines the :class:`~discretize.TreeMesh` along the tetrahedron to the desired level
+
+        Refines the TreeMesh by determining if a cell intersects the given triangle(s)
+        to the prescribed level(s).
+
+        Parameters
+        ----------
+        tetra : (N, dim+1, dim) array_like
+            The nodes of the tetrahedron(s).
+        levels : int or (N) array_like of int
+            The level to refine intersecting cells to.
+        finalize : bool, optional
+            Whether to finalize after refining
+        diagonal_balance : bool or None, optional
+            Whether to balance cells diagonally in the refinement, `None` implies using
+            the same setting used to instantiate the TreeMesh`.
+
+        Examples
+        --------
+        We create a simple mesh and refine the TreeMesh such that all cells that
+        intersect the line segment path are at the given levels.
+
+        >>> import discretize
+        >>> import matplotlib.pyplot as plt
+        >>> import matplotlib.patches as patches
+        >>> tree_mesh = discretize.TreeMesh([32, 32])
+        >>> tree_mesh.max_level
+        5
+
+        Next we define the points along the line and the level we want to refine to,
+        and refine the mesh.
+
+        >>> segments = np.array([[0.1, 0.3], [0.3, 0.9], [0.8, 0.9]])
+        >>> levels = 5
+        >>> tree_mesh.refine_line(segments, levels)
+
+        Now lets look at the mesh, and overlay the line on it to ensure it refined
+        where we wanted it to.
+
+        >>> ax = tree_mesh.plot_grid()
+        >>> ax.plot(*segments.T, color='C1')
+        >>> plt.show()
+
+        """
+        if self.dim == 2:
+            return self.refine_triangle(tetra, levels, finalize=finalize, diagonal_balance=diagonal_balance)
+        tetra = np.require(np.atleast_2d(tetra), dtype=np.float64, requirements="C")
+        if tetra.ndim == 2:
+            tetra = tetra[None, ...]
+        if tetra.shape[-1] != self.dim or tetra.shape[-2] != self.dim+1:
+            raise ValueError(f"tetra array must be (N, {self.dim+1}, {self.dim})")
+        cdef double[:, :, :] tris = tetra
+
+        levels = np.require(np.atleast_1d(levels), dtype=np.int32,
+                                    requirements='C')
+        cdef int n_triangles = tetra.shape[0];
+        if levels.shape[0] == 1:
+            levels = np.full(n_triangles, levels[0], dtype=np.int32)
+        if n_triangles != levels.shape[0]:
+            raise ValueError(f"inconsistent number of triangles {n_triangles} and levels {levels.shape[0]}")
+
+        cdef int[:] ls = levels
+
+        if diagonal_balance is None:
+            diagonal_balance = self._diagonal_balance
+        cdef bool diag_balance = diagonal_balance
+
+        cdef int l
+        cdef int max_level = self.max_level
+        for i in range(n_triangles):
+            l = ls[i]
+            if l < 0:
+                l = (max_level + 1) - (abs(l) % (max_level + 1))
+            self.tree.refine_tetra(&tris[i, 0, 0], &tris[i, 1, 0], &tris[i, 2, 0], &tris[i, 3, 0], l, diag_balance)
+        if finalize:
+            self.finalize()
+
+    @cython.cdivision(True)
     def insert_cells(self, points, levels, finalize=True, diagonal_balance=None):
         """Insert cells into the :class:`~discretize.TreeMesh` that contain given points
 

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -783,15 +783,16 @@ cdef class _TreeMesh:
         Next we define the points along the line and the level we want to refine to,
         and refine the mesh.
 
-        >>> segments = np.array([[0.1, 0.3], [0.3, 0.9], [0.8, 0.9]])
+        >>> triangle = [[0.14, 0.31], [0.32, 0.96], [0.23, 0.87]]
         >>> levels = 5
-        >>> tree_mesh.refine_line(segments, levels)
+        >>> tree_mesh.refine_triangle(triangle, levels)
 
         Now lets look at the mesh, and overlay the line on it to ensure it refined
         where we wanted it to.
 
         >>> ax = tree_mesh.plot_grid()
-        >>> ax.plot(*segments.T, color='C1')
+        >>> tri = patches.Polygon(triangle, fill=False)
+        >>> ax.add_patch(tri)
         >>> plt.show()
 
         """
@@ -853,22 +854,27 @@ cdef class _TreeMesh:
         >>> import discretize
         >>> import matplotlib.pyplot as plt
         >>> import matplotlib.patches as patches
-        >>> tree_mesh = discretize.TreeMesh([32, 32])
+        >>> tree_mesh = discretize.TreeMesh([32, 32, 32])
         >>> tree_mesh.max_level
         5
 
         Next we define the points along the line and the level we want to refine to,
         and refine the mesh.
 
-        >>> segments = np.array([[0.1, 0.3], [0.3, 0.9], [0.8, 0.9]])
+        >>> tetra = [
+        ...     [0.32, 0.21, 0.15],
+        ...     [0.82, 0.19, 0.34],
+        ...     [0.14, 0.82, 0.29],
+        ...     [0.32, 0.27, 0.83],
+        ... ]
         >>> levels = 5
-        >>> tree_mesh.refine_line(segments, levels)
+        >>> tree_mesh.refine_tetrahedron(tetra, levels)
 
-        Now lets look at the mesh, and overlay the line on it to ensure it refined
-        where we wanted it to.
+        Now lets look at the mesh, checking how the refine function proceeded.
 
-        >>> ax = tree_mesh.plot_grid()
-        >>> ax.plot(*segments.T, color='C1')
+        >>> levels = tree_mesh.cell_levels_by_index(np.arange(tree_mesh.n_cells))
+        >>> ax = plt.gca()
+        >>> tree_mesh.plot_slice(levels, normal='z', slice_loc=0.2, grid=True, ax=ax)
         >>> plt.show()
 
         """

--- a/discretize/base/base_mesh.py
+++ b/discretize/base/base_mesh.py
@@ -3,7 +3,11 @@ import warnings
 import os
 import json
 from scipy.spatial import KDTree
-from discretize.utils.code_utils import deprecate_property, deprecate_method, as_array_n_by_dim
+from discretize.utils.code_utils import (
+    deprecate_property,
+    deprecate_method,
+    as_array_n_by_dim,
+)
 
 
 class BaseMesh:
@@ -610,7 +614,9 @@ class BaseMesh:
         (n_boundary_faces, dim) numpy.ndarray of float
             Outward normal vectors of boundary faces
         """
-        raise NotImplementedError(f"boundary_face_outward_normals not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"boundary_face_outward_normals not implemented for {type(self)}"
+        )
 
     def project_face_vector(self, face_vectors):
         """Project vectors onto the faces of the mesh.
@@ -1206,7 +1212,9 @@ class BaseMesh:
 
         where `w` is defined on all faces, and `u_b` is defined on boundary faces.
         """
-        raise NotImplementedError(f"boundary_face_scalar_integral not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"boundary_face_scalar_integral not implemented for {type(self)}"
+        )
 
     @property
     def boundary_edge_vector_integral(self):
@@ -1240,7 +1248,9 @@ class BaseMesh:
         where `w` is defined on all edges, and `u_b` is all three components defined on
         boundary edges.
         """
-        raise NotImplementedError(f"boundary_edge_vector_integral not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"boundary_edge_vector_integral not implemented for {type(self)}"
+        )
 
     @property
     def boundary_node_vector_integral(self):
@@ -1268,7 +1278,9 @@ class BaseMesh:
         where `w` is defined on all nodes, and `u_b` is all three components defined on
         boundary nodes.
         """
-        raise NotImplementedError(f"boundary_node_vector_integral not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"boundary_node_vector_integral not implemented for {type(self)}"
+        )
 
     @property
     def nodal_laplacian(self):
@@ -1519,7 +1531,9 @@ class BaseMesh:
             >>> ax2.set_xlabel("Cell Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"stencil_cell_gradient not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"stencil_cell_gradient not implemented for {type(self)}"
+        )
 
     # Inner Products
     def get_face_inner_product(
@@ -1528,7 +1542,7 @@ class BaseMesh:
         invert_model=False,
         invert_matrix=False,
         do_fast=True,
-        **kwargs
+        **kwargs,
     ):
         r"""Generate the face inner product matrix or its inverse.
 
@@ -1699,7 +1713,9 @@ class BaseMesh:
             >>> ax3.set_title("M (full anisotropic)", fontsize=16)
             >>> plt.show()
         """
-        raise NotImplementedError(f"get_face_inner_product not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"get_face_inner_product not implemented for {type(self)}"
+        )
 
     def get_edge_inner_product(
         self,
@@ -1707,7 +1723,7 @@ class BaseMesh:
         invert_model=False,
         invert_matrix=False,
         do_fast=True,
-        **kwargs
+        **kwargs,
     ):
         r"""Generate the edge inner product matrix or its inverse.
 
@@ -1880,7 +1896,9 @@ class BaseMesh:
             >>> plt.show()
 
         """
-        raise NotImplementedError(f"get_edge_inner_product not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"get_edge_inner_product not implemented for {type(self)}"
+        )
 
     def get_face_inner_product_deriv(
         self, model, do_fast=True, invert_model=False, invert_matrix=False, **kwargs
@@ -2066,7 +2084,9 @@ class BaseMesh:
             >>> plt.show()
 
         """
-        raise NotImplementedError(f"get_face_inner_product_deriv not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"get_face_inner_product_deriv not implemented for {type(self)}"
+        )
 
     def get_edge_inner_product_deriv(
         self, model, do_fast=True, invert_model=False, invert_matrix=False, **kwargs
@@ -2250,7 +2270,9 @@ class BaseMesh:
             >>> ax2.set_ylabel("Edge Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"get_edge_inner_product_deriv not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"get_edge_inner_product_deriv not implemented for {type(self)}"
+        )
 
     # Averaging
     @property
@@ -2339,7 +2361,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Cell Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_face_to_cell not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_face_to_cell not implemented for {type(self)}"
+        )
 
     @property
     def average_face_to_cell_vector(self):
@@ -2442,7 +2466,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Cell Vector Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_face_to_cell_vector not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_face_to_cell_vector not implemented for {type(self)}"
+        )
 
     @property
     def average_cell_to_face(self):
@@ -2538,7 +2564,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Face Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_cell_to_face not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_cell_to_face not implemented for {type(self)}"
+        )
 
     @property
     def average_cell_vector_to_face(self):
@@ -2646,7 +2674,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Face Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_cell_vector_to_face not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_cell_vector_to_face not implemented for {type(self)}"
+        )
 
     @property
     def average_cell_to_edge(self):
@@ -2741,7 +2771,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Edge Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_cell_to_edge not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_cell_to_edge not implemented for {type(self)}"
+        )
 
     @property
     def average_edge_to_cell(self):
@@ -2828,7 +2860,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Cell Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_edge_to_cell not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_edge_to_cell not implemented for {type(self)}"
+        )
 
     @property
     def average_edge_to_cell_vector(self):
@@ -2930,7 +2964,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Cell Vector Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_edge_to_cell_vector not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_edge_to_cell_vector not implemented for {type(self)}"
+        )
 
     @property
     def average_edge_to_face_vector(self):
@@ -3024,7 +3060,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Face Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_edge_to_face_vector not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_edge_to_face_vector not implemented for {type(self)}"
+        )
 
     @property
     def average_node_to_cell(self):
@@ -3111,7 +3149,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Cell Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_node_to_cell not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_node_to_cell not implemented for {type(self)}"
+        )
 
     @property
     def average_node_to_edge(self):
@@ -3199,7 +3239,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Edge Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_node_to_edge not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_node_to_edge not implemented for {type(self)}"
+        )
 
     @property
     def average_node_to_face(self):
@@ -3287,7 +3329,9 @@ class BaseMesh:
             >>> ax1.set_ylabel("Face Index", fontsize=12)
             >>> plt.show()
         """
-        raise NotImplementedError(f"average_node_to_face not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"average_node_to_face not implemented for {type(self)}"
+        )
 
     @property
     def project_face_to_boundary_face(self):
@@ -3306,7 +3350,9 @@ class BaseMesh:
         scipy.sparse.csr_matrix
             (n_boundary_faces, n_faces) Projection matrix with shape
         """
-        raise NotImplementedError(f"project_face_to_boundary_face not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"project_face_to_boundary_face not implemented for {type(self)}"
+        )
 
     @property
     def project_edge_to_boundary_edge(self):
@@ -3325,7 +3371,9 @@ class BaseMesh:
         (n_boundary_edges, n_edges) scipy.sparse.csr_matrix
             Projection matrix with shape
         """
-        raise NotImplementedError(f"project_edge_to_boundary_edge not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"project_edge_to_boundary_edge not implemented for {type(self)}"
+        )
 
     @property
     def project_node_to_boundary_node(self):
@@ -3344,9 +3392,11 @@ class BaseMesh:
         (n_boundary_nodes, n_nodes) scipy.sparse.csr_matrix
             Projection matrix with shape
         """
-        raise NotImplementedError(f"project_node_to_boundary_node not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"project_node_to_boundary_node not implemented for {type(self)}"
+        )
 
-    def closest_points_index(self, locations, grid_loc='CC', discard=False):
+    def closest_points_index(self, locations, grid_loc="CC", discard=False):
         """Find the indicies for the nearest grid location for a set of points.
 
         Parameters
@@ -3400,7 +3450,7 @@ class BaseMesh:
         locations = as_array_n_by_dim(locations, self.dim)
 
         grid_loc = self._parse_location_type(grid_loc)
-        tree_name = f'_{grid_loc}_tree'
+        tree_name = f"_{grid_loc}_tree"
 
         tree = getattr(self, tree_name, None)
         if tree is None:
@@ -3429,7 +3479,6 @@ class BaseMesh:
             Cell indices that contain the points
         """
         raise NotImplementedError(f"point2index not implemented for {type(self)}")
-
 
     def get_interpolation_matrix(
         self, loc, location_type="cell_centers", zeros_outside=False, **kwargs
@@ -3529,7 +3578,9 @@ class BaseMesh:
             >>> ax3.set_title('Relative Error')
             >>> plt.show()
         """
-        raise NotImplementedError(f"get_interpolation_matrix not implemented for {type(self)}")
+        raise NotImplementedError(
+            f"get_interpolation_matrix not implemented for {type(self)}"
+        )
 
     def _parse_location_type(self, location_type):
         if len(location_type) == 0:
@@ -3555,16 +3606,29 @@ class BaseMesh:
             return location_type
 
     # DEPRECATED
-    normals = deprecate_property("face_normals", "normals", removal_version="1.0.0", future_warn=True)
-    tangents = deprecate_property("edge_tangents", "tangents", removal_version="1.0.0", future_warn=True)
+    normals = deprecate_property(
+        "face_normals", "normals", removal_version="1.0.0", future_warn=True
+    )
+    tangents = deprecate_property(
+        "edge_tangents", "tangents", removal_version="1.0.0", future_warn=True
+    )
     projectEdgeVector = deprecate_method(
-        "project_edge_vector", "projectEdgeVector", removal_version="1.0.0", future_warn=True
+        "project_edge_vector",
+        "projectEdgeVector",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     projectFaceVector = deprecate_method(
-        "project_face_vector", "projectFaceVector", removal_version="1.0.0", future_warn=True
+        "project_face_vector",
+        "projectFaceVector",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     getInterpolationMat = deprecate_method(
-        "get_interpolation_matrix", "getInterpolationMat", removal_version="1.0.0", future_warn=True
+        "get_interpolation_matrix",
+        "getInterpolationMat",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     nodalGrad = deprecate_property(
         "nodal_gradient", "nodalGrad", removal_version="1.0.0", future_warn=True
@@ -3572,26 +3636,42 @@ class BaseMesh:
     nodalLaplacian = deprecate_property(
         "nodal_laplacian", "nodalLaplacian", removal_version="1.0.0", future_warn=True
     )
-    faceDiv = deprecate_property("face_divergence", "faceDiv", removal_version="1.0.0", future_warn=True)
-    edgeCurl = deprecate_property("edge_curl", "edgeCurl", removal_version="1.0.0", future_warn=True)
+    faceDiv = deprecate_property(
+        "face_divergence", "faceDiv", removal_version="1.0.0", future_warn=True
+    )
+    edgeCurl = deprecate_property(
+        "edge_curl", "edgeCurl", removal_version="1.0.0", future_warn=True
+    )
     getFaceInnerProduct = deprecate_method(
-        "get_face_inner_product", "getFaceInnerProduct", removal_version="1.0.0", future_warn=True
+        "get_face_inner_product",
+        "getFaceInnerProduct",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     getEdgeInnerProduct = deprecate_method(
-        "get_edge_inner_product", "getEdgeInnerProduct", removal_version="1.0.0", future_warn=True
+        "get_edge_inner_product",
+        "getEdgeInnerProduct",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     getFaceInnerProductDeriv = deprecate_method(
         "get_face_inner_product_deriv",
         "getFaceInnerProductDeriv",
         removal_version="1.0.0",
-        future_warn=True
+        future_warn=True,
     )
     getEdgeInnerProductDeriv = deprecate_method(
         "get_edge_inner_product_deriv",
         "getEdgeInnerProductDeriv",
         removal_version="1.0.0",
-        future_warn=True
+        future_warn=True,
     )
-    vol = deprecate_property("cell_volumes", "vol", removal_version="1.0.0", future_warn=True)
-    area = deprecate_property("face_areas", "area", removal_version="1.0.0", future_warn=True)
-    edge = deprecate_property("edge_lengths", "edge", removal_version="1.0.0", future_warn=True)
+    vol = deprecate_property(
+        "cell_volumes", "vol", removal_version="1.0.0", future_warn=True
+    )
+    area = deprecate_property(
+        "face_areas", "area", removal_version="1.0.0", future_warn=True
+    )
+    edge = deprecate_property(
+        "edge_lengths", "edge", removal_version="1.0.0", future_warn=True
+    )

--- a/discretize/base/base_regular_mesh.py
+++ b/discretize/base/base_regular_mesh.py
@@ -31,6 +31,7 @@ class BaseRegularMesh(BaseMesh):
     reference_system : {'cartesian', 'cylindrical', 'spherical'}
         Can also be a shorthand version of these, e.g. {'car[t]', 'cy[l]', 'sph'}
     """
+
     _aliases = {
         **BaseMesh._aliases,
         "nEx": "n_edges_x",

--- a/discretize/base/base_tensor_mesh.py
+++ b/discretize/base/base_tensor_mesh.py
@@ -1061,9 +1061,15 @@ class BaseTensorMesh(BaseRegularMesh):
         )
         return None if self.dim < 3 else self.h[2]
 
-    vectorNx = deprecate_property("nodes_x", "vectorNx", removal_version="1.0.0", future_warn=True)
-    vectorNy = deprecate_property("nodes_y", "vectorNy", removal_version="1.0.0", future_warn=True)
-    vectorNz = deprecate_property("nodes_z", "vectorNz", removal_version="1.0.0", future_warn=True)
+    vectorNx = deprecate_property(
+        "nodes_x", "vectorNx", removal_version="1.0.0", future_warn=True
+    )
+    vectorNy = deprecate_property(
+        "nodes_y", "vectorNy", removal_version="1.0.0", future_warn=True
+    )
+    vectorNz = deprecate_property(
+        "nodes_z", "vectorNz", removal_version="1.0.0", future_warn=True
+    )
     vectorCCx = deprecate_property(
         "cell_centers_x", "vectorCCx", removal_version="1.0.0", future_warn=True
     )
@@ -1073,5 +1079,9 @@ class BaseTensorMesh(BaseRegularMesh):
     vectorCCz = deprecate_property(
         "cell_centers_z", "vectorCCz", removal_version="1.0.0", future_warn=True
     )
-    isInside = deprecate_method("is_inside", "isInside", removal_version="1.0.0", future_warn=True)
-    getTensor = deprecate_method("get_tensor", "getTensor", removal_version="1.0.0", future_warn=True)
+    isInside = deprecate_method(
+        "is_inside", "isInside", removal_version="1.0.0", future_warn=True
+    )
+    getTensor = deprecate_method(
+        "get_tensor", "getTensor", removal_version="1.0.0", future_warn=True
+    )

--- a/discretize/cylindrical_mesh.py
+++ b/discretize/cylindrical_mesh.py
@@ -950,7 +950,11 @@ class CylindricalMesh(
         if self.dim == 2:
             return np.r_[self._ishanging_edges_x, self._ishanging_edges_y]
         else:
-            return np.r_[self._ishanging_edges_x, self._ishanging_edges_y, self._ishanging_edges_z]
+            return np.r_[
+                self._ishanging_edges_x,
+                self._ishanging_edges_y,
+                self._ishanging_edges_z,
+            ]
 
     @property
     def _ishanging_edges_z(self):
@@ -1007,7 +1011,7 @@ class CylindricalMesh(
                 is_hanging[0] = True  # axis of symmetry nodes are hanging
                 is_hanging[0, 0] = False  # axis of symmetry nodes which are not hanging
                 is_hanging[:, -1] = True  # nodes at maximum theta that are duplicated
-                self._ishanging_nodes_bool = is_hanging.reshape(-1, order='F')
+                self._ishanging_nodes_bool = is_hanging.reshape(-1, order="F")
 
         return self._ishanging_nodes_bool
 
@@ -1166,9 +1170,7 @@ class CylindricalMesh(
         is_bz = is_bz.reshape(-1, order="F")
 
         is_b = np.r_[
-            is_br[~self._ishanging_faces_x],
-            is_bt[~self._ishanging_faces_y],
-            is_bz
+            is_br[~self._ishanging_faces_x], is_bt[~self._ishanging_faces_y], is_bz
         ]
         return is_b
 
@@ -1184,17 +1186,17 @@ class CylindricalMesh(
         # then n_cells_theta * n_cells_r, bottom faces,
         n1 = self.shape_cells[1] * self.shape_cells[2]
         n2 = self.shape_cells[0] * self.shape_cells[1]
-        normals[n1:n1+n2] *= -1
+        normals[n1 : n1 + n2] *= -1
         return normals
 
     @property
     def _is_boundary_node(self):
-        is_b = np.zeros(self._shape_total_nodes, dtype=bool, order='F')
+        is_b = np.zeros(self._shape_total_nodes, dtype=bool, order="F")
         # outward rs are boundary:
         is_b[-1] = True
         # top and bottom zs are boundary
         is_b[:, :, [0, -1]] = True
-        is_b = is_b.reshape(-1, order='F')
+        is_b = is_b.reshape(-1, order="F")
         is_b = is_b[~self._ishanging_nodes]
         return is_b
 
@@ -1205,15 +1207,15 @@ class CylindricalMesh(
     @property
     def _is_boundary_edge(self):
         # top and bottom radial edges are on the boundary
-        is_br = np.zeros(self._shape_total_edges_x, dtype=bool, order='F')
+        is_br = np.zeros(self._shape_total_edges_x, dtype=bool, order="F")
         is_br[:, :, [0, -1]] = True
-        is_br = is_br.reshape(-1, order='F')
-        is_bt = np.zeros(self._shape_total_edges_y, dtype=bool, order='F')
+        is_br = is_br.reshape(-1, order="F")
+        is_bt = np.zeros(self._shape_total_edges_y, dtype=bool, order="F")
         # outside theta edges are on boundary
         is_bt[-1] = True
         # top and bottom theta edges are on boundary
         is_bt[:, :, [0, -1]] = True
-        is_bt = is_bt.reshape(-1, order='F')
+        is_bt = is_bt.reshape(-1, order="F")
         # outside z edges are on boundaries
         is_bz = np.zeros(self._shape_total_edges_z, dtype=bool, order="F")
         is_bz[-1] = True
@@ -1222,7 +1224,7 @@ class CylindricalMesh(
         is_b = np.r_[
             is_br[~self._ishanging_edges_x],
             is_bt[~self._ishanging_edges_y],
-            is_bz[~self._ishanging_edges_z]
+            is_bz[~self._ishanging_edges_z],
         ]
         return is_b
 
@@ -1327,18 +1329,38 @@ class CylindricalMesh(
             return None
         if getattr(self, "_nodal_gradient", None) is None:
             if self.dim == 2:
-                Gr = sp.kron(speye(self._shape_total_nodes[1]), ddx(self.shape_cells[0]))
-                Gphi = sp.kron(ddx(self.shape_cells[1]), speye(self._shape_total_nodes[0]))
+                Gr = sp.kron(
+                    speye(self._shape_total_nodes[1]), ddx(self.shape_cells[0])
+                )
+                Gphi = sp.kron(
+                    ddx(self.shape_cells[1]), speye(self._shape_total_nodes[0])
+                )
                 Gz = None
             else:
-                Gr = kron3(speye(self._shape_total_nodes[2]), speye(self._shape_total_nodes[1]), ddx(self.shape_cells[0]))
-                Gphi = kron3(speye(self._shape_total_nodes[2]), ddx(self.shape_cells[1]), speye(self._shape_total_nodes[0]))
-                Gz = kron3(ddx(self.shape_cells[2]), speye(self._shape_total_nodes[1]), speye(self._shape_total_nodes[0]))
+                Gr = kron3(
+                    speye(self._shape_total_nodes[2]),
+                    speye(self._shape_total_nodes[1]),
+                    ddx(self.shape_cells[0]),
+                )
+                Gphi = kron3(
+                    speye(self._shape_total_nodes[2]),
+                    ddx(self.shape_cells[1]),
+                    speye(self._shape_total_nodes[0]),
+                )
+                Gz = kron3(
+                    ddx(self.shape_cells[2]),
+                    speye(self._shape_total_nodes[1]),
+                    speye(self._shape_total_nodes[0]),
+                )
             # remove the hanging edges
             G = sp.vstack([Gr, Gphi, Gz])[~self._ishanging_edges]
 
             # apply inflation to map true nodes to hanging nodes with the same values
-            G = sdiag(1/self.edge_lengths) @ G @ self._deflation_matrix('nodes', as_ones=True).T
+            G = (
+                sdiag(1 / self.edge_lengths)
+                @ G
+                @ self._deflation_matrix("nodes", as_ones=True).T
+            )
             self._nodal_gradient = G
         return self._nodal_gradient
 
@@ -1363,8 +1385,8 @@ class CylindricalMesh(
             return sp.vstack((Dz, Dr))
         else:
             stencil = super()._edge_curl_stencil
-            P_f = self._deflation_matrix('faces')
-            P_e = self._deflation_matrix('edges', as_ones=True)
+            P_f = self._deflation_matrix("faces")
+            P_e = self._deflation_matrix("edges", as_ones=True)
             return P_f @ stencil @ P_e.T
 
     @property
@@ -1502,7 +1524,7 @@ class CylindricalMesh(
         aveN2Fx = kron3(
             av(self.shape_cells[2]),
             av(self.shape_cells[1]),
-            speye(self._shape_total_nodes[0])
+            speye(self._shape_total_nodes[0]),
         )
         return aveN2Fx[~self._ishanging_faces_x]
 
@@ -1519,7 +1541,7 @@ class CylindricalMesh(
     def average_node_to_face(self):
         if getattr(self, "_average_node_to_face", None) is None:
             ave = super().average_node_to_face
-            ave = ave @ self._deflation_matrix('nodes', as_ones=True).T
+            ave = ave @ self._deflation_matrix("nodes", as_ones=True).T
             self._average_node_to_face = ave
         return self._average_node_to_face
 
@@ -1534,7 +1556,7 @@ class CylindricalMesh(
                     av_extrap(self.shape_cells[0]),
                 )[~self._ishanging_faces_x]
 
-                av_c2f_t = self._deflation_matrix('faces_y') @ kron3(
+                av_c2f_t = self._deflation_matrix("faces_y") @ kron3(
                     speye(self.shape_cells[2]),
                     av_extrap(self.shape_cells[1]),
                     speye(self.shape_cells[0]),
@@ -1594,7 +1616,7 @@ class CylindricalMesh(
             )
         if location == "cell_centers":
             return speye(self.n_cells)
-        if self.is_symmetric and location == 'nodes':
+        if self.is_symmetric and location == "nodes":
             return sp.csr_matrix((self.n_nodes, self._n_total_nodes))
 
         elif location in ["edges", "faces"]:
@@ -1721,32 +1743,35 @@ class CylindricalMesh(
             elif location_type[-1] == "z":
                 Q = sp.hstack([Z, Q])
             Q = Q.tocsr()
-        elif location_type == 'nodes':
-            rtz = [
-                self.nodes_x,
-                self._nodes_y_full
-            ]
+        elif location_type == "nodes":
+            rtz = [self.nodes_x, self._nodes_y_full]
             if self.dim == 3:
                 rtz.append(self.nodes_z)
             Q = interpolation_matrix(loc, *rtz)
-            Q = Q @ self._deflation_matrix('nodes', as_ones=True).T
-        elif location_type == 'cell_centers':
+            Q = Q @ self._deflation_matrix("nodes", as_ones=True).T
+        elif location_type == "cell_centers":
             # theta wrap around interpolation
             rtz = [
                 self.cell_centers_x,
                 np.r_[
                     self.cell_centers_y[-1] - 2 * np.pi,
                     self.cell_centers_y,
-                    self.cell_centers_y[0] + 2 * np.pi
+                    self.cell_centers_y[0] + 2 * np.pi,
                 ],
             ]
             if self.dim == 3:
                 rtz.append(self.cell_centers_z)
             Q = interpolation_matrix(loc, *rtz)
-            irs, its, izs = np.unravel_index(Q.indices, self.shape_cells + np.r_[0, 2, 0], order='F')
+            irs, its, izs = np.unravel_index(
+                Q.indices, self.shape_cells + np.r_[0, 2, 0], order="F"
+            )
             its = (its - 1) % self.shape_cells[1]
-            new_indices = np.ravel_multi_index((irs, its, izs), self.shape_cells, order='F')
-            Q = sp.csr_matrix((Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_cells))
+            new_indices = np.ravel_multi_index(
+                (irs, its, izs), self.shape_cells, order="F"
+            )
+            Q = sp.csr_matrix(
+                (Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_cells)
+            )
         else:
             ind = {"x": 0, "y": 1, "z": 2}[location_type[-1]]
             if self.dim < ind:
@@ -1756,7 +1781,7 @@ class CylindricalMesh(
             else:
                 items = (self.nEx, self.nEy, self.nEz)[: self.dim]
             components = [spzeros(loc.shape[0], n) for n in items]
-            if location_type == 'faces_x':
+            if location_type == "faces_x":
                 # theta wrap around interpolation
                 nodes_x = self.nodes_x if self.is_symmetric else self.nodes_x[1:]
                 rtz = [
@@ -1764,19 +1789,25 @@ class CylindricalMesh(
                     np.r_[
                         self.cell_centers_y[-1] - 2 * np.pi,
                         self.cell_centers_y,
-                        self.cell_centers_y[0] + 2 * np.pi
+                        self.cell_centers_y[0] + 2 * np.pi,
                     ],
                 ]
                 if self.dim == 3:
                     rtz.append(self.cell_centers_z)
                 Q = interpolation_matrix(loc, *rtz)
                 # unwrap the theta indices
-                irs, its, izs = np.unravel_index(Q.indices, self.shape_faces_x + np.r_[0, 2, 0], order='F')
+                irs, its, izs = np.unravel_index(
+                    Q.indices, self.shape_faces_x + np.r_[0, 2, 0], order="F"
+                )
                 its = (its - 1) % self.shape_faces_x[1]
-                new_indices = np.ravel_multi_index((irs, its, izs), self.shape_faces_x, order='F')
-                Q = sp.csr_matrix((Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_faces_x))
+                new_indices = np.ravel_multi_index(
+                    (irs, its, izs), self.shape_faces_x, order="F"
+                )
+                Q = sp.csr_matrix(
+                    (Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_faces_x)
+                )
                 components[0] = Q
-            elif location_type == 'faces_y':
+            elif location_type == "faces_y":
                 rtz = [
                     self.cell_centers_x,
                     self._nodes_y_full,
@@ -1784,27 +1815,33 @@ class CylindricalMesh(
                 if self.dim == 3:
                     rtz.append(self.cell_centers_z)
                 Q = interpolation_matrix(loc, *rtz)
-                Q = Q @ self._deflation_matrix('faces_y', as_ones=True).T
+                Q = Q @ self._deflation_matrix("faces_y", as_ones=True).T
                 components[1] = Q
-            elif location_type == 'faces_z':
+            elif location_type == "faces_z":
                 # theta wrap around interpolation
                 rtz = [
                     self.cell_centers_x,
                     np.r_[
                         self.cell_centers_y[-1] - 2 * np.pi,
                         self.cell_centers_y,
-                        self.cell_centers_y[0] + 2 * np.pi
+                        self.cell_centers_y[0] + 2 * np.pi,
                     ],
-                    self.nodes_z
+                    self.nodes_z,
                 ]
                 Q = interpolation_matrix(loc, *rtz)
                 # unwrap the theta indices
-                irs, its, izs = np.unravel_index(Q.indices, self.shape_faces_z + np.r_[0, 2, 0], order='F')
+                irs, its, izs = np.unravel_index(
+                    Q.indices, self.shape_faces_z + np.r_[0, 2, 0], order="F"
+                )
                 its = (its - 1) % self.shape_faces_z[1]
-                new_indices = np.ravel_multi_index((irs, its, izs), self.shape_faces_z, order='F')
-                Q = sp.csr_matrix((Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_faces_z))
+                new_indices = np.ravel_multi_index(
+                    (irs, its, izs), self.shape_faces_z, order="F"
+                )
+                Q = sp.csr_matrix(
+                    (Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_faces_z)
+                )
                 components[2] = Q
-            elif location_type == 'edges_x':
+            elif location_type == "edges_x":
                 rtz = [
                     self.cell_centers_x,
                     self._nodes_y_full,
@@ -1812,9 +1849,9 @@ class CylindricalMesh(
                 if self.dim == 3:
                     rtz.append(self.nodes_z)
                 Q = interpolation_matrix(loc, *rtz)
-                Q = Q @ self._deflation_matrix('edges_x', as_ones=True).T
+                Q = Q @ self._deflation_matrix("edges_x", as_ones=True).T
                 components[0] = Q
-            elif location_type == 'edges_y':
+            elif location_type == "edges_y":
                 # theta wrap around
                 nodes_x = self.nodes_x if self.is_symmetric else self.nodes_x[1:]
                 rtz = [
@@ -1822,25 +1859,27 @@ class CylindricalMesh(
                     np.r_[
                         self.cell_centers_y[-1] - 2 * np.pi,
                         self.cell_centers_y,
-                        self.cell_centers_y[0] + 2 * np.pi
+                        self.cell_centers_y[0] + 2 * np.pi,
                     ],
                 ]
                 if self.dim == 3:
                     rtz.append(self.nodes_z)
                 Q = interpolation_matrix(loc, *rtz)
-                irs, its, izs = np.unravel_index(Q.indices, self.shape_edges_y + np.r_[0, 2, 0], order='F')
+                irs, its, izs = np.unravel_index(
+                    Q.indices, self.shape_edges_y + np.r_[0, 2, 0], order="F"
+                )
                 its = (its - 1) % self.shape_edges_y[1]
-                new_indices = np.ravel_multi_index((irs, its, izs), self.shape_edges_y, order='F')
-                Q = sp.csr_matrix((Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_edges_y))
+                new_indices = np.ravel_multi_index(
+                    (irs, its, izs), self.shape_edges_y, order="F"
+                )
+                Q = sp.csr_matrix(
+                    (Q.data, new_indices, Q.indptr), shape=(Q.shape[0], self.n_edges_y)
+                )
                 components[1] = Q
-            elif location_type == 'edges_z':
-                rtz = [
-                    self.nodes_x,
-                    self._nodes_y_full,
-                    self.cell_centers_z
-                ]
+            elif location_type == "edges_z":
+                rtz = [self.nodes_x, self._nodes_y_full, self.cell_centers_z]
                 Q = interpolation_matrix(loc, *rtz)
-                Q = Q @ self._deflation_matrix('edges_z', as_ones=True).T
+                Q = Q @ self._deflation_matrix("edges_z", as_ones=True).T
                 components[2] = Q
             else:
                 raise ValueError("Unrecognized location type")
@@ -2006,12 +2045,24 @@ class CylindricalMesh(
         return Proj * Pc2r
 
     # DEPRECATIONS
-    areaFx = deprecate_property("face_x_areas", "areaFx", removal_version="1.0.0", future_warn=True)
-    areaFy = deprecate_property("face_y_areas", "areaFy", removal_version="1.0.0", future_warn=True)
-    areaFz = deprecate_property("face_z_areas", "areaFz", removal_version="1.0.0", future_warn=True)
-    edgeEx = deprecate_property("edge_x_lengths", "edgeEx", removal_version="1.0.0", future_warn=True)
-    edgeEy = deprecate_property("edge_y_lengths", "edgeEy", removal_version="1.0.0", future_warn=True)
-    edgeEz = deprecate_property("edge_z_lengths", "edgeEz", removal_version="1.0.0", future_warn=True)
+    areaFx = deprecate_property(
+        "face_x_areas", "areaFx", removal_version="1.0.0", future_warn=True
+    )
+    areaFy = deprecate_property(
+        "face_y_areas", "areaFy", removal_version="1.0.0", future_warn=True
+    )
+    areaFz = deprecate_property(
+        "face_z_areas", "areaFz", removal_version="1.0.0", future_warn=True
+    )
+    edgeEx = deprecate_property(
+        "edge_x_lengths", "edgeEx", removal_version="1.0.0", future_warn=True
+    )
+    edgeEy = deprecate_property(
+        "edge_y_lengths", "edgeEy", removal_version="1.0.0", future_warn=True
+    )
+    edgeEz = deprecate_property(
+        "edge_z_lengths", "edgeEz", removal_version="1.0.0", future_warn=True
+    )
     isSymmetric = deprecate_property(
         "is_symmetric", "isSymmetric", removal_version="1.0.0", future_warn=True
     )
@@ -2022,7 +2073,7 @@ class CylindricalMesh(
         "get_interpolation_matrix_cartesian_mesh",
         "getInterpolationMatCartMesh",
         removal_version="1.0.0",
-        future_warn=True
+        future_warn=True,
     )
     cartesianGrid = deprecate_method(
         "cartesian_grid", "cartesianGrid", removal_version="1.0.0", future_warn=True

--- a/discretize/mixins/mesh_io.py
+++ b/discretize/mixins/mesh_io.py
@@ -6,7 +6,10 @@ from discretize.utils.code_utils import deprecate_method
 import warnings
 
 try:
-    from discretize.mixins.vtk_mod import InterfaceTensorread_vtk, InterfaceSimplexReadVTK
+    from discretize.mixins.vtk_mod import (
+        InterfaceTensorread_vtk,
+        InterfaceSimplexReadVTK,
+    )
 except ImportError:
     InterfaceSimplexReadVTK = InterfaceTensorread_vtk = object
 
@@ -21,6 +24,7 @@ class TensorMeshIO(InterfaceTensorread_vtk):
         - Read/write models defined on tensor meshes
 
     """
+
     @classmethod
     def _readUBC_3DMesh(cls, file_name):
         """Read 3D tensor mesh from UBC-GIF formatted file.
@@ -416,7 +420,9 @@ class TensorMeshIO(InterfaceTensorread_vtk):
     readModelUBC = deprecate_method(
         "read_model_UBC", "readModelUBC", removal_version="1.0.0", future_warn=True
     )
-    writeUBC = deprecate_method("write_UBC", "writeUBC", removal_version="1.0.0", future_warn=True)
+    writeUBC = deprecate_method(
+        "write_UBC", "writeUBC", removal_version="1.0.0", future_warn=True
+    )
     writeModelUBC = deprecate_method(
         "write_model_UBC", "writeModelUBC", removal_version="1.0.0", future_warn=True
     )
@@ -432,6 +438,7 @@ class TreeMeshIO(object):
         - Read/write models defined on tree meshes
 
     """
+
     @classmethod
     def read_UBC(TreeMesh, file_name, directory=""):
         """Read 3D tree mesh (OcTree mesh) from UBC-GIF formatted file.
@@ -601,7 +608,9 @@ class TreeMeshIO(object):
     readModelUBC = deprecate_method(
         "read_model_UBC", "readModelUBC", removal_version="1.0.0", future_warn=True
     )
-    writeUBC = deprecate_method("write_UBC", "writeUBC", removal_version="1.0.0", future_warn=True)
+    writeUBC = deprecate_method(
+        "write_UBC", "writeUBC", removal_version="1.0.0", future_warn=True
+    )
     writeModelUBC = deprecate_method(
         "write_model_UBC", "writeModelUBC", removal_version="1.0.0", future_warn=True
     )

--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -5,6 +5,7 @@ from discretize.utils.code_utils import deprecate_method
 
 import discretize
 
+
 def load_matplotlib():
     """Lazy load principal matplotlib routines.
 
@@ -13,6 +14,7 @@ def load_matplotlib():
     """
     import matplotlib
     import matplotlib.pyplot as plt
+
     return matplotlib, plt
 
 
@@ -141,6 +143,7 @@ class InterfaceMPL(object):
         """
         matplotlib, plt = load_matplotlib()
         from matplotlib import rc_params  # lazy loaded
+
         mesh_type = self._meshType.lower()
         plotters = {
             "tree": self.__plot_grid_tree,
@@ -286,7 +289,7 @@ class InterfaceMPL(object):
             "tensor": self.__plot_image_tensor,
             "curv": self.__plot_image_curv,
             "cyl": self.__plot_image_cyl,
-            "simplex": self.__plot_image_simp
+            "simplex": self.__plot_image_simp,
         }
         try:
             plotter = plotters[mesh_type]
@@ -321,9 +324,7 @@ class InterfaceMPL(object):
             )
         if "vType" in kwargs:
             v_type = kwargs.pop("vType")
-            warnings.warn(
-                "vType has been deprecated, please use v_type", FutureWarning
-            )
+            warnings.warn("vType has been deprecated, please use v_type", FutureWarning)
 
         # Some Error checking and common defaults
         if pcolor_opts is None:
@@ -558,9 +559,7 @@ class InterfaceMPL(object):
             )
         if "vType" in kwargs:
             v_type = kwargs["vType"]
-            warnings.warn(
-                "vType has been deprecated, please use v_type", FutureWarning
-            )
+            warnings.warn("vType has been deprecated, please use v_type", FutureWarning)
         if pcolor_opts is None:
             pcolor_opts = {}
         if stream_opts is None:
@@ -2203,7 +2202,10 @@ class InterfaceMPL(object):
                 vecs[:, 1],
                 **quiver_opts,
             )
-            out = (out, qvr,)
+            out = (
+                out,
+                qvr,
+            )
 
         return out
 
@@ -2221,11 +2223,13 @@ class InterfaceMPL(object):
     ):
         if lines:
             if self.dim == 2:
-                ax.triplot(*self.nodes.T, self.simplices, color=color, linewidth=linewidth)
+                ax.triplot(
+                    *self.nodes.T, self.simplices, color=color, linewidth=linewidth
+                )
             elif self.dim == 3:
                 edge_nodes = self._edges
                 n_edges = edge_nodes.shape[0]
-                to_plot = np.full((3*n_edges, 3), np.nan)
+                to_plot = np.full((3 * n_edges, 3), np.nan)
                 to_plot[::3] = self.nodes[edge_nodes[:, 0]]
                 to_plot[1::3] = self.nodes[edge_nodes[:, 1]]
                 ax.plot(*to_plot.T, color=color, linewidth=linewidth)
@@ -2240,7 +2244,7 @@ class InterfaceMPL(object):
         ax.set_xlabel("x1")
         ax.set_ylabel("x2")
         if self.dim == 3:
-            ax.set_zlabel('x3')
+            ax.set_zlabel("x3")
         return ax
 
     def __plot_image_simp(
@@ -2268,21 +2272,21 @@ class InterfaceMPL(object):
                 raise ValueError("Other types for CCv not supported")
         if "F" in v_type:
             aveOp = "average_face_to_cell"
-            if view == "vec" or 'x' in v_type or "y" in v_type:
+            if view == "vec" or "x" in v_type or "y" in v_type:
                 aveOp += "_vector"
             v = getattr(self, aveOp) * v
         elif "E" in v_type:
             aveOp = "average_edge_to_cell"
-            if view == "vec" or 'x' in v_type or "y" in v_type:
+            if view == "vec" or "x" in v_type or "y" in v_type:
                 aveOp += "_vector"
             v = getattr(self, aveOp) * v
         if view == "vec":
-            v = v.reshape((self.n_cells, 2), order='F')
+            v = v.reshape((self.n_cells, 2), order="F")
         elif "x" in v_type:
-            v = v.reshape((self.n_cells, 2), order='F')
+            v = v.reshape((self.n_cells, 2), order="F")
             v = v[:, 0]
         elif "y" in v_type:
-            v = v.reshape((self.n_cells, 2), order='F')
+            v = v.reshape((self.n_cells, 2), order="F")
             v = v[:, 1]
 
         if view in ["real", "imag", "abs"]:
@@ -2291,8 +2295,7 @@ class InterfaceMPL(object):
             image_data = np.linalg.norm(v, axis=1)
         shading = "gouraud" if v_type == "N" else "flat"
         trip = ax.tripcolor(
-            *self.nodes.T, self._simplices, image_data,
-            shading=shading, **pcolor_opts
+            *self.nodes.T, self._simplices, image_data, shading=shading, **pcolor_opts
         )
 
         if range_x is None:
@@ -2305,7 +2308,7 @@ class InterfaceMPL(object):
         ax.set_xlim(*range_x)
         ax.set_ylim(*range_y)
 
-        out = (trip, )
+        out = (trip,)
         if view == "vec":
             if quiver_opts is None:
                 quiver_opts = {}
@@ -2324,9 +2327,15 @@ class InterfaceMPL(object):
 
         return out
 
-    plotGrid = deprecate_method("plot_grid", "plotGrid", removal_version="1.0.0", future_warn=True)
-    plotImage = deprecate_method("plot_image", "plotImage", removal_version="1.0.0", future_warn=True)
-    plotSlice = deprecate_method("plot_slice", "plotSlice", removal_version="1.0.0", future_warn=True)
+    plotGrid = deprecate_method(
+        "plot_grid", "plotGrid", removal_version="1.0.0", future_warn=True
+    )
+    plotImage = deprecate_method(
+        "plot_image", "plotImage", removal_version="1.0.0", future_warn=True
+    )
+    plotSlice = deprecate_method(
+        "plot_slice", "plotSlice", removal_version="1.0.0", future_warn=True
+    )
 
 
 class Slicer(object):

--- a/discretize/mixins/omf_mod.py
+++ b/discretize/mixins/omf_mod.py
@@ -1,9 +1,11 @@
 import numpy as np
 import discretize
 
+
 def omf():
     """Lazy loading omf."""
     import omf
+
     return omf
 
 
@@ -150,6 +152,7 @@ class InterfaceOMF(object):
     ``discretize`` objects and `open mining format <https://www.seequent.com/the-open-mining-format/>`__ (OMF) objects.
     Examples include: meshes, models and data arrays.
     """
+
     def _tensor_mesh_to_omf(mesh, models=None):
         """
         Constructs an :class:`omf.VolumeElement` object of this tensor mesh and

--- a/discretize/operators/differential_operators.py
+++ b/discretize/operators/differential_operators.py
@@ -1792,7 +1792,9 @@ class DiffOperators(object):
         Boundary conditions matrix for the cell gradient operator (Deprecated)
         """
 
-        warnings.warn("cell_gradient_BC is deprecated and is not longer used. See cell_gradient")
+        warnings.warn(
+            "cell_gradient_BC is deprecated and is not longer used. See cell_gradient"
+        )
 
         if getattr(self, "_cell_gradient_BC", None) is None:
             BC = self.set_cell_gradient_BC(self._cell_gradient_BC_list)
@@ -3528,7 +3530,9 @@ class DiffOperators(object):
         return sp.eye(self.n_nodes, format="csr")[is_b]
 
     # DEPRECATED
-    cellGrad = deprecate_property("cell_gradient", "cellGrad", removal_version="1.0.0", future_warn=True)
+    cellGrad = deprecate_property(
+        "cell_gradient", "cellGrad", removal_version="1.0.0", future_warn=True
+    )
     cellGradBC = deprecate_property(
         "cell_gradient_BC", "cellGradBC", removal_version="1.0.0", future_warn=True
     )
@@ -3551,24 +3555,42 @@ class DiffOperators(object):
         "face_z_divergence", "faceDivz", removal_version="1.0.0", future_warn=True
     )
     _cellGradStencil = deprecate_property(
-        "stencil_cell_gradient", "_cellGradStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient",
+        "_cellGradStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _cellGradxStencil = deprecate_property(
-        "stencil_cell_gradient_x", "_cellGradxStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient_x",
+        "_cellGradxStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _cellGradyStencil = deprecate_property(
-        "stencil_cell_gradient_y", "_cellGradyStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient_y",
+        "_cellGradyStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _cellGradzStencil = deprecate_property(
-        "stencil_cell_gradient_z", "_cellGradzStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient_z",
+        "_cellGradzStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
 
     setCellGradBC = deprecate_method(
-        "set_cell_gradient_BC", "setCellGradBC", removal_version="1.0.0", future_warn=True
+        "set_cell_gradient_BC",
+        "setCellGradBC",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     getBCProjWF = deprecate_method(
         "get_BC_projections", "getBCProjWF", removal_version="1.0.0", future_warn=True
     )
     getBCProjWF_simple = deprecate_method(
-        "get_BC_projections_simple", "getBCProjWF_simple", removal_version="1.0.0", future_warn=True
+        "get_BC_projections_simple",
+        "getBCProjWF_simple",
+        removal_version="1.0.0",
+        future_warn=True,
     )

--- a/discretize/tensor_mesh.py
+++ b/discretize/tensor_mesh.py
@@ -568,15 +568,33 @@ class TensorMesh(
         return attrs
 
     # DEPRECATIONS
-    areaFx = deprecate_property("face_x_areas", "areaFx", removal_version="1.0.0", future_warn=True)
-    areaFy = deprecate_property("face_y_areas", "areaFy", removal_version="1.0.0", future_warn=True)
-    areaFz = deprecate_property("face_z_areas", "areaFz", removal_version="1.0.0", future_warn=True)
-    edgeEx = deprecate_property("edge_x_lengths", "edgeEx", removal_version="1.0.0", future_warn=True)
-    edgeEy = deprecate_property("edge_y_lengths", "edgeEy", removal_version="1.0.0", future_warn=True)
-    edgeEz = deprecate_property("edge_z_lengths", "edgeEz", removal_version="1.0.0", future_warn=True)
+    areaFx = deprecate_property(
+        "face_x_areas", "areaFx", removal_version="1.0.0", future_warn=True
+    )
+    areaFy = deprecate_property(
+        "face_y_areas", "areaFy", removal_version="1.0.0", future_warn=True
+    )
+    areaFz = deprecate_property(
+        "face_z_areas", "areaFz", removal_version="1.0.0", future_warn=True
+    )
+    edgeEx = deprecate_property(
+        "edge_x_lengths", "edgeEx", removal_version="1.0.0", future_warn=True
+    )
+    edgeEy = deprecate_property(
+        "edge_y_lengths", "edgeEy", removal_version="1.0.0", future_warn=True
+    )
+    edgeEz = deprecate_property(
+        "edge_z_lengths", "edgeEz", removal_version="1.0.0", future_warn=True
+    )
     faceBoundaryInd = deprecate_property(
-        "face_boundary_indices", "faceBoundaryInd", removal_version="1.0.0", future_warn=True
+        "face_boundary_indices",
+        "faceBoundaryInd",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     cellBoundaryInd = deprecate_property(
-        "cell_boundary_indices", "cellBoundaryInd", removal_version="1.0.0", future_warn=True
+        "cell_boundary_indices",
+        "cellBoundaryInd",
+        removal_version="1.0.0",
+        future_warn=True,
     )

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -130,7 +130,9 @@ def setup_mesh(mesh_type, nC, nDim):
         elif "random" in mesh_type:
             h1 = np.random.rand(nC) * nC * 0.5 + nC * 0.5
             if "symmetric" in mesh_type:
-                h2 = [2 * np.pi, ]
+                h2 = [
+                    2 * np.pi,
+                ]
             else:
                 h2 = np.random.rand(nC) * nC * 0.5 + nC * 0.5
             h3 = np.random.rand(nC) * nC * 0.5 + nC * 0.5
@@ -765,8 +767,12 @@ def assert_isadjoint(
 
 
 # DEPRECATIONS
-setupMesh = deprecate_function(setup_mesh, "setupMesh", removal_version="1.0.0", future_warn=True)
-Rosenbrock = deprecate_function(rosenbrock, "Rosenbrock", removal_version="1.0.0", future_warn=True)
+setupMesh = deprecate_function(
+    setup_mesh, "setupMesh", removal_version="1.0.0", future_warn=True
+)
+Rosenbrock = deprecate_function(
+    rosenbrock, "Rosenbrock", removal_version="1.0.0", future_warn=True
+)
 checkDerivative = deprecate_function(
     check_derivative, "checkDerivative", removal_version="1.0.0", future_warn=True
 )

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -97,7 +97,12 @@ from discretize.utils.code_utils import deprecate_property
 
 
 class TreeMesh(
-    _TreeMesh, InnerProducts, DiffOperators, BaseTensorMesh, TreeMeshIO, InterfaceMixins,
+    _TreeMesh,
+    InnerProducts,
+    DiffOperators,
+    BaseTensorMesh,
+    TreeMeshIO,
+    InterfaceMixins,
 ):
     """Class for QuadTree (2D) and OcTree (3D) meshes.
 
@@ -631,7 +636,7 @@ class TreeMesh(
 
     @property
     def cell_state(self):
-        """ The current state of the cells on the mesh.
+        """The current state of the cells on the mesh.
 
         This represents the x, y, z indices of the cells in the base tensor mesh, as
         well as their levels. It can be used to reconstruct the mesh.
@@ -661,7 +666,9 @@ class TreeMesh(
     def __reduce__(self):
         return TreeMesh, (self.h, self.origin), self.__getstate__()
 
-    cellGrad = deprecate_property("cell_gradient", "cellGrad", removal_version="1.0.0", future_warn=True)
+    cellGrad = deprecate_property(
+        "cell_gradient", "cellGrad", removal_version="1.0.0", future_warn=True
+    )
     cellGradx = deprecate_property(
         "cell_gradient_x", "cellGradx", removal_version="1.0.0", future_warn=True
     )
@@ -672,7 +679,10 @@ class TreeMesh(
         "cell_gradient_z", "cellGradz", removal_version="1.0.0", future_warn=True
     )
     cellGradStencil = deprecate_property(
-        "cell_gradient_stencil", "cellGradStencil", removal_version="1.0.0", future_warn=True
+        "cell_gradient_stencil",
+        "cellGradStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     faceDivx = deprecate_property(
         "face_x_divergence", "faceDivx", removal_version="1.0.0", future_warn=True
@@ -683,42 +693,87 @@ class TreeMesh(
     faceDivz = deprecate_property(
         "face_z_divergence", "faceDivz", removal_version="1.0.0", future_warn=True
     )
-    maxLevel = deprecate_property("max_used_level", "maxLevel", removal_version="1.0.0", future_warn=True)
-    areaFx = deprecate_property("face_x_areas", "areaFx", removal_version="1.0.0", future_warn=True)
-    areaFy = deprecate_property("face_y_areas", "areaFy", removal_version="1.0.0", future_warn=True)
-    areaFz = deprecate_property("face_z_areas", "areaFz", removal_version="1.0.0", future_warn=True)
-    edgeEx = deprecate_property("edge_x_lengths", "edgeEx", removal_version="1.0.0", future_warn=True)
-    edgeEy = deprecate_property("edge_y_lengths", "edgeEy", removal_version="1.0.0", future_warn=True)
-    edgeEz = deprecate_property("edge_z_lengths", "edgeEz", removal_version="1.0.0", future_warn=True)
+    maxLevel = deprecate_property(
+        "max_used_level", "maxLevel", removal_version="1.0.0", future_warn=True
+    )
+    areaFx = deprecate_property(
+        "face_x_areas", "areaFx", removal_version="1.0.0", future_warn=True
+    )
+    areaFy = deprecate_property(
+        "face_y_areas", "areaFy", removal_version="1.0.0", future_warn=True
+    )
+    areaFz = deprecate_property(
+        "face_z_areas", "areaFz", removal_version="1.0.0", future_warn=True
+    )
+    edgeEx = deprecate_property(
+        "edge_x_lengths", "edgeEx", removal_version="1.0.0", future_warn=True
+    )
+    edgeEy = deprecate_property(
+        "edge_y_lengths", "edgeEy", removal_version="1.0.0", future_warn=True
+    )
+    edgeEz = deprecate_property(
+        "edge_z_lengths", "edgeEz", removal_version="1.0.0", future_warn=True
+    )
     permuteCC = deprecate_property(
         "permute_cells", "permuteCC", removal_version="1.0.0", future_warn=True
     )
-    permuteF = deprecate_property("permute_faces", "permuteF", removal_version="1.0.0", future_warn=True)
-    permuteE = deprecate_property("permute_edges", "permuteE", removal_version="1.0.0", future_warn=True)
+    permuteF = deprecate_property(
+        "permute_faces", "permuteF", removal_version="1.0.0", future_warn=True
+    )
+    permuteE = deprecate_property(
+        "permute_edges", "permuteE", removal_version="1.0.0", future_warn=True
+    )
     faceBoundaryInd = deprecate_property(
-        "face_boundary_indices", "faceBoundaryInd", removal_version="1.0.0", future_warn=True
+        "face_boundary_indices",
+        "faceBoundaryInd",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     cellBoundaryInd = deprecate_property(
-        "cell_boundary_indices", "cellBoundaryInd", removal_version="1.0.0", future_warn=True
+        "cell_boundary_indices",
+        "cellBoundaryInd",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _aveCC2FxStencil = deprecate_property(
-        "average_cell_to_total_face_x", "_aveCC2FxStencil", removal_version="1.0.0", future_warn=True
+        "average_cell_to_total_face_x",
+        "_aveCC2FxStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _aveCC2FyStencil = deprecate_property(
-        "average_cell_to_total_face_y", "_aveCC2FyStencil", removal_version="1.0.0", future_warn=True
+        "average_cell_to_total_face_y",
+        "_aveCC2FyStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _aveCC2FzStencil = deprecate_property(
-        "average_cell_to_total_face_z", "_aveCC2FzStencil", removal_version="1.0.0", future_warn=True
+        "average_cell_to_total_face_z",
+        "_aveCC2FzStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _cellGradStencil = deprecate_property(
-        "stencil_cell_gradient", "_cellGradStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient",
+        "_cellGradStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _cellGradxStencil = deprecate_property(
-        "stencil_cell_gradient_x", "_cellGradxStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient_x",
+        "_cellGradxStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _cellGradyStencil = deprecate_property(
-        "stencil_cell_gradient_y", "_cellGradyStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient_y",
+        "_cellGradyStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )
     _cellGradzStencil = deprecate_property(
-        "stencil_cell_gradient_z", "_cellGradzStencil", removal_version="1.0.0", future_warn=True
+        "stencil_cell_gradient_z",
+        "_cellGradzStencil",
+        removal_version="1.0.0",
+        future_warn=True,
     )

--- a/discretize/utils/__init__.py
+++ b/discretize/utils/__init__.py
@@ -138,7 +138,10 @@ from discretize.utils.mesh_utils import (
     example_simplex_mesh,
 )
 from discretize.utils.curvilinear_utils import (
-  example_curvilinear_grid, volume_tetrahedron, face_info, index_cube
+    example_curvilinear_grid,
+    volume_tetrahedron,
+    face_info,
+    index_cube,
 )
 from discretize.utils.interpolation_utils import interpolation_matrix, volume_average
 from discretize.utils.coordinate_utils import (
@@ -168,7 +171,12 @@ from discretize.utils.mesh_utils import (
     closestPoints,
     ExtractCoreMesh,
 )
-from discretize.utils.curvilinear_utils import exampleLrmGrid, volTetra, indexCube, faceInfo
+from discretize.utils.curvilinear_utils import (
+    exampleLrmGrid,
+    volTetra,
+    indexCube,
+    faceInfo,
+)
 from discretize.utils.interpolation_utils import interpmat
 from discretize.utils.coordinate_utils import (
     rotationMatrixFromNormals,

--- a/discretize/utils/code_utils.py
+++ b/discretize/utils/code_utils.py
@@ -122,6 +122,7 @@ def deprecate_class(removal_version=None, new_location=None, future_warn=False):
         Warning = FutureWarning
     else:
         Warning = DeprecationWarning
+
     def decorator(cls):
         my_name = cls.__name__
         parent_name = cls.__bases__[0].__name__
@@ -262,7 +263,9 @@ def deprecate_function(new_function, old_name, removal_version=None, future_warn
 
 
 # DEPRECATIONS
-isScalar = deprecate_function(is_scalar, "isScalar", removal_version="1.0.0", future_warn=True)
+isScalar = deprecate_function(
+    is_scalar, "isScalar", removal_version="1.0.0", future_warn=True
+)
 asArray_N_x_Dim = deprecate_function(
     as_array_n_by_dim, "asArray_N_x_Dim", removal_version="1.0.0", future_warn=True
 )

--- a/discretize/utils/coordinate_utils.py
+++ b/discretize/utils/coordinate_utils.py
@@ -293,8 +293,14 @@ def rotate_points_from_normals(xyz, v0, v1, x0=np.r_[0.0, 0.0, 0.0]):
 
 
 rotationMatrixFromNormals = deprecate_function(
-    rotation_matrix_from_normals, "rotationMatrixFromNormals", removal_version="1.0.0", future_warn=True
+    rotation_matrix_from_normals,
+    "rotationMatrixFromNormals",
+    removal_version="1.0.0",
+    future_warn=True,
 )
 rotatePointsFromNormals = deprecate_function(
-    rotate_points_from_normals, "rotatePointsFromNormals", removal_version="1.0.0", future_warn=True
+    rotate_points_from_normals,
+    "rotatePointsFromNormals",
+    removal_version="1.0.0",
+    future_warn=True,
 )

--- a/discretize/utils/curvilinear_utils.py
+++ b/discretize/utils/curvilinear_utils.py
@@ -4,7 +4,6 @@ from discretize.utils.code_utils import deprecate_function
 import warnings
 
 
-
 def example_curvilinear_grid(nC, exType):
     """Creates and returns the gridded node locations for a curvilinear mesh.
 
@@ -472,7 +471,6 @@ def face_info(xyz, A, B, C, D, average=True, normalize_normals=True, **kwargs):
     if not isinstance(normalize_normals, bool):
         raise TypeError("normalize_normals must be a boolean")
 
-
     AB = xyz[B, :] - xyz[A, :]
     BC = xyz[C, :] - xyz[B, :]
     CD = xyz[D, :] - xyz[C, :]
@@ -517,8 +515,17 @@ def face_info(xyz, A, B, C, D, average=True, normalize_normals=True, **kwargs):
 
 
 exampleLrmGrid = deprecate_function(
-    example_curvilinear_grid, "exampleLrmGrid", removal_version="1.0.0", future_warn=True
+    example_curvilinear_grid,
+    "exampleLrmGrid",
+    removal_version="1.0.0",
+    future_warn=True,
 )
-volTetra = deprecate_function(volume_tetrahedron, "volTetra", removal_version="1.0.0", future_warn=True)
-indexCube = deprecate_function(index_cube, "indexCube", removal_version="1.0.0", future_warn=True)
-faceInfo = deprecate_function(face_info, "faceInfo", removal_version="1.0.0", future_warn=True)
+volTetra = deprecate_function(
+    volume_tetrahedron, "volTetra", removal_version="1.0.0", future_warn=True
+)
+indexCube = deprecate_function(
+    index_cube, "indexCube", removal_version="1.0.0", future_warn=True
+)
+faceInfo = deprecate_function(
+    face_info, "faceInfo", removal_version="1.0.0", future_warn=True
+)

--- a/discretize/utils/matrix_utils.py
+++ b/discretize/utils/matrix_utils.py
@@ -937,7 +937,7 @@ def invert_blocks(A):
         B = np.empty_like(A)
         B[..., 0, 0] = a22 / detA
         B[..., 0, 1] = -a12 / detA
-        B[..., 1, 0] = - a21 / detA
+        B[..., 1, 0] = -a21 / detA
         B[..., 1, 1] = a11 / detA
 
     elif A.shape[-1] == 3:
@@ -969,6 +969,7 @@ def invert_blocks(A):
     else:
         raise NotImplementedError("Only supports 2x2 and 3x3 blocks")
     return B
+
 
 class TensorType(object):
     r"""Class for determining property tensor type.
@@ -1714,20 +1715,34 @@ class _inftup(tuple):
 
 sdInv = deprecate_function(sdinv, "sdInv", removal_version="1.0.0", future_warn=True)
 
-getSubArray = deprecate_function(get_subarray, "getSubArray", removal_version="1.0.0", future_warn=True)
+getSubArray = deprecate_function(
+    get_subarray, "getSubArray", removal_version="1.0.0", future_warn=True
+)
 
 inv3X3BlockDiagonal = deprecate_function(
-    inverse_3x3_block_diagonal, "inv3X3BlockDiagonal", removal_version="1.0.0", future_warn=True
+    inverse_3x3_block_diagonal,
+    "inv3X3BlockDiagonal",
+    removal_version="1.0.0",
+    future_warn=True,
 )
 
 inv2X2BlockDiagonal = deprecate_function(
-    inverse_2x2_block_diagonal, "inv2X2BlockDiagonal", removal_version="1.0.0", future_warn=True
+    inverse_2x2_block_diagonal,
+    "inv2X2BlockDiagonal",
+    removal_version="1.0.0",
+    future_warn=True,
 )
 
 makePropertyTensor = deprecate_function(
-    make_property_tensor, "makePropertyTensor", removal_version="1.0.0", future_warn=True
+    make_property_tensor,
+    "makePropertyTensor",
+    removal_version="1.0.0",
+    future_warn=True,
 )
 
 invPropertyTensor = deprecate_function(
-    inverse_property_tensor, "invPropertyTensor", removal_version="1.0.0", future_warn=True
+    inverse_property_tensor,
+    "invPropertyTensor",
+    removal_version="1.0.0",
+    future_warn=True,
 )

--- a/discretize/utils/mesh_utils.py
+++ b/discretize/utils/mesh_utils.py
@@ -1083,61 +1083,63 @@ def example_simplex_mesh(rect_shape):
     """
     if len(rect_shape) == 2:
         n1, n2 = rect_shape
-        xs, ys = np.mgrid[0:1:(n1+1)*1j, 0:1:(n2+1)*1j]
+        xs, ys = np.mgrid[0 : 1 : (n1 + 1) * 1j, 0 : 1 : (n2 + 1) * 1j]
         points = np.c_[xs.reshape(-1), ys.reshape(-1)]
 
-        node_inds = np.arange((n1+1) * (n2+1)).reshape((n1+1, n2+1))
+        node_inds = np.arange((n1 + 1) * (n2 + 1)).reshape((n1 + 1, n2 + 1))
 
         left_triangs = np.c_[
-            node_inds[:-1, :-1].reshape(-1), # i00
+            node_inds[:-1, :-1].reshape(-1),  # i00
             node_inds[1:, :-1].reshape(-1),  # i10
-            node_inds[:-1, 1:].reshape(-1)   # i01
+            node_inds[:-1, 1:].reshape(-1),  # i01
         ]
         right_triangs = np.c_[
-            node_inds[1:,1:].reshape(-1),    # i11
+            node_inds[1:, 1:].reshape(-1),  # i11
             node_inds[1:, :-1].reshape(-1),  # i10
-            node_inds[:-1, 1:].reshape(-1)   # i01
+            node_inds[:-1, 1:].reshape(-1),  # i01
         ]
 
         simplices = np.r_[left_triangs, right_triangs]
     if len(rect_shape) == 3:
         n1, n2, n3 = rect_shape
-        xs, ys, zs = np.mgrid[0:1:(n1+1)*1j, 0:1:(n2+1)*1j, 0:1:(n3+1)*1j]
+        xs, ys, zs = np.mgrid[
+            0 : 1 : (n1 + 1) * 1j, 0 : 1 : (n2 + 1) * 1j, 0 : 1 : (n3 + 1) * 1j
+        ]
         points = np.c_[xs.reshape(-1), ys.reshape(-1), zs.reshape(-1)]
 
-        node_inds = np.arange(
-            (n1+1) * (n2+1) * (n3+1)
-        ).reshape((n1+1, n2+1, n3+1))
+        node_inds = np.arange((n1 + 1) * (n2 + 1) * (n3 + 1)).reshape(
+            (n1 + 1, n2 + 1, n3 + 1)
+        )
 
         a_triangs = np.c_[
             node_inds[1:, :-1, :-1].reshape(-1),  # i100
             node_inds[:-1, :-1, 1:].reshape(-1),  # i001
             node_inds[:-1, 1:, :-1].reshape(-1),  # i010
-            node_inds[:-1, :-1, :-1].reshape(-1)  # i000
+            node_inds[:-1, :-1, :-1].reshape(-1),  # i000
         ]
         b_triangs = np.c_[
             node_inds[:-1, 1:, 1:].reshape(-1),  # i011
-            node_inds[1:, :-1, :-1].reshape(-1), # i100
-            node_inds[:-1, :-1, 1:].reshape(-1), # i001
-            node_inds[:-1, 1:, :-1].reshape(-1)  # i010
+            node_inds[1:, :-1, :-1].reshape(-1),  # i100
+            node_inds[:-1, :-1, 1:].reshape(-1),  # i001
+            node_inds[:-1, 1:, :-1].reshape(-1),  # i010
         ]
         c_triangs = np.c_[
             node_inds[1:, 1:, :-1].reshape(-1),  # i110
             node_inds[:-1, 1:, 1:].reshape(-1),  # i011
-            node_inds[1:, :-1, :-1].reshape(-1), # i100
-            node_inds[:-1, 1:, :-1].reshape(-1)  # i010
+            node_inds[1:, :-1, :-1].reshape(-1),  # i100
+            node_inds[:-1, 1:, :-1].reshape(-1),  # i010
         ]
         d_triangs = np.c_[
             node_inds[1:, :-1, 1:].reshape(-1),  # i101
             node_inds[:-1, 1:, 1:].reshape(-1),  # i011
-            node_inds[1:, :-1, :-1].reshape(-1), # i100
-            node_inds[:-1, :-1, 1:].reshape(-1)  # i001
+            node_inds[1:, :-1, :-1].reshape(-1),  # i100
+            node_inds[:-1, :-1, 1:].reshape(-1),  # i001
         ]
         e_triangs = np.c_[
             node_inds[1:, :-1, 1:].reshape(-1),  # i101
             node_inds[1:, 1:, :-1].reshape(-1),  # i110
             node_inds[:-1, 1:, 1:].reshape(-1),  # i011
-            node_inds[1:, 1:, 1:].reshape(-1)    # i111
+            node_inds[1:, 1:, 1:].reshape(-1),  # i111
         ]
         f_triangs = np.c_[
             node_inds[1:, :-1, 1:].reshape(-1),  # i101
@@ -1153,7 +1155,9 @@ def example_simplex_mesh(rect_shape):
     return points, simplices
 
 
-meshTensor = deprecate_function(unpack_widths, "meshTensor", removal_version="1.0.0", future_warn=True)
+meshTensor = deprecate_function(
+    unpack_widths, "meshTensor", removal_version="1.0.0", future_warn=True
+)
 closestPoints = deprecate_function(
     closest_points_index, "closestPoints", removal_version="1.0.0", future_warn=True
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,8 +67,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"discretize"
-copyright = u"2013 - {}, SimPEG Developers, http://simpeg.xyz".format(
+project = "discretize"
+copyright = "2013 - {}, SimPEG Developers, http://simpeg.xyz".format(
     datetime.now().year
 )
 
@@ -131,7 +131,7 @@ if link_github:
     import inspect
     from os.path import relpath, dirname
 
-    extensions.append('sphinx.ext.linkcode')
+    extensions.append("sphinx.ext.linkcode")
 
     def linkcode_resolve(domain, info):
         if domain != "py":
@@ -180,9 +180,13 @@ if link_github:
         except ValueError:
             return None
 
-        return f"https://github.com/simpeg/discretize/blob/main/discretize/{fn}{linespec}"
+        return (
+            f"https://github.com/simpeg/discretize/blob/main/discretize/{fn}{linespec}"
+        )
+
+
 else:
-    extensions.append('sphinx.ext.viewcode')
+    extensions.append("sphinx.ext.viewcode")
 
 # Make numpydoc to generate plots for example sections
 numpydoc_use_plots = True
@@ -228,7 +232,7 @@ try:
     html_theme_options = {
         "external_links": [
             {"name": "SimPEG", "url": "https://simpeg.xyz"},
-            {"name": "Contact", "url": "http://slack.simpeg.xyz"}
+            {"name": "Contact", "url": "http://slack.simpeg.xyz"},
         ],
         "icon_links": [
             {
@@ -261,10 +265,10 @@ try:
     }
     html_logo = "images/discretize-logo.png"
 
-    html_static_path = ['_static']
+    html_static_path = ["_static"]
 
     html_css_files = [
-        'css/custom.css',
+        "css/custom.css",
     ]
 
     html_context = {
@@ -366,8 +370,8 @@ latex_documents = [
     (
         "index",
         "discretize.tex",
-        u"discretize documentation",
-        u"SimPEG Developers",
+        "discretize documentation",
+        "SimPEG Developers",
         "manual",
     ),
 ]
@@ -397,9 +401,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ("index", "simpeg", u"discretize Documentation", [u"SimPEG Developers"], 1)
-]
+man_pages = [("index", "simpeg", "discretize Documentation", ["SimPEG Developers"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -411,7 +413,7 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "pyvista": ("https://docs.pyvista.org/", None),
-    "omf": ("https://omf.readthedocs.io/en/stable/", None)
+    "omf": ("https://omf.readthedocs.io/en/stable/", None),
 }
 numpydoc_xref_param_type = True
 
@@ -424,8 +426,8 @@ texinfo_documents = [
     (
         "index",
         "discretize",
-        u"discretize documentation",
-        u"SimPEG Developers",
+        "discretize documentation",
+        "SimPEG Developers",
         "discretize",
         "Finite volume methods for python.",
         "Miscellaneous",
@@ -476,7 +478,7 @@ sphinx_gallery_conf["image_scrapers"] = (pyvista.Scraper(), "matplotlib")
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
-graphviz_dot = shutil.which('dot')
+graphviz_dot = shutil.which("dot")
 # this must be png, because links on SVG are broken
 graphviz_output_format = "png"
 

--- a/examples/plot_pyvista_laguna.py
+++ b/examples/plot_pyvista_laguna.py
@@ -67,7 +67,7 @@ models = {"Lpout": np.load(os.path.join("laguna_del_maule_slicer", "Lpout.npy"))
 
 # Get the PyVista dataset of the inverted model
 dataset = mesh.to_vtk(models)
-dataset.set_active_scalars('Lpout')
+dataset.set_active_scalars("Lpout")
 
 ###############################################################################
 
@@ -86,7 +86,7 @@ grav = pv.PolyData(grav_data[:, 0:3])
 # Add the data arrays
 grav.point_data["comp-1"] = grav_data[:, 3]
 grav.point_data["comp-2"] = grav_data[:, 4]
-grav.set_active_scalars('comp-1')
+grav.set_active_scalars("comp-1")
 
 ###############################################################################
 # Plot the topographic surface and the gravity data
@@ -94,8 +94,10 @@ grav.set_active_scalars('comp-1')
 p = pv.Plotter()
 p.add_mesh(topo, color="grey")
 p.add_mesh(
-    grav, point_size=15, render_points_as_spheres=True,
-    scalar_bar_args={"title": "Observed Gravtiy Data"}
+    grav,
+    point_size=15,
+    render_points_as_spheres=True,
+    scalar_bar_args={"title": "Observed Gravtiy Data"},
 )
 # Use a non-phot-realistic shading technique to show topographic relief
 p.enable_eye_dome_lighting()

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ metadata = dict(
     platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
     use_scm_version={
         "write_to": os.path.join("discretize", "version.py"),
-    }
+    },
 )
 if len(sys.argv) >= 2 and (
     "--help" in sys.argv[1:]
@@ -72,7 +72,7 @@ if len(sys.argv) >= 2 and (
 
     # add cython and setuptools_scm to install requires on these commands though
     install_requires = build_requires + install_requires[1:]
-    metadata['install_requires'] = install_requires
+    metadata["install_requires"] = install_requires
 else:
     from setuptools.extension import Extension
     from Cython.Build import cythonize
@@ -100,9 +100,9 @@ else:
             ["discretize/_extensions/simplex_helpers.pyx"],
             include_dirs=[np.get_include()],
             **ext_kwargs
-        )
+        ),
     ]
 
-    metadata['ext_modules'] = cythonize(extensions)
+    metadata["ext_modules"] = cythonize(extensions)
 
 setup(**metadata)

--- a/tests/base/test_basemesh.py
+++ b/tests/base/test_basemesh.py
@@ -3,6 +3,7 @@ from discretize.base import BaseRectangularMesh, BaseMesh
 import numpy as np
 import inspect
 
+
 class TestBaseMesh(unittest.TestCase):
     not_implemented_attributes = [
         "dim",
@@ -52,7 +53,7 @@ class TestBaseMesh(unittest.TestCase):
         "get_face_inner_product_deriv",
         "get_edge_inner_product_deriv",
         "point2index",
-        "get_interpolation_matrix"
+        "get_interpolation_matrix",
     ]
 
     def setUp(self):
@@ -70,12 +71,18 @@ class TestBaseMesh(unittest.TestCase):
                 params = inspect.signature(func).parameters
 
                 n_params = sum(
-                    [1 if (
-                        param.default is param.empty and param.kind != param.VAR_KEYWORD
-                    ) else 0 for param in params.values()]
+                    [
+                        1
+                        if (
+                            param.default is param.empty
+                            and param.kind != param.VAR_KEYWORD
+                        )
+                        else 0
+                        for param in params.values()
+                    ]
                 )
                 # pass empty parameters to the function
-                func(*([None]*n_params))
+                func(*([None] * n_params))
 
 
 class TestBaseRectangularMesh(unittest.TestCase):

--- a/tests/base/test_interpolation.py
+++ b/tests/base/test_interpolation.py
@@ -241,10 +241,13 @@ class TestInterpolationSymCyl(discretize.tests.OrderTest):
         self.name = "Interpolation 3D Symmetric CYLMESH: Ey"
         self.orderTest()
 
+
 class TestInterpolationCyl(discretize.tests.OrderTest):
     name = "Interpolation Cylindrical 3D"
     LOCS = np.c_[
-        np.random.rand(20) * 0.6 + 0.2, 2*np.pi*(np.random.rand(20) * 0.6 + 0.2), np.random.rand(20) * 0.6 + 0.2
+        np.random.rand(20) * 0.6 + 0.2,
+        2 * np.pi * (np.random.rand(20) * 0.6 + 0.2),
+        np.random.rand(20) * 0.6 + 0.2,
     ]
     meshTypes = ["uniformCylMesh", "randomCylMesh"]  # MESHTYPES +
     meshDimension = 3
@@ -308,6 +311,7 @@ class TestInterpolationCyl(discretize.tests.OrderTest):
         self.type = "Ez"
         self.name = "Interpolation 3D CYLMESH: Ez"
         self.orderTest()
+
 
 class TestInterpolation3D(discretize.tests.OrderTest):
     name = "Interpolation"

--- a/tests/base/test_operators.py
+++ b/tests/base/test_operators.py
@@ -422,7 +422,7 @@ class TestAveraging1D(discretize.tests.OrderTest):
     def test_exactN2F(self):
         self.name = "Averaging 1D: N2F"
         fun = lambda x: np.cos(x)
-        M, _ = discretize.tests.setup_mesh('uniformTensorMesh', 32, 1)
+        M, _ = discretize.tests.setup_mesh("uniformTensorMesh", 32, 1)
         v1 = M.aveN2F * fun(M.gridN)
         v2 = fun(M.faces)
         np.testing.assert_allclose(v1, v2)
@@ -464,7 +464,7 @@ class TestAveraging1D(discretize.tests.OrderTest):
     def test_exactE2CC(self):
         self.name = "Averaging 1D: E2CC"
         fun = lambda x: np.cos(x)
-        M, _ = discretize.tests.setup_mesh('uniformTensorMesh', 32, 1)
+        M, _ = discretize.tests.setup_mesh("uniformTensorMesh", 32, 1)
         v1 = M.aveE2CC @ fun(M.edges)
         v2 = fun(M.gridCC)
         np.testing.assert_allclose(v1, v2)
@@ -472,7 +472,7 @@ class TestAveraging1D(discretize.tests.OrderTest):
     def test_exactE2CCV(self):
         self.name = "Averaging 1D: E2CCV"
         fun = lambda x: np.cos(x)
-        M, _ = discretize.tests.setup_mesh('uniformTensorMesh', 32, 1)
+        M, _ = discretize.tests.setup_mesh("uniformTensorMesh", 32, 1)
         v1 = M.aveE2CCV @ fun(M.edges)
         v2 = fun(M.gridCC)
         np.testing.assert_allclose(v1, v2)
@@ -480,7 +480,7 @@ class TestAveraging1D(discretize.tests.OrderTest):
     def test_exactCC2E(self):
         self.name = "Averaging 1D: cell_centers_to_edges"
         fun = lambda x: np.cos(x)
-        M, _ = discretize.tests.setup_mesh('uniformTensorMesh', 32, 1)
+        M, _ = discretize.tests.setup_mesh("uniformTensorMesh", 32, 1)
         v1 = M.average_cell_to_edge @ fun(M.edges)
         v2 = fun(M.gridCC)
         np.testing.assert_allclose(v1, v2)

--- a/tests/base/test_tests.py
+++ b/tests/base/test_tests.py
@@ -68,7 +68,7 @@ class TestAssertIsAdjoint:
         )
 
 
-@pytest.mark.skipif(not sys.platform.startswith('linux'), reason="Not Linux.")
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Not Linux.")
 def test_import_time():
     # Relevant for the CLI: How long does it take to import?
     cmd = ["time", "-f", "%U", "python", "-c", "import discretize"]

--- a/tests/boundaries/test_boundary_integrals.py
+++ b/tests/boundaries/test_boundary_integrals.py
@@ -7,12 +7,12 @@ from discretize.utils import cart2cyl, cyl2cart
 def u(*args):
     if len(args) == 1:
         x = args[0]
-        return x**3
+        return x ** 3
     if len(args) == 2:
         x, y = args
-        return x**3 + y**2
+        return x ** 3 + y ** 2
     x, y, z = args
-    return x**3 + y**2 + z**4
+    return x ** 3 + y ** 2 + z ** 4
 
 
 def u_cyl(*args):
@@ -23,12 +23,12 @@ def u_cyl(*args):
 def v(*args):
     if len(args) == 1:
         x = args[0]
-        return 2*x**2
+        return 2 * x ** 2
     if len(args) == 2:
         x, y = args
-        return np.c_[2*x**2, 3*y**3]
+        return np.c_[2 * x ** 2, 3 * y ** 3]
     x, y, z = args
-    return np.c_[2*x**2, 3*y**3, -4*z**2]
+    return np.c_[2 * x ** 2, 3 * y ** 3, -4 * z ** 2]
 
 
 def v_cyl(*args):
@@ -40,15 +40,16 @@ def v_cyl(*args):
 def w(*args):
     if len(args) == 2:
         x, y = args
-        return np.c_[(y - 2)**2, (x + 2)**2]
+        return np.c_[(y - 2) ** 2, (x + 2) ** 2]
     x, y, z = args
-    return np.c_[(y-2)**2 + z**2, (x+2)**2 - (z-4)**2, y**2-x**2]
+    return np.c_[(y - 2) ** 2 + z ** 2, (x + 2) ** 2 - (z - 4) ** 2, y ** 2 - x ** 2]
 
 
 def w_cyl(*args):
     xyz = cyl2cart(np.stack(args, axis=-1))
     xyz_vec = w(*xyz.T)
     return cart2cyl(xyz, xyz_vec)
+
 
 # mesh will be on [0, 1] square
 
@@ -98,18 +99,18 @@ class Test1DBoundaryIntegral(discretize.tests.OrderTest):
             M_bf = mesh.boundary_face_scalar_integral
 
             discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
-            true_val = 6/5
+            true_val = 6 / 5
         if self.myTest == "edge_div":
             u_n = u(mesh.nodes)
             v_e = v(mesh.edges)
-            v_bn = v(mesh.boundary_nodes).reshape(-1, order='F')
+            v_bn = v(mesh.boundary_nodes).reshape(-1, order="F")
 
             M_e = mesh.get_edge_inner_product()
             G = mesh.nodal_gradient
             M_bn = mesh.boundary_node_vector_integral
 
             discrete_val = -(u_n.T @ G.T) @ M_e @ v_e + u_n.T @ (M_bn @ v_bn)
-            true_val = 4/5
+            true_val = 4 / 5
         return np.abs(discrete_val - true_val)
 
     def test_orderWeakCellGradIntegral(self):
@@ -130,8 +131,8 @@ class Test2DBoundaryIntegral(discretize.tests.OrderTest):
         "uniformTree",
         "uniformCurv",
         "rotateCurv",
-        "sphereCurv"
-        ]
+        "sphereCurv",
+    ]
     meshDimension = 2
     expectedOrders = [2, 2, 2, 2, 1]
     meshSizes = [4, 8, 16, 32, 64, 128]
@@ -150,13 +151,13 @@ class Test2DBoundaryIntegral(discretize.tests.OrderTest):
 
             discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
             if "sphere" not in self._meshType:
-                true_val = 12/5
+                true_val = 12 / 5
             else:
-                true_val = 3*np.pi/2
+                true_val = 3 * np.pi / 2
         elif self.myTest == "edge_div":
             u_n = u(*mesh.nodes.T)
             v_e = mesh.project_edge_vector(v(*mesh.edges.T))
-            v_bn = v(*mesh.boundary_nodes.T).reshape(-1, order='F')
+            v_bn = v(*mesh.boundary_nodes.T).reshape(-1, order="F")
 
             M_e = mesh.get_edge_inner_product()
             G = mesh.nodal_gradient
@@ -164,9 +165,9 @@ class Test2DBoundaryIntegral(discretize.tests.OrderTest):
 
             discrete_val = -(u_n.T @ G.T) @ M_e @ v_e + u_n.T @ (M_bn @ v_bn)
             if "sphere" not in self._meshType:
-                true_val = 241/60
+                true_val = 241 / 60
             else:
-                true_val = 13*np.pi/8
+                true_val = 13 * np.pi / 8
         elif self.myTest == "face_curl":
             w_e = mesh.project_edge_vector(w(*mesh.edges.T))
             u_c = u(*mesh.cell_centers.T)
@@ -177,12 +178,12 @@ class Test2DBoundaryIntegral(discretize.tests.OrderTest):
             M_be = mesh.boundary_edge_vector_integral
 
             discrete_val = (w_e.T @ Curl.T) @ M_c @ u_c - w_e.T @ (M_be @ u_be)
-            if 'Curv' in self._meshType:
+            if "Curv" in self._meshType:
                 self._expectedOrder = -1.0
             if "sphere" not in self._meshType:
-                true_val = -173/30
+                true_val = -173 / 30
             else:
-                true_val = -43*np.pi/8
+                true_val = -43 * np.pi / 8
 
         return np.abs(discrete_val - true_val)
 
@@ -211,7 +212,7 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
         "uniformCurv",
         "rotateCurv",
         "sphereCurv",
-        ]
+    ]
     meshDimension = 3
     expectedOrders = [2, 1, 2, 2, 2, 0]
     meshSizes = [4, 8, 16, 32]
@@ -230,13 +231,13 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
 
             discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
             if "sphere" not in self._meshType:
-                true_val = -4/15
+                true_val = -4 / 15
             else:
-                true_val = 48*np.pi/35
+                true_val = 48 * np.pi / 35
         elif self.myTest == "edge_div":
             u_n = u(*mesh.nodes.T)
             v_e = mesh.project_edge_vector(v(*mesh.edges.T))
-            v_bn = v(*mesh.boundary_nodes.T).reshape(-1, order='F')
+            v_bn = v(*mesh.boundary_nodes.T).reshape(-1, order="F")
 
             M_e = mesh.get_edge_inner_product()
             G = mesh.nodal_gradient
@@ -244,13 +245,13 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
 
             discrete_val = -(u_n.T @ G.T) @ M_e @ v_e + u_n.T @ (M_bn @ v_bn)
             if "sphere" not in self._meshType:
-                true_val = 27/20
+                true_val = 27 / 20
             else:
-                true_val = 8*np.pi/5
+                true_val = 8 * np.pi / 5
         elif self.myTest == "face_curl":
             w_f = mesh.project_face_vector(w(*mesh.faces.T))
             v_e = mesh.project_edge_vector(v(*mesh.edges.T))
-            w_be = w(*mesh.boundary_edges.T).reshape(-1, order='F')
+            w_be = w(*mesh.boundary_edges.T).reshape(-1, order="F")
 
             M_f = mesh.get_face_inner_product()
             Curl = mesh.edge_curl
@@ -258,9 +259,9 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
 
             discrete_val = (v_e.T @ Curl.T) @ M_f @ w_f - v_e.T @ (M_be @ w_be)
             if "sphere" not in self._meshType:
-                true_val = -79/6
+                true_val = -79 / 6
             else:
-                true_val = -64*np.pi/5
+                true_val = -64 * np.pi / 5
 
         return np.abs(discrete_val - true_val)
 
@@ -284,9 +285,11 @@ class Test3DCylindricalBoundary(discretize.tests.OrderTest):
     name = "3D Cylindrical Boundary Integrals"
     meshTypes = [
         "uniformCylindricalMesh",
-        ]
+    ]
     meshDimension = 3
-    expectedOrders = [2, ]
+    expectedOrders = [
+        2,
+    ]
     meshSizes = [8, 16, 32, 64]
 
     def getError(self):
@@ -302,17 +305,17 @@ class Test3DCylindricalBoundary(discretize.tests.OrderTest):
             M_bf = mesh.boundary_face_scalar_integral
 
             discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
-            true_val = -7 * np.pi/6
+            true_val = -7 * np.pi / 6
         elif self.myTest == "edge_div":
             u_n = u_cyl(*mesh.nodes.T)
             v_e = mesh.project_edge_vector(v_cyl(*mesh.edges.T))
-            v_bn = v_cyl(*mesh.boundary_nodes.T).reshape(-1, order='F')
+            v_bn = v_cyl(*mesh.boundary_nodes.T).reshape(-1, order="F")
 
             M_e = mesh.get_edge_inner_product()
             G = mesh.nodal_gradient
             M_bn = mesh.boundary_node_vector_integral
 
-            true_val = -31 * np.pi/120
+            true_val = -31 * np.pi / 120
             discrete_val = -(u_n.T @ G.T) @ M_e @ v_e + u_n.T @ (M_bn @ v_bn)
         return np.abs(discrete_val - true_val)
 

--- a/tests/boundaries/test_boundary_maxwell.py
+++ b/tests/boundaries/test_boundary_maxwell.py
@@ -16,7 +16,7 @@ class TestFz2D_InhomogeneousDirichlet(discretize.tests.OrderTest):
         # PDE: Curl(Curl Ez) + Ez = q
         # faces_z are cell_centers on 2D mesh
         ez_fun = lambda x: np.cos(np.pi * x[:, 0]) * np.cos(np.pi * x[:, 1])
-        q_fun = lambda x: (1+2*np.pi**2) * ez_fun(x)
+        q_fun = lambda x: (1 + 2 * np.pi ** 2) * ez_fun(x)
 
         mesh = self.M
         ez_ana = ez_fun(mesh.cell_centers)
@@ -35,9 +35,9 @@ class TestFz2D_InhomogeneousDirichlet(discretize.tests.OrderTest):
 
         ez_test = Pardiso(A) * rhs
         if self._meshType == "rotateCurv":
-            err = np.linalg.norm(mesh.cell_volumes*(ez_test - ez_ana))
+            err = np.linalg.norm(mesh.cell_volumes * (ez_test - ez_ana))
         else:
-            err = np.linalg.norm(ez_test - ez_ana)/np.sqrt(mesh.n_cells)
+            err = np.linalg.norm(ez_test - ez_ana) / np.sqrt(mesh.n_cells)
 
         return err
 
@@ -45,6 +45,7 @@ class TestFz2D_InhomogeneousDirichlet(discretize.tests.OrderTest):
         self.name = "2D - InhomogeneousDirichlet_Inverse"
         self.myTest = "xc"
         self.orderTest()
+
 
 class TestE3D_Inhomogeneous(discretize.tests.OrderTest):
     name = "3D - Maxwell"
@@ -59,16 +60,12 @@ class TestE3D_Inhomogeneous(discretize.tests.OrderTest):
         def e_fun(x):
             x = np.cos(x)
             cx, cy, cz = x[:, 0], x[:, 1], x[:, 2]
-            return np.c_[cy*cz, cx*cz, cx*cy]
+            return np.c_[cy * cz, cx * cz, cx * cy]
 
         def h_fun(x):
             cx, cy, cz = np.cos(x[:, 0]), np.cos(x[:, 1]), np.cos(x[:, 2])
             sx, sy, sz = np.sin(x[:, 0]), np.sin(x[:, 1]), np.sin(x[:, 2])
-            return np.c_[
-                (-sy + sz)*cx,
-                (sx - sz)*cy,
-                (-sx + sy)*cz
-            ]
+            return np.c_[(-sy + sz) * cx, (sx - sz) * cy, (-sx + sy) * cz]
 
         def q_fun(x):
             return 3 * e_fun(x)
@@ -76,11 +73,11 @@ class TestE3D_Inhomogeneous(discretize.tests.OrderTest):
         mesh = self.M
         C = mesh.edge_curl
 
-        if 'Face' in self.myTest:
+        if "Face" in self.myTest:
             e_ana = mesh.project_face_vector(e_fun(mesh.faces))
             q_ana = mesh.project_face_vector(q_fun(mesh.faces))
 
-            e_bc = e_fun(mesh.boundary_edges).reshape(-1, order='F')
+            e_bc = e_fun(mesh.boundary_edges).reshape(-1, order="F")
 
             MeI = mesh.get_edge_inner_product(invert_matrix=True)
             M_be = mesh.boundary_edge_vector_integral
@@ -93,28 +90,28 @@ class TestE3D_Inhomogeneous(discretize.tests.OrderTest):
             e_ana = mesh.project_edge_vector(e_fun(mesh.edges))
             q_ana = mesh.project_edge_vector(q_fun(mesh.edges))
 
-            h_bc = h_fun(mesh.boundary_edges).reshape(-1, order='F')
+            h_bc = h_fun(mesh.boundary_edges).reshape(-1, order="F")
 
             Mf = mesh.get_face_inner_product()
             Me = mesh.get_edge_inner_product()
             M_be = mesh.boundary_edge_vector_integral
 
             A = C.T @ Mf @ C + Me
-            rhs = Me @ q_ana + M_be*h_bc
+            rhs = Me @ q_ana + M_be * h_bc
 
         e_test = Pardiso(A, is_symmetric=True, is_positive_definite=True) * rhs
 
         diff = e_test - e_ana
         if "Face" in self.myTest:
             if "Curv" in self._meshType or "Tree" in self._meshType:
-                err = np.linalg.norm(Mf*diff)
+                err = np.linalg.norm(Mf * diff)
             else:
-                err = np.linalg.norm(e_test - e_ana)/np.sqrt(mesh.n_faces)
+                err = np.linalg.norm(e_test - e_ana) / np.sqrt(mesh.n_faces)
         elif "Edge" in self.myTest:
             if "Curv" in self._meshType or "Tree" in self._meshType:
-                err = np.linalg.norm(Me*diff)
+                err = np.linalg.norm(Me * diff)
             else:
-                err = np.linalg.norm(e_test - e_ana)/np.sqrt(mesh.n_edges)
+                err = np.linalg.norm(e_test - e_ana) / np.sqrt(mesh.n_edges)
         return err
 
     def test_orderFace(self):

--- a/tests/boundaries/test_boundary_poisson.py
+++ b/tests/boundaries/test_boundary_poisson.py
@@ -41,7 +41,7 @@ class TestCC1D_InhomogeneousDirichlet(discretize.tests.OrderTest):
         rhs = V @ q_ana - V @ D @ MfI @ M_bf @ phi_bc
 
         phi_test = Solver(A) * rhs
-        err = np.linalg.norm((phi_test - phi_ana))/np.sqrt(mesh.n_cells)
+        err = np.linalg.norm((phi_test - phi_ana)) / np.sqrt(mesh.n_cells)
 
         return err
 
@@ -84,9 +84,9 @@ class TestCC2D_InhomogeneousDirichlet(discretize.tests.OrderTest):
 
         phi_test = Solver(A) * rhs
         if self._meshType == "rotateCurv":
-            err = np.linalg.norm(mesh.cell_volumes*(phi_test - phi_ana))
+            err = np.linalg.norm(mesh.cell_volumes * (phi_test - phi_ana))
         else:
-            err = np.linalg.norm(phi_test - phi_ana)/np.sqrt(mesh.n_cells)
+            err = np.linalg.norm(phi_test - phi_ana) / np.sqrt(mesh.n_cells)
 
         return err
 
@@ -127,9 +127,11 @@ class TestCC1D_InhomogeneousNeumann(discretize.tests.OrderTest):
         alpha = 0.0
         beta = 1.0
         gamma = alpha * phi_bc + beta * j_bc * mesh.boundary_face_outward_normals
-        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(alpha=alpha, beta=beta, gamma=gamma)
+        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(
+            alpha=alpha, beta=beta, gamma=gamma
+        )
 
-        j = MfI @ ((-G+B_bc)@ xc_ana + b_bc)
+        j = MfI @ ((-G + B_bc) @ xc_ana + b_bc)
         q = D @ j
 
         # Since the xc_bc is a known, move it to the RHS!
@@ -144,7 +146,7 @@ class TestCC1D_InhomogeneousNeumann(discretize.tests.OrderTest):
             # TODO: fix the null space
             xc, info = linalg.minres(A, rhs, tol=1e-6)
             j = MfI @ ((-G + B_bc) @ xc + b_bc)
-            err = np.linalg.norm((j - j_ana))/np.sqrt(mesh.n_edges)
+            err = np.linalg.norm((j - j_ana)) / np.sqrt(mesh.n_edges)
             if info > 0:
                 print("Solve does not work well")
                 print("ACCURACY", np.linalg.norm(utils.mkvc(A * xc) - rhs))
@@ -198,7 +200,9 @@ class TestCC2D_InhomogeneousNeumann(discretize.tests.OrderTest):
         beta = 1.0
         gamma = alpha * phi_bc + beta * j_bc_dot_n
 
-        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(alpha=alpha, beta=beta, gamma=gamma)
+        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(
+            alpha=alpha, beta=beta, gamma=gamma
+        )
 
         A = V @ D @ MfI @ (-G + B_bc)
         rhs = V @ q_ana - V @ D @ MfI @ b_bc
@@ -210,7 +214,7 @@ class TestCC2D_InhomogeneousNeumann(discretize.tests.OrderTest):
         # err = np.linalg.norm(phi_test - phi_ana)/np.sqrt(mesh.n_cells)
 
         if self._meshType == "rotateCurv":
-            err = np.linalg.norm(mesh.cell_volumes*(phi_test - phi_ana))
+            err = np.linalg.norm(mesh.cell_volumes * (phi_test - phi_ana))
         else:
             err = np.linalg.norm((phi_test - phi_ana), np.inf)
 
@@ -253,17 +257,19 @@ class TestCC1D_InhomogeneousMixed(discretize.tests.OrderTest):
         alpha = np.r_[1.0, 0.0]
         beta = np.r_[0.0, 1.0]
         gamma = alpha * phi_bc + beta * j_bc * mesh.boundary_face_outward_normals
-        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(alpha=alpha, beta=beta, gamma=gamma)
+        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(
+            alpha=alpha, beta=beta, gamma=gamma
+        )
 
         A = V @ D @ MfI @ (-G + B_bc)
         rhs = V @ q_ana - V @ D @ MfI @ b_bc
 
         if self.myTest == "xc":
-            xc = Solver(A)*rhs
-            err = np.linalg.norm(xc - xc_ana)/np.sqrt(mesh.n_cells)
+            xc = Solver(A) * rhs
+            err = np.linalg.norm(xc - xc_ana) / np.sqrt(mesh.n_cells)
         elif self.myTest == "xcJ":
-            xc = Solver(A)*rhs
-            j = MfI @ ((-G+B_bc)@ xc + b_bc)
+            xc = Solver(A) * rhs
+            j = MfI @ ((-G + B_bc) @ xc + b_bc)
             err = np.linalg.norm(j - j_ana, np.inf)
         return err
 
@@ -323,7 +329,9 @@ class TestCC2D_InhomogeneousMixed(discretize.tests.OrderTest):
 
         gamma = alpha * phi_bc + beta * j_bc_dot_n
 
-        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(alpha=alpha, beta=beta, gamma=gamma)
+        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(
+            alpha=alpha, beta=beta, gamma=gamma
+        )
 
         A = V @ D @ MfI @ (-G + B_bc)
         rhs = V @ q_ana - V @ D @ MfI @ b_bc
@@ -331,9 +339,9 @@ class TestCC2D_InhomogeneousMixed(discretize.tests.OrderTest):
         phi_test = Solver(A) * rhs
 
         if self._meshType == "rotateCurv":
-            err = np.linalg.norm(mesh.cell_volumes*(phi_test - phi_ana))
+            err = np.linalg.norm(mesh.cell_volumes * (phi_test - phi_ana))
         else:
-            err = np.linalg.norm((phi_test - phi_ana))/np.sqrt(mesh.n_cells)
+            err = np.linalg.norm((phi_test - phi_ana)) / np.sqrt(mesh.n_cells)
 
         return err
 
@@ -352,11 +360,30 @@ class TestCC3D_InhomogeneousMixed(discretize.tests.OrderTest):
 
     def getError(self):
         # Test function
-        phi = lambda x: np.sin(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1]) * np.sin(np.pi * x[:, 2])
+        phi = (
+            lambda x: np.sin(np.pi * x[:, 0])
+            * np.sin(np.pi * x[:, 1])
+            * np.sin(np.pi * x[:, 2])
+        )
 
-        j_funX = lambda x: np.pi * np.cos(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1]) * np.sin(np.pi * x[:, 2])
-        j_funY = lambda x: np.pi * np.sin(np.pi * x[:, 0]) * np.cos(np.pi * x[:, 1]) * np.sin(np.pi * x[:, 2])
-        j_funZ = lambda x: np.pi * np.sin(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1]) * np.cos(np.pi * x[:, 2])
+        j_funX = (
+            lambda x: np.pi
+            * np.cos(np.pi * x[:, 0])
+            * np.sin(np.pi * x[:, 1])
+            * np.sin(np.pi * x[:, 2])
+        )
+        j_funY = (
+            lambda x: np.pi
+            * np.sin(np.pi * x[:, 0])
+            * np.cos(np.pi * x[:, 1])
+            * np.sin(np.pi * x[:, 2])
+        )
+        j_funZ = (
+            lambda x: np.pi
+            * np.sin(np.pi * x[:, 0])
+            * np.sin(np.pi * x[:, 1])
+            * np.cos(np.pi * x[:, 2])
+        )
 
         q_fun = lambda x: -3 * (np.pi ** 2) * phi(x)
 
@@ -391,7 +418,9 @@ class TestCC3D_InhomogeneousMixed(discretize.tests.OrderTest):
 
         gamma = alpha * phi_bc + beta * j_bc_dot_n
 
-        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(alpha=alpha, beta=beta, gamma=gamma)
+        B_bc, b_bc = mesh.cell_gradient_weak_form_robin(
+            alpha=alpha, beta=beta, gamma=gamma
+        )
 
         A = V @ D @ MfI @ (-G + B_bc)
         rhs = V @ q_ana - V @ D @ MfI @ b_bc
@@ -399,9 +428,9 @@ class TestCC3D_InhomogeneousMixed(discretize.tests.OrderTest):
         phi_test = Pardiso(A) * rhs
 
         if self._meshType == "rotateCurv":
-            err = np.linalg.norm(mesh.cell_volumes*(phi_test - phi_ana))
+            err = np.linalg.norm(mesh.cell_volumes * (phi_test - phi_ana))
         else:
-            err = np.linalg.norm(phi_test - phi_ana)/np.sqrt(mesh.n_cells)
+            err = np.linalg.norm(phi_test - phi_ana) / np.sqrt(mesh.n_cells)
         return err
 
     def test_orderX(self):
@@ -425,7 +454,9 @@ class TestN1D_boundaries(discretize.tests.OrderTest):
         q_fun = lambda x: -1 * (np.pi ** 2) * phi(x)
 
         mesh = self.M
-        mesh.origin = [-0.25, ]
+        mesh.origin = [
+            -0.25,
+        ]
 
         phi_ana = phi(mesh.nodes)
         j_ana = j_fun(mesh.edges_x)
@@ -492,9 +523,9 @@ class TestN2D_boundaries(discretize.tests.OrderTest):
 
     def getError(self):
         # Test function
-        phi = lambda x: np.sin(np.pi * x[:, 0])*np.sin(np.pi*x[:, 1])
-        j_funX = lambda x: np.pi * np.cos(np.pi * x[:, 0])*np.sin(np.pi*x[:, 1])
-        j_funY = lambda x: np.pi * np.cos(np.pi * x[:, 1])*np.sin(np.pi*x[:, 0])
+        phi = lambda x: np.sin(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1])
+        j_funX = lambda x: np.pi * np.cos(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1])
+        j_funY = lambda x: np.pi * np.cos(np.pi * x[:, 1]) * np.sin(np.pi * x[:, 0])
         q_fun = lambda x: -2 * (np.pi ** 2) * phi(x)
 
         mesh = self.M
@@ -518,7 +549,7 @@ class TestN2D_boundaries(discretize.tests.OrderTest):
             M_bn = mesh.boundary_node_vector_integral
 
             B_bc = sp.csr_matrix((mesh.n_nodes, mesh.n_nodes))
-            b_bc = M_bn @ (j_bc.reshape(-1, order='F'))
+            b_bc = M_bn @ (j_bc.reshape(-1, order="F"))
         else:
             phi_bc = phi(mesh.boundary_faces)
             jx_bc = j_funX(mesh.boundary_faces)
@@ -587,11 +618,30 @@ class TestN3D_boundaries(discretize.tests.OrderTest):
 
     def getError(self):
         # Test function
-        phi = lambda x: np.sin(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1]) * np.sin(np.pi * x[:, 2])
+        phi = (
+            lambda x: np.sin(np.pi * x[:, 0])
+            * np.sin(np.pi * x[:, 1])
+            * np.sin(np.pi * x[:, 2])
+        )
 
-        j_funX = lambda x: np.pi * np.cos(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1]) * np.sin(np.pi * x[:, 2])
-        j_funY = lambda x: np.pi * np.sin(np.pi * x[:, 0]) * np.cos(np.pi * x[:, 1]) * np.sin(np.pi * x[:, 2])
-        j_funZ = lambda x: np.pi * np.sin(np.pi * x[:, 0]) * np.sin(np.pi * x[:, 1]) * np.cos(np.pi * x[:, 2])
+        j_funX = (
+            lambda x: np.pi
+            * np.cos(np.pi * x[:, 0])
+            * np.sin(np.pi * x[:, 1])
+            * np.sin(np.pi * x[:, 2])
+        )
+        j_funY = (
+            lambda x: np.pi
+            * np.sin(np.pi * x[:, 0])
+            * np.cos(np.pi * x[:, 1])
+            * np.sin(np.pi * x[:, 2])
+        )
+        j_funZ = (
+            lambda x: np.pi
+            * np.sin(np.pi * x[:, 0])
+            * np.sin(np.pi * x[:, 1])
+            * np.cos(np.pi * x[:, 2])
+        )
 
         q_fun = lambda x: -3 * (np.pi ** 2) * phi(x)
 
@@ -607,11 +657,7 @@ class TestN3D_boundaries(discretize.tests.OrderTest):
 
         phi_ana = phi(mesh.nodes)
         q_ana = q_fun(mesh.nodes)
-        j_ana = np.r_[
-            j_funX(mesh.edges_x),
-            j_funY(mesh.edges_y),
-            j_funZ(mesh.edges_z)
-        ]
+        j_ana = np.r_[j_funX(mesh.edges_x), j_funY(mesh.edges_y), j_funZ(mesh.edges_z)]
 
         if self.boundary_type == "Nuemann":
             # Nuemann with J defined at boundary nodes
@@ -623,7 +669,7 @@ class TestN3D_boundaries(discretize.tests.OrderTest):
             M_bn = mesh.boundary_node_vector_integral
 
             B_bc = sp.csr_matrix((mesh.n_nodes, mesh.n_nodes))
-            b_bc = M_bn @ (j_bc.reshape(-1, order='F'))
+            b_bc = M_bn @ (j_bc.reshape(-1, order="F"))
         else:
             phi_bc = phi(mesh.boundary_faces)
             jx_bc = j_funX(mesh.boundary_faces)

--- a/tests/boundaries/test_errors.py
+++ b/tests/boundaries/test_errors.py
@@ -4,7 +4,6 @@ import discretize
 
 
 class RobinOperatorTest(unittest.TestCase):
-
     def setUp(self):
         self.mesh = discretize.TensorMesh([18, 20, 32])
 
@@ -18,39 +17,25 @@ class RobinOperatorTest(unittest.TestCase):
         beta = np.full(n_boundary_faces, 1.5)
         gamma = np.full(n_boundary_faces, 2.0)
 
-        B1, b1 = mesh.cell_gradient_weak_form_robin(
-            alpha=alpha,
-            beta=beta,
-            gamma=gamma
-        )
+        B1, b1 = mesh.cell_gradient_weak_form_robin(alpha=alpha, beta=beta, gamma=gamma)
 
         for a in [0.5, alpha]:
             for b in [1.5, beta]:
                 for g in [2.0, gamma]:
                     B_t, bt = mesh.cell_gradient_weak_form_robin(
-                        alpha=a,
-                        beta=b,
-                        gamma=g
+                        alpha=a, beta=b, gamma=g
                     )
                     np.testing.assert_equal(bt, b1)
-                    self.assertEqual((B1-B_t).nnz, 0)
+                    self.assertEqual((B1 - B_t).nnz, 0)
 
         gamma = np.random.rand(n_boundary_faces, 2)
         B1, b1 = mesh.cell_gradient_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma[:, 0]
+            alpha=0.5, beta=1.5, gamma=gamma[:, 0]
         )
         B2, b2 = mesh.cell_gradient_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma[:, 1]
+            alpha=0.5, beta=1.5, gamma=gamma[:, 1]
         )
-        B3, b3 = mesh.cell_gradient_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma
-        )
+        B3, b3 = mesh.cell_gradient_weak_form_robin(alpha=0.5, beta=1.5, gamma=gamma)
         np.testing.assert_allclose(B1.data, B2.data)
         np.testing.assert_allclose(B1.data, B3.data)
         np.testing.assert_allclose(np.c_[b1, b2], b3)
@@ -68,18 +53,14 @@ class RobinOperatorTest(unittest.TestCase):
         gamma = np.full(n_boundary_faces, 2.0)
 
         B1, b1 = mesh.edge_divergence_weak_form_robin(
-            alpha=alpha,
-            beta=beta,
-            gamma=gamma
+            alpha=alpha, beta=beta, gamma=gamma
         )
 
         for a in [0.5, alpha]:
             for b in [1.5, beta]:
                 for g in [2.0, gamma]:
                     B_t, bt = mesh.edge_divergence_weak_form_robin(
-                        alpha=a,
-                        beta=b,
-                        gamma=g
+                        alpha=a, beta=b, gamma=g
                     )
                     np.testing.assert_allclose(bt, b1)
                     np.testing.assert_allclose(B1.data, B_t.data)
@@ -92,49 +73,31 @@ class RobinOperatorTest(unittest.TestCase):
             for b in [1.5, beta]:
                 for g in [2.0, gamma]:
                     B_t, bt = mesh.edge_divergence_weak_form_robin(
-                        alpha=a,
-                        beta=b,
-                        gamma=g
+                        alpha=a, beta=b, gamma=g
                     )
                     np.testing.assert_allclose(bt, b1)
                     np.testing.assert_allclose(B1.data, B_t.data)
 
         gamma = np.random.rand(n_boundary_faces, 2)
         B1, b1 = mesh.edge_divergence_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma[:, 0]
+            alpha=0.5, beta=1.5, gamma=gamma[:, 0]
         )
         B2, b2 = mesh.edge_divergence_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma[:, 1]
+            alpha=0.5, beta=1.5, gamma=gamma[:, 1]
         )
-        B3, b3 = mesh.edge_divergence_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma
-        )
+        B3, b3 = mesh.edge_divergence_weak_form_robin(alpha=0.5, beta=1.5, gamma=gamma)
         np.testing.assert_allclose(B1.data, B2.data)
         np.testing.assert_allclose(B1.data, B3.data)
         np.testing.assert_allclose(np.c_[b1, b2], b3)
 
         gamma = np.random.rand(n_boundary_nodes, 2)
         B1, b1 = mesh.edge_divergence_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma[:, 0]
+            alpha=0.5, beta=1.5, gamma=gamma[:, 0]
         )
         B2, b2 = mesh.edge_divergence_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma[:, 1]
+            alpha=0.5, beta=1.5, gamma=gamma[:, 1]
         )
-        B3, b3 = mesh.edge_divergence_weak_form_robin(
-            alpha=0.5,
-            beta=1.5,
-            gamma=gamma
-        )
+        B3, b3 = mesh.edge_divergence_weak_form_robin(alpha=0.5, beta=1.5, gamma=gamma)
         np.testing.assert_allclose(B1.data, B2.data)
         np.testing.assert_allclose(B1.data, B3.data)
         np.testing.assert_allclose(np.c_[b1, b2], b3)
@@ -165,9 +128,8 @@ class RobinOperatorTest(unittest.TestCase):
 
 
 class mesh1DTests(unittest.TestCase):
-
     def setUp(self):
-        self.mesh, _ = discretize.tests.setup_mesh('uniformTensorMesh', 32, 1)
+        self.mesh, _ = discretize.tests.setup_mesh("uniformTensorMesh", 32, 1)
 
     def testItems(self):
         mesh = self.mesh

--- a/tests/cyl/test_cyl3D.py
+++ b/tests/cyl/test_cyl3D.py
@@ -90,6 +90,7 @@ def test_boundary_items():
     P_bf = mesh.project_face_to_boundary_face
     np.testing.assert_equal(mesh.boundary_faces, P_bf @ mesh.faces)
 
+
 # ----------------------- Test Grids and Counting --------------------------- #
 
 
@@ -356,11 +357,17 @@ class Deflation(unittest.TestCase):
         mesh = discretize.CylMesh([2, 5, 3])
 
         hangingF = np.hstack(
-            [getattr(mesh, "_ishanging_faces_{}".format(dim)) for dim in ["x", "y", "z"]]
+            [
+                getattr(mesh, "_ishanging_faces_{}".format(dim))
+                for dim in ["x", "y", "z"]
+            ]
         )
         self.assertTrue(np.all(mesh._face_areas_full[~hangingF] == mesh.area))
         hangingE = np.hstack(
-            [getattr(mesh, "_ishanging_edges_{}".format(dim)) for dim in ["x", "y", "z"]]
+            [
+                getattr(mesh, "_ishanging_edges_{}".format(dim))
+                for dim in ["x", "y", "z"]
+            ]
         )
         self.assertTrue(np.all(mesh._edge_lengths_full[~hangingE] == mesh.edge))
 

--- a/tests/cyl/test_cylOperators.py
+++ b/tests/cyl/test_cylOperators.py
@@ -274,7 +274,7 @@ class TestAveCC2F(tests.OrderTest):
     meshTypes = ["uniformCylindricalMesh"]
     meshSizes = [8, 16, 32, 64]
     meshDimension = 3
-    expectedOrders = 1 # Extrapolation at the boundaries
+    expectedOrders = 1  # Extrapolation at the boundaries
     full = True
 
     def getError(self):
@@ -586,11 +586,14 @@ class TestCylNodalGradient_Order(tests.OrderTest):
 
             g_r = out_t * 2 * np.pi * np.cos(2 * np.pi * r)
             g_phi = out_r / r * np.cos(t)
-            g_phi[r==0.0] = 0.0
+            g_phi[r == 0.0] = 0.0
             out = np.c_[g_r, g_phi]
             if z is not None:
                 out_z = np.sin(2 * np.pi * z)
-                out = np.c_[out_z[:, None] * out, out_r * out_t * 2 * np.pi * np.cos(2 * np.pi * z)]
+                out = np.c_[
+                    out_z[:, None] * out,
+                    out_r * out_t * 2 * np.pi * np.cos(2 * np.pi * z),
+                ]
             return out
 
         phi = fun(*mesh.nodes.T)
@@ -633,12 +636,10 @@ class MimeticProperties(unittest.TestCase):
             v = np.random.rand(mesh.nN)
             curlgradv = mesh.edge_curl * (mesh.nodal_gradient * v)
             rel_err = np.linalg.norm(curlgradv) / np.linalg.norm(v)
-            passed = rel_err  < self.tol
+            passed = rel_err < self.tol
             print(
                 "Testing Curl * Grad on {} : |Curl Grad v| / |v|= {} "
-                "... {}".format(
-                    meshType, rel_err, 'FAIL' if not passed else 'ok'
-                )
+                "... {}".format(meshType, rel_err, "FAIL" if not passed else "ok")
             )
 
 

--- a/tests/cyl/test_cyl_innerproducts.py
+++ b/tests/cyl/test_cyl_innerproducts.py
@@ -13,7 +13,7 @@ np.random.seed(99)
 
 
 class FaceInnerProductFctsIsotropic(object):
-    """ Some made up face functions to test the face inner product """
+    """Some made up face functions to test the face inner product"""
 
     def fcts(self):
         j = sympy.Matrix([r ** 2 * z, r * z ** 2])
@@ -43,7 +43,7 @@ class FaceInnerProductFctsIsotropic(object):
         return ans
 
     def vectors(self, mesh):
-        """ Get Vectors sig, sr. jx from sympy"""
+        """Get Vectors sig, sr. jx from sympy"""
         j, Sig = self.fcts()
 
         f_jr = sympy.lambdify((r, z), j[0], "numpy")
@@ -78,7 +78,7 @@ class FaceInnerProductFunctionsDiagAnisotropic(FaceInnerProductFctsIsotropic):
         return j, Sig
 
     def vectors(self, mesh):
-        """ Get Vectors sig, sr. jx from sympy"""
+        """Get Vectors sig, sr. jx from sympy"""
         j, Sig = self.fcts()
 
         f_jr = sympy.lambdify((r, z), j[0], "numpy")
@@ -95,7 +95,7 @@ class FaceInnerProductFunctionsDiagAnisotropic(FaceInnerProductFctsIsotropic):
 
 
 class EdgeInnerProductFctsIsotropic(object):
-    """ Some made up edge functions to test the edge inner product """
+    """Some made up edge functions to test the edge inner product"""
 
     def fcts(self):
         h = sympy.Matrix([r ** 2 * z])
@@ -118,7 +118,7 @@ class EdgeInnerProductFctsIsotropic(object):
         return ans
 
     def vectors(self, mesh):
-        """ Get Vectors sig, sr. jx from sympy"""
+        """Get Vectors sig, sr. jx from sympy"""
         h, Sig = self.fcts()
 
         f_h = sympy.lambdify((r, z), h[0], "numpy")

--- a/tests/cyl/test_cyl_io.py
+++ b/tests/cyl/test_cyl_io.py
@@ -3,9 +3,11 @@ import discretize
 import pytest
 import os
 
+
 def test_convert_to_vtk():
     mesh = discretize.CylindricalMesh([20, 15, 10])
     vtk_mesh = mesh.to_vtk()
+
 
 def test_bad_convert():
     mesh = discretize.CylindricalMesh([20, 2, 10])
@@ -16,15 +18,17 @@ def test_bad_convert():
     with pytest.raises(NotImplementedError):
         mesh.to_vtk()
 
+
 def test_serialize():
     mesh = discretize.CylindricalMesh([20, 10, 3])
-    mesh.save('test.cyl')
-    mesh2 = discretize.load_mesh('test.cyl')
+    mesh.save("test.cyl")
+    mesh2 = discretize.load_mesh("test.cyl")
     assert mesh.equals(mesh2)
+
 
 @pytest.fixture(autouse=True)
 def cleanup_files(monkeypatch):
-    files = ['test.cyl']
+    files = ["test.cyl"]
     yield
     for file in files:
         try:

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -2,6 +2,7 @@ import unittest
 import os
 from sphinx.application import Sphinx
 import multiprocessing
+
 n_cpu = multiprocessing.cpu_count()
 
 
@@ -15,14 +16,32 @@ class Doc_Test(unittest.TestCase):
         src_dir = config_dir = self.path_to_docs
         output_dir = os.path.sep.join([src_dir, "_build", "html"])
         doctree_dir = os.path.sep.join([src_dir, "_build", "doctrees"])
-        app = Sphinx(src_dir, config_dir, output_dir, doctree_dir, buildername="html", warningiserror=False, parallel=n_cpu, confoverrides={"numpydoc_show_inherited_class_members":False})
+        app = Sphinx(
+            src_dir,
+            config_dir,
+            output_dir,
+            doctree_dir,
+            buildername="html",
+            warningiserror=False,
+            parallel=n_cpu,
+            confoverrides={"numpydoc_show_inherited_class_members": False},
+        )
         app.build()
 
     def test_linkcheck(self):
         src_dir = config_dir = self.path_to_docs
         output_dir = os.path.sep.join([src_dir, "_build", "linkcheck"])
         doctree_dir = os.path.sep.join([src_dir, "_build", "doctrees"])
-        app = Sphinx(src_dir, config_dir, output_dir, doctree_dir, buildername="linkcheck", warningiserror=False, parallel=n_cpu, confoverrides={"numpydoc_show_inherited_class_members":False})
+        app = Sphinx(
+            src_dir,
+            config_dir,
+            output_dir,
+            doctree_dir,
+            buildername="linkcheck",
+            warningiserror=False,
+            parallel=n_cpu,
+            confoverrides={"numpydoc_show_inherited_class_members": False},
+        )
         app.build()
 
 

--- a/tests/simplex/test_inner_products.py
+++ b/tests/simplex/test_inner_products.py
@@ -8,36 +8,36 @@ from discretize.utils import example_simplex_mesh
 def u(*args):
     if len(args) == 1:
         x = args[0]
-        return x**3
+        return x ** 3
     if len(args) == 2:
         x, y = args
-        return x**3 + y**2
+        return x ** 3 + y ** 2
     x, y, z = args
-    return x**3 + y**2 + z**4
+    return x ** 3 + y ** 2 + z ** 4
 
 
 def v(*args):
     if len(args) == 1:
         x = args[0]
-        return 2*x**2
+        return 2 * x ** 2
     if len(args) == 2:
         x, y = args
-        return np.c_[2*x**2, 3*y**3]
+        return np.c_[2 * x ** 2, 3 * y ** 3]
     x, y, z = args
-    return np.c_[2*x**2, 3*y**3, -4*z**2]
+    return np.c_[2 * x ** 2, 3 * y ** 3, -4 * z ** 2]
 
 
 def w(*args):
     if len(args) == 2:
         x, y = args
-        return np.c_[(y - 2)**2, (x + 2)**2]
+        return np.c_[(y - 2) ** 2, (x + 2) ** 2]
     x, y, z = args
-    return np.c_[(y-2)**2 + z**2, (x+2)**2 - (z-4)**2, y**2-x**2]
+    return np.c_[(y - 2) ** 2 + z ** 2, (x + 2) ** 2 - (z - 4) ** 2, y ** 2 - x ** 2]
 
 
 class TestInnerProducts2D(discretize.tests.OrderTest):
     meshSizes = [8, 16, 32]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
 
     def setupMesh(self, n):
         points, simplices = example_simplex_mesh((n, n))
@@ -60,7 +60,7 @@ class TestInnerProducts2D(discretize.tests.OrderTest):
         cc = mesh.cell_centers
         if self.sigmaTest == 1:
             sigma = np.c_[sigma1(*cc.T)]
-            analytic = 144877.0 / 360   # Found using sympy.
+            analytic = 144877.0 / 360  # Found using sympy.
         elif self.sigmaTest == 2:
             sigma = np.r_[sigma1(*cc.T), sigma2(*cc.T)]
             analytic = 189959.0 / 120  # Found using sympy.
@@ -182,7 +182,7 @@ class TestInnerProducts2D(discretize.tests.OrderTest):
 
 class TestInnerProducts3D(discretize.tests.OrderTest):
     meshSizes = [8, 16, 32]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
 
     def setupMesh(self, n):
         points, simplices = example_simplex_mesh((n, n, n))
@@ -338,9 +338,7 @@ class TestInnerProductsDerivs(unittest.TestCase):
 
         def fun(sig):
             M = mesh.get_face_inner_product(sig)
-            Md = mesh.get_face_inner_product_deriv(
-                sig
-            )
+            Md = mesh.get_face_inner_product_deriv(sig)
             return M * v, Md(v)
 
         print("Face", rep)
@@ -354,9 +352,7 @@ class TestInnerProductsDerivs(unittest.TestCase):
 
         def fun(sig):
             M = mesh.get_edge_inner_product(sig)
-            Md = mesh.get_edge_inner_product_deriv(
-                sig
-            )
+            Md = mesh.get_edge_inner_product_deriv(sig)
             return M * v, Md(v)
 
         print("Edge", rep)
@@ -413,7 +409,7 @@ class TestInnerProductsDerivs(unittest.TestCase):
 
 class Test2DBoundaryIntegral(discretize.tests.OrderTest):
     meshSizes = [8, 16, 32]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
 
     def setupMesh(self, n):
         points, simplices = example_simplex_mesh((n, n))
@@ -433,18 +429,18 @@ class Test2DBoundaryIntegral(discretize.tests.OrderTest):
             M_bf = mesh.boundary_face_scalar_integral
 
             discrete_val = -(v_f.T @ D.T) @ M_c @ u_cc + v_f.T @ (M_bf @ u_bf)
-            true_val = 12/5
+            true_val = 12 / 5
         elif self.myTest == "edge_div":
             u_n = u(*mesh.nodes.T)
             v_e = mesh.project_edge_vector(v(*mesh.edges.T))
-            v_bn = v(*mesh.boundary_nodes.T).reshape(-1, order='F')
+            v_bn = v(*mesh.boundary_nodes.T).reshape(-1, order="F")
 
             M_e = mesh.get_edge_inner_product()
             G = mesh.nodal_gradient
             M_bn = mesh.boundary_node_vector_integral
 
             discrete_val = -(u_n.T @ G.T) @ M_e @ v_e + u_n.T @ (M_bn @ v_bn)
-            true_val = 241/60
+            true_val = 241 / 60
         elif self.myTest == "face_curl":
             w_e = mesh.project_edge_vector(w(*mesh.edges.T))
             u_c = u(*mesh.cell_centers.T)
@@ -455,7 +451,7 @@ class Test2DBoundaryIntegral(discretize.tests.OrderTest):
             M_be = mesh.boundary_edge_vector_integral
 
             discrete_val = (w_e.T @ Curl.T) @ M_c @ u_c - w_e.T @ (M_be @ u_be)
-            true_val = -173/30
+            true_val = -173 / 30
 
         return np.abs(discrete_val - true_val)
 
@@ -476,7 +472,6 @@ class Test2DBoundaryIntegral(discretize.tests.OrderTest):
 
 
 class TestBadModels(unittest.TestCase):
-
     def setUp(self):
         n = 8
         points, simplices = example_simplex_mesh((n, n))

--- a/tests/simplex/test_interpolation.py
+++ b/tests/simplex/test_interpolation.py
@@ -6,10 +6,10 @@ from discretize.utils import example_simplex_mesh
 class TestInterpolation2d(discretize.tests.OrderTest):
     name = "Interpolation 2D"
     meshSizes = [8, 16, 32, 64]
-    meshTypes = ['uniform simplex mesh']
-    interp_points = np.stack(np.mgrid[
-        0.25:0.75:32j, 0.25:0.75:32j
-    ], axis=-1).reshape(-1, 2)
+    meshTypes = ["uniform simplex mesh"]
+    interp_points = np.stack(np.mgrid[0.25:0.75:32j, 0.25:0.75:32j], axis=-1).reshape(
+        -1, 2
+    )
     meshDimension = 2
     expectedOrders = 1
 
@@ -19,8 +19,8 @@ class TestInterpolation2d(discretize.tests.OrderTest):
         return 1.0 / n
 
     def getError(self):
-        funX = lambda x, y: -y**2
-        funY = lambda x, y: x**2
+        funX = lambda x, y: -(y ** 2)
+        funY = lambda x, y: x ** 2
 
         if "x" in self.type:
             ana = funX(*self.interp_points.T)
@@ -84,10 +84,10 @@ class TestInterpolation2d(discretize.tests.OrderTest):
 class TestInterpolation3d(discretize.tests.OrderTest):
     name = "Interpolation 3D"
     meshSizes = [5, 10, 20, 40]
-    meshTypes = ['uniform simplex mesh']
-    interp_points = np.stack(np.mgrid[
-        0.25:0.75:32j, 0.25:0.75:32j, 0.25:0.75:32j
-    ], axis=-1).reshape(-1, 3)
+    meshTypes = ["uniform simplex mesh"]
+    interp_points = np.stack(
+        np.mgrid[0.25:0.75:32j, 0.25:0.75:32j, 0.25:0.75:32j], axis=-1
+    ).reshape(-1, 3)
     meshDimension = 3
     expectedOrders = 1
 
@@ -128,11 +128,7 @@ class TestInterpolation3d(discretize.tests.OrderTest):
                 + funZ(*mesh.cell_centers.T)
             )
         elif "N" == self.type:
-            grid = (
-                funX(*mesh.nodes.T)
-                + funY(*mesh.nodes.T)
-                + funZ(*mesh.nodes.T)
-            )
+            grid = funX(*mesh.nodes.T) + funY(*mesh.nodes.T) + funZ(*mesh.nodes.T)
 
         comp = mesh.get_interpolation_matrix(self.interp_points, self.type) * grid
 
@@ -186,21 +182,26 @@ class TestInterpolation3d(discretize.tests.OrderTest):
 
 class TestAveraging(discretize.tests.OrderTest):
     meshSizes = [8, 16, 32]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
 
     def setupMesh(self, n):
         dim = self.meshDimension
-        points, simplices = example_simplex_mesh(dim * (n, ) )
+        points, simplices = example_simplex_mesh(dim * (n,))
         self.M = discretize.SimplexMesh(points, simplices)
         return 1.0 / n
 
     def getError(self):
         mesh = self.M
         if mesh.dim == 2:
-            func = lambda x, y: np.cos(x**2) - np.sin(y**2) + 2*x*y
+            func = lambda x, y: np.cos(x ** 2) - np.sin(y ** 2) + 2 * x * y
         else:
-            func = lambda x, y, z: np.cos(x**2) - np.sin(y**2) + 2*x*y + np.cos(2*z)**2 + z**3
-
+            func = (
+                lambda x, y, z: np.cos(x ** 2)
+                - np.sin(y ** 2)
+                + 2 * x * y
+                + np.cos(2 * z) ** 2
+                + z ** 3
+            )
 
         if self.target_type == "CC":
             interp_points = mesh.cell_centers
@@ -369,7 +370,7 @@ class TestAveraging(discretize.tests.OrderTest):
 class TestVectorAveraging2D(discretize.tests.OrderTest):
     name = "Averaging 2D"
     meshSizes = [8, 16, 32, 64]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
     meshDimension = 2
     expectedOrders = 1
 
@@ -378,12 +379,13 @@ class TestVectorAveraging2D(discretize.tests.OrderTest):
         self.M = discretize.SimplexMesh(points, simplices)
         return 1.0 / n
 
-
     def getError(self):
-        funX = lambda x, y: -y**2
-        funY = lambda x, y: x**2
+        funX = lambda x, y: -(y ** 2)
+        funY = lambda x, y: x ** 2
         mesh = self.M
-        ana = np.c_[funX(*mesh.cell_centers.T), funY(*mesh.cell_centers.T)].reshape(-1, order='F')
+        ana = np.c_[funX(*mesh.cell_centers.T), funY(*mesh.cell_centers.T)].reshape(
+            -1, order="F"
+        )
 
         if self.source_type == "F":
             Fc = np.c_[funX(*mesh.faces.T), funY(*mesh.faces.T)]
@@ -411,7 +413,7 @@ class TestVectorAveraging2D(discretize.tests.OrderTest):
 class TestVectorAveraging3D(discretize.tests.OrderTest):
     name = "Averaging 3D"
     meshSizes = [8, 16, 32]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
     meshDimension = 3
     expectedOrders = 1
 
@@ -420,13 +422,16 @@ class TestVectorAveraging3D(discretize.tests.OrderTest):
         self.M = discretize.SimplexMesh(points, simplices)
         return 1.0 / n
 
-
     def getError(self):
         funX = lambda x, y, z: np.cos(2 * np.pi * y)
         funY = lambda x, y, z: np.cos(2 * np.pi * z)
         funZ = lambda x, y, z: np.cos(2 * np.pi * x)
         mesh = self.M
-        ana = np.c_[funX(*mesh.cell_centers.T), funY(*mesh.cell_centers.T), funZ(*mesh.cell_centers.T)].reshape(-1, order='F')
+        ana = np.c_[
+            funX(*mesh.cell_centers.T),
+            funY(*mesh.cell_centers.T),
+            funZ(*mesh.cell_centers.T),
+        ].reshape(-1, order="F")
 
         if self.source_type == "F":
             Fc = np.c_[funX(*mesh.faces.T), funY(*mesh.faces.T), funZ(*mesh.faces.T)]

--- a/tests/simplex/test_operators.py
+++ b/tests/simplex/test_operators.py
@@ -5,7 +5,7 @@ from discretize.utils import example_simplex_mesh
 
 class TestOperators2D(discretize.tests.OrderTest):
     meshSizes = [8, 16, 32, 64]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
 
     def setupMesh(self, n):
         points, simplices = example_simplex_mesh((n, n))
@@ -25,32 +25,40 @@ class TestOperators2D(discretize.tests.OrderTest):
             Ep = mesh.project_edge_vector(Ev)
             ana = sol(*mesh.cell_centers.T)
             test = C @ Ep
-            err = np.linalg.norm(mesh.cell_volumes * (test-ana))
+            err = np.linalg.norm(mesh.cell_volumes * (test - ana))
         elif self._test_type == "Div":
             D = mesh.face_divergence
 
             fx = lambda x, y: np.sin(2 * np.pi * x)
             fy = lambda x, y: np.sin(2 * np.pi * y)
-            sol = lambda x, y: 2 * np.pi * (np.cos(2 * np.pi * x) + np.cos(2 * np.pi * y))
+            sol = (
+                lambda x, y: 2 * np.pi * (np.cos(2 * np.pi * x) + np.cos(2 * np.pi * y))
+            )
 
             f = mesh.project_face_vector(np.c_[fx(*mesh.faces.T), fy(*mesh.faces.T)])
 
             ana = sol(*mesh.cell_centers.T)
             test = D @ f
-            err = np.linalg.norm(mesh.cell_volumes * (test-ana))
+            err = np.linalg.norm(mesh.cell_volumes * (test - ana))
         elif self._test_type == "Grad":
             G = mesh.nodal_gradient
 
             phi = lambda x, y: np.sin(2 * np.pi * x) * np.sin(2 * np.pi * y)
 
-            dphi_dx = lambda x, y: 2 * np.pi * np.cos(2 * np.pi * x) * np.sin(2 * np.pi * y)
-            dphi_dy = lambda x, y: 2 * np.pi * np.cos(2 * np.pi * y) * np.sin(2 * np.pi * x)
+            dphi_dx = (
+                lambda x, y: 2 * np.pi * np.cos(2 * np.pi * x) * np.sin(2 * np.pi * y)
+            )
+            dphi_dy = (
+                lambda x, y: 2 * np.pi * np.cos(2 * np.pi * y) * np.sin(2 * np.pi * x)
+            )
 
             p = phi(*mesh.nodes.T)
 
-            ana = mesh.project_edge_vector(np.c_[dphi_dx(*mesh.edges.T), dphi_dy(*mesh.edges.T)])
+            ana = mesh.project_edge_vector(
+                np.c_[dphi_dx(*mesh.edges.T), dphi_dy(*mesh.edges.T)]
+            )
             test = G @ p
-            err = np.linalg.norm(test-ana, np.inf)
+            err = np.linalg.norm(test - ana, np.inf)
         return err
 
     def test_curl_order(self):
@@ -80,15 +88,15 @@ class TestOperators2D(discretize.tests.OrderTest):
         mod[test_cell] = 1.0
 
         diff = G_sten @ mod
-        np.testing.assert_equal(np.where(diff!=0.0)[0], np.sort(mesh._simplex_faces[21]))
-        np.testing.assert_equal(diff[diff!=0.0], [-1, 1, -1])
-
-
+        np.testing.assert_equal(
+            np.where(diff != 0.0)[0], np.sort(mesh._simplex_faces[21])
+        )
+        np.testing.assert_equal(diff[diff != 0.0], [-1, 1, -1])
 
 
 class TestOperators3D(discretize.tests.OrderTest):
     meshSizes = [8, 16, 32]
-    meshTypes = ['uniform simplex mesh']
+    meshTypes = ["uniform simplex mesh"]
 
     def setupMesh(self, n):
         points, simplices = example_simplex_mesh((n, n, n))
@@ -118,7 +126,7 @@ class TestOperators3D(discretize.tests.OrderTest):
             ana = mesh.project_face_vector(Fv)
             test = C @ Ep
 
-            err = np.linalg.norm(test-ana)/mesh.n_faces
+            err = np.linalg.norm(test - ana) / mesh.n_faces
         elif self._test_type == "Div":
             D = mesh.face_divergence
 
@@ -131,12 +139,14 @@ class TestOperators3D(discretize.tests.OrderTest):
                 + 2 * np.pi * np.cos(2 * np.pi * z)
             )
 
-            f = mesh.project_face_vector(np.c_[fx(*mesh.faces.T), fy(*mesh.faces.T), fz(*mesh.faces.T)])
+            f = mesh.project_face_vector(
+                np.c_[fx(*mesh.faces.T), fy(*mesh.faces.T), fz(*mesh.faces.T)]
+            )
 
             ana = sol(*mesh.cell_centers.T)
             test = D @ f
 
-            err = np.linalg.norm(mesh.cell_volumes * (test-ana))
+            err = np.linalg.norm(mesh.cell_volumes * (test - ana))
         elif self._test_type == "Grad":
             G = mesh.nodal_gradient
 
@@ -152,7 +162,7 @@ class TestOperators3D(discretize.tests.OrderTest):
                 np.c_[ex(*mesh.edges.T), ey(*mesh.edges.T), ez(*mesh.edges.T)]
             )
             test = G @ p
-            err = np.linalg.norm(test-ana, np.inf)
+            err = np.linalg.norm(test - ana, np.inf)
         return err
 
     def test_curl_order(self):

--- a/tests/simplex/test_utils.py
+++ b/tests/simplex/test_utils.py
@@ -14,22 +14,27 @@ else:
 
 
 class SimplexTests(unittest.TestCase):
-
     def test_init_errors(self):
-        bad_nodes = np.array([[0, 0, 0],
-                          [1, 0, 0],
-                          [0, 1, 0],
-                          [2, 2, 0],
-                          ])
+        bad_nodes = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [2, 2, 0],
+            ]
+        )
         simplices = np.array([[0, 1, 2, 3]])
         with self.assertRaises(ValueError):
             mesh = discretize.SimplexMesh(bad_nodes, simplices)
 
-        good_nodes = np.array([[0, 0, 0],
-                          [1, 0, 0],
-                          [0, 1, 0],
-                          [0, 0, 1],
-                          ])
+        good_nodes = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ]
+        )
         with self.assertRaises(ValueError):
             # pass incompatible shaped nodes and simplices
             mesh = discretize.SimplexMesh(good_nodes, simplices[:, :-1])
@@ -82,19 +87,19 @@ class SimplexTests(unittest.TestCase):
         ccv_dat = np.random.rand(mesh.n_cells, 2)
 
         mesh.plot_image(cc_dat)
-        mesh.plot_image(ccv_dat, v_type='CCv', view='vec')
+        mesh.plot_image(ccv_dat, v_type="CCv", view="vec")
 
         mesh.plot_image(n_dat)
 
-        mesh.plot_image(f_dat, v_type='Fx')
-        mesh.plot_image(f_dat, v_type='Fy')
-        mesh.plot_image(f_dat, v_type='F')
-        mesh.plot_image(f_dat, v_type='F', view='vec')
+        mesh.plot_image(f_dat, v_type="Fx")
+        mesh.plot_image(f_dat, v_type="Fy")
+        mesh.plot_image(f_dat, v_type="F")
+        mesh.plot_image(f_dat, v_type="F", view="vec")
 
-        mesh.plot_image(e_dat, v_type='Ex')
-        mesh.plot_image(e_dat, v_type='Ey')
-        mesh.plot_image(e_dat, v_type='E')
-        mesh.plot_image(e_dat, v_type='E', view='vec')
+        mesh.plot_image(e_dat, v_type="Ex")
+        mesh.plot_image(e_dat, v_type="Ey")
+        mesh.plot_image(e_dat, v_type="E")
+        mesh.plot_image(e_dat, v_type="E", view="vec")
 
         with self.assertRaises(NotImplementedError):
             points, simplices = discretize.utils.example_simplex_mesh((n, n, n))
@@ -114,26 +119,27 @@ class SimplexTests(unittest.TestCase):
         mesh.plot_grid(nodes=True, faces=True, edges=True, centers=True)
 
     if has_vtk:
+
         def test_2D_vtk(self):
             n = 5
             points, simplices = discretize.utils.example_simplex_mesh((n, n))
             mesh = discretize.SimplexMesh(points, simplices)
             cc_dat = np.random.rand(mesh.n_cells)
 
-            vtk_obj = mesh.to_vtk(models={'info': cc_dat})
+            vtk_obj = mesh.to_vtk(models={"info": cc_dat})
 
             mesh2, models = discretize.SimplexMesh.vtk_to_simplex_mesh(vtk_obj)
 
             np.testing.assert_equal(mesh.nodes, mesh2.nodes)
             np.testing.assert_equal(mesh._simplices, mesh2._simplices)
-            np.testing.assert_equal(cc_dat, models['info'])
+            np.testing.assert_equal(cc_dat, models["info"])
 
-            mesh.write_vtk('test.vtu', models={'info': cc_dat})
-            mesh2, models = discretize.SimplexMesh.read_vtk('test.vtu')
+            mesh.write_vtk("test.vtu", models={"info": cc_dat})
+            mesh2, models = discretize.SimplexMesh.read_vtk("test.vtu")
 
             np.testing.assert_equal(mesh.nodes, mesh2.nodes)
             np.testing.assert_equal(mesh._simplices, mesh2._simplices)
-            np.testing.assert_equal(cc_dat, models['info'])
+            np.testing.assert_equal(cc_dat, models["info"])
 
         def test_3D_vtk(self):
             n = 5
@@ -141,20 +147,20 @@ class SimplexTests(unittest.TestCase):
             mesh = discretize.SimplexMesh(points, simplices)
             cc_dat = np.random.rand(mesh.n_cells)
 
-            vtk_obj = mesh.to_vtk(models={'info': cc_dat})
+            vtk_obj = mesh.to_vtk(models={"info": cc_dat})
 
             mesh2, models = discretize.SimplexMesh.vtk_to_simplex_mesh(vtk_obj)
 
             np.testing.assert_equal(mesh.nodes, mesh2.nodes)
             np.testing.assert_equal(mesh._simplices, mesh2._simplices)
-            np.testing.assert_equal(cc_dat, models['info'])
+            np.testing.assert_equal(cc_dat, models["info"])
 
-            mesh.write_vtk('test.vtu', models={'info': cc_dat})
-            mesh2, models = discretize.SimplexMesh.read_vtk('test.vtu')
+            mesh.write_vtk("test.vtu", models={"info": cc_dat})
+            mesh2, models = discretize.SimplexMesh.read_vtk("test.vtu")
 
             np.testing.assert_equal(mesh.nodes, mesh2.nodes)
             np.testing.assert_equal(mesh._simplices, mesh2._simplices)
-            np.testing.assert_equal(cc_dat, models['info'])
+            np.testing.assert_equal(cc_dat, models["info"])
 
     def tearDown(self):
         try:

--- a/tests/tree/test_refine.py
+++ b/tests/tree/test_refine.py
@@ -44,11 +44,13 @@ def test_line_errors():
 def test_triangle2d():
     # define a slower function that is surely accurate
     triangle = np.array([[0.14, 0.31], [0.32, 0.96], [0.23, 0.87]])
-    edges = np.stack([
-        triangle[1]-triangle[0],
-        triangle[2]-triangle[1],
-        triangle[2]-triangle[0],
-    ])
+    edges = np.stack(
+        [
+            triangle[1] - triangle[0],
+            triangle[2] - triangle[1],
+            triangle[2] - triangle[0],
+        ]
+    )
 
     def project_min_max(points, axis):
         ps = points @ axis
@@ -67,12 +69,14 @@ def test_triangle2d():
         if np.any(maxs < x0):
             return 0
 
-        box_points = np.array([
-            [x0[0], x0[1]],
-            [x0[0], xF[1]],
-            [xF[0], x0[1]],
-            [xF[0], xF[1]],
-        ])
+        box_points = np.array(
+            [
+                [x0[0], x0[1]],
+                [x0[0], xF[1]],
+                [xF[0], x0[1]],
+                [xF[0], xF[1]],
+            ]
+        )
         for i in range(3):
             axis = [-edges[i, 1], edges[i, 0]]
             bmin, bmax = project_min_max(box_points, axis)
@@ -93,17 +97,20 @@ def test_triangle2d():
 def test_triangle3d():
     # define a slower function that is surely accurate
     triangle = np.array([[0.14, 0.31, 0.23], [0.32, 0.96, 0.41], [0.23, 0.87, 0.72]])
-    edges = np.stack([
-        triangle[1]-triangle[0],
-        triangle[2]-triangle[1],
-        triangle[2]-triangle[0],
-    ])
+    edges = np.stack(
+        [
+            triangle[1] - triangle[0],
+            triangle[2] - triangle[1],
+            triangle[2] - triangle[0],
+        ]
+    )
     triangle_norm = np.cross(edges[0], edges[1])
     triangle_proj = triangle[0] @ triangle_norm
 
     def project_min_max(points, axis):
         ps = points @ axis
         return ps.min(), ps.max()
+
     box_normals = np.eye(3)
 
     def refine_triangle(cell):
@@ -119,16 +126,18 @@ def test_triangle3d():
         if np.any(maxs < x0):
             return 0
 
-        box_points = np.array([
-            [x0[0], x0[1], x0[2]],
-            [x0[0], xF[1], x0[2]],
-            [xF[0], x0[1], x0[2]],
-            [xF[0], xF[1], x0[2]],
-            [x0[0], x0[1], xF[2]],
-            [x0[0], xF[1], xF[2]],
-            [xF[0], x0[1], xF[2]],
-            [xF[0], xF[1], xF[2]],
-        ])
+        box_points = np.array(
+            [
+                [x0[0], x0[1], x0[2]],
+                [x0[0], xF[1], x0[2]],
+                [xF[0], x0[1], x0[2]],
+                [xF[0], xF[1], x0[2]],
+                [x0[0], x0[1], xF[2]],
+                [x0[0], xF[1], xF[2]],
+                [xF[0], x0[1], xF[2]],
+                [xF[0], xF[1], xF[2]],
+            ]
+        )
         for i in range(3):
             for j in range(3):
                 axis = np.cross(edges[i], box_normals[j])

--- a/tests/tree/test_refine.py
+++ b/tests/tree/test_refine.py
@@ -1,0 +1,99 @@
+import discretize
+import numpy as np
+import pytest
+
+
+def test_2d_line():
+    segments = np.array([[0.1, 0.3], [0.3, 0.9]])
+
+    mesh = discretize.TreeMesh([64, 64])
+    mesh.refine_line(segments, mesh.max_level)
+
+    cells = mesh.get_cells_along_line(segments[0], segments[1])
+    levels = mesh.cell_levels_by_index(cells)
+
+    np.testing.assert_equal(levels, mesh.max_level)
+
+
+def test_3d_line():
+    segments = np.array([[0.1, 0.3, 0.2], [0.3, 0.9, 0.7]])
+
+    mesh = discretize.TreeMesh([64, 64, 64])
+    mesh.refine_line(segments, mesh.max_level)
+
+    cells = mesh.get_cells_along_line(segments[0], segments[1])
+    levels = mesh.cell_levels_by_index(cells)
+
+    np.testing.assert_equal(levels, mesh.max_level)
+
+
+def test_line_errors():
+    mesh = discretize.TreeMesh([64, 64])
+    segments2D = np.array([[0.1, 0.3], [0.3, 0.9]])
+    segments3D = np.array([[0.1, 0.3, 0.2], [0.3, 0.9, 0.7]])
+
+    # incorrect dimension
+    with pytest.raises(ValueError):
+        mesh.refine_line(segments3D, mesh.max_level, finalize=False)
+
+    # incorrect number of levels
+    with pytest.raises(ValueError):
+        mesh.refine_line(segments2D, [mesh.max_level, 3], finalize=False)
+
+
+def test_box_errors():
+    mesh = discretize.TreeMesh([64, 64])
+    x0s = np.array([0.1, 0.2])
+    x0s2d = np.array([[0.1, 0.1], [0.5, 0.5]])
+    x1s2d = np.array([[0.2, 0.3], [0.8, 0.9]])
+
+    x0s3d = np.array([[0.1, 0.1, 0.1], [0.5, 0.5, 0.5]])
+    x1s3d = np.array([[0.2, 0.3, 0.1], [0.8, 0.9, 0.75]])
+
+    # incorrect dimension on x0
+    with pytest.raises(ValueError):
+        mesh.refine_box(x0s3d, x1s3d, [5, 5], finalize=False)
+
+    # incorrect dimension on x1
+    with pytest.raises(ValueError):
+        mesh.refine_box(x0s2d, x1s3d, [5, 5], finalize=False)
+
+    # incompatible shapes
+    with pytest.raises(ValueError):
+        mesh.refine_box(x0s, x1s2d, [5, 5], finalize=False)
+
+    # incorrect number of levels
+    with pytest.raises(ValueError):
+        mesh.refine_box(x0s2d, x1s2d, [mesh.max_level], finalize=False)
+
+
+def test_ball_errors():
+    mesh = discretize.TreeMesh([64, 64])
+    x0s2d = np.array([[0.1, 0.1], [0.5, 0.5]])
+    x0s3d = np.array([[0.1, 0.1, 0.1], [0.5, 0.5, 0.5]])
+
+    # incorrect dimension on x0
+    with pytest.raises(ValueError):
+        mesh.refine_ball(x0s3d, [1, 1], [5, 5], finalize=False)
+
+    # incorrect number of radii
+    with pytest.raises(ValueError):
+        mesh.refine_ball(x0s2d, [1, 1, 2], [5, 5], finalize=False)
+
+    # incorrect number of levels
+    with pytest.raises(ValueError):
+        mesh.refine_ball(x0s2d, [1, 1], [5, 5, 4], finalize=False)
+
+
+def test_insert_errors():
+    mesh = discretize.TreeMesh([64, 64])
+    x0s2d = np.array([[0.1, 0.1], [0.5, 0.5]])
+    x0s3d = np.array([[0.1, 0.1, 0.1], [0.5, 0.5, 0.5]])
+
+    # incorrect dimension on points
+    with pytest.raises(ValueError):
+        mesh.insert_cells(x0s3d, [1, 1], finalize=False)
+
+    # incorrect number of levels
+    with pytest.raises(ValueError):
+        mesh.insert_cells(x0s2d, [1, 1, 3], finalize=False)

--- a/tests/tree/test_tree.py
+++ b/tests/tree/test_tree.py
@@ -337,6 +337,7 @@ class TestOcTree(unittest.TestCase):
         cell_2 = M[2]
         np.testing.assert_equal(cell_2.nodes, cell_nodes[2])
 
+
 class Test2DInterpolation(unittest.TestCase):
     def setUp(self):
         def topo(x):
@@ -431,7 +432,6 @@ class Test3DInterpolation(unittest.TestCase):
 
 
 class TestWrapAroundLevels(unittest.TestCase):
-
     def test_refine_func(self):
         mesh1 = discretize.TreeMesh((16, 16, 16))
         mesh2 = discretize.TreeMesh((16, 16, 16))

--- a/tests/tree/test_tree.py
+++ b/tests/tree/test_tree.py
@@ -12,7 +12,7 @@ class TestSimpleQuadTree(unittest.TestCase):
         h2 = np.random.rand(nc) * nc * 0.5 + nc * 0.5
         h = [hi / np.sum(hi) for hi in [h1, h2]]  # normalize
         M = discretize.TreeMesh(h)
-        points = np.array([[0.1, 0.1, 0.3]])
+        points = np.array([[0.1, 0.1]])
         level = np.array([3])
 
         M.insert_cells(points, level)

--- a/tests/tree/test_tree_balancing.py
+++ b/tests/tree/test_tree_balancing.py
@@ -142,6 +142,23 @@ def test_refine_triangle():
     assert len(bad_nodes) == 0
 
 
+def test_refine_tetra():
+    simplex = np.array(
+        [[0.32, 0.21, 0.15], [0.82, 0.19, 0.34], [0.14, 0.82, 0.29], [0.32, 0.27, 0.83]]
+    )
+    mesh1 = discretize.TreeMesh([32, 32, 32], diagonal_balance=False)
+    mesh1.refine_tetrahedron(simplex, -1)
+    bad_nodes = check_for_diag_unbalance(mesh1)
+
+    assert len(bad_nodes) == 62
+
+    mesh2 = discretize.TreeMesh([32, 32, 32], diagonal_balance=True)
+    mesh2.refine_tetrahedron(simplex, -1)
+    bad_nodes = check_for_diag_unbalance(mesh2)
+
+    assert len(bad_nodes) == 0
+
+
 def test_balance_out_unbalance_in():
     mesh1 = discretize.TreeMesh([64, 64], diagonal_balance=True)
     mesh1.insert_cells([0.09, 0.09], -1, finalize=False)

--- a/tests/tree/test_tree_balancing.py
+++ b/tests/tree/test_tree_balancing.py
@@ -127,6 +127,21 @@ def test_refine_line():
     assert len(bad_nodes) == 0
 
 
+def test_refine_triangle():
+    triangle = np.array([[0.14, 0.31], [0.32, 0.96], [0.23, 0.87]])
+    mesh1 = discretize.TreeMesh([64, 64], diagonal_balance=False)
+    mesh1.refine_triangle(triangle, -1)
+    bad_nodes = check_for_diag_unbalance(mesh1)
+
+    assert len(bad_nodes) == 5
+
+    mesh2 = discretize.TreeMesh([64, 64], diagonal_balance=True)
+    mesh2.refine_triangle(triangle, -1)
+    bad_nodes = check_for_diag_unbalance(mesh2)
+
+    assert len(bad_nodes) == 0
+
+
 def test_balance_out_unbalance_in():
     mesh1 = discretize.TreeMesh([64, 64], diagonal_balance=True)
     mesh1.insert_cells([0.09, 0.09], -1, finalize=False)

--- a/tests/tree/test_tree_balancing.py
+++ b/tests/tree/test_tree_balancing.py
@@ -8,7 +8,7 @@ def check_for_diag_unbalance(mesh):
     for i in range(mesh.n_nodes):
         cells_around_node = avg[i, :].indices
         levels = np.atleast_1d(mesh.cell_levels_by_index(cells_around_node))
-        level_diff = max(levels)-min(levels)
+        level_diff = max(levels) - min(levels)
         if level_diff >= 2:
             bad_nodes.append(i)
     bad_nodes = np.asarray(bad_nodes)

--- a/tests/tree/test_tree_balancing.py
+++ b/tests/tree/test_tree_balancing.py
@@ -111,6 +111,22 @@ def test_refine_ball():
     assert len(bad_nodes) == 0
 
 
+def test_refine_line():
+    segments = np.array([[0.1, 0.3], [0.3, 0.9], [0.8, 0.9]])
+
+    mesh1 = discretize.TreeMesh([64, 64])
+    mesh1.refine_line(segments, -1)
+    bad_nodes = check_for_diag_unbalance(mesh1)
+
+    assert len(bad_nodes) == 7
+
+    mesh2 = discretize.TreeMesh([64, 64], diagonal_balance=True)
+    mesh2.refine_line(segments, -1)
+    bad_nodes = check_for_diag_unbalance(mesh2)
+
+    assert len(bad_nodes) == 0
+
+
 def test_balance_out_unbalance_in():
     mesh1 = discretize.TreeMesh([64, 64], diagonal_balance=True)
     mesh1.insert_cells([0.09, 0.09], -1, finalize=False)

--- a/tests/tree/test_tree_interpolation.py
+++ b/tests/tree/test_tree_interpolation.py
@@ -218,15 +218,15 @@ class TestInterpolation3D(discretize.tests.OrderTest):
 
 
 class TestCaching(unittest.TestCase):
-
     def setUp(self):
-        self.mesh, maxh = discretize.tests.setup_mesh('uniformTree', 32, 3)
+        self.mesh, maxh = discretize.tests.setup_mesh("uniformTree", 32, 3)
 
     def testCaching(self):
         mesh = self.mesh
         A1 = mesh.average_edge_to_face_vector
         A2 = mesh.average_edge_to_face_vector
         self.assertIs(A1, A2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tree/test_tree_plotting.py
+++ b/tests/tree/test_tree_plotting.py
@@ -6,8 +6,8 @@ from discretize import TreeMesh
 
 matplotlib.use("Agg")
 
-class TestOcTreePlotting(unittest.TestCase):
 
+class TestOcTreePlotting(unittest.TestCase):
     def setUp(self):
         mesh = TreeMesh([32, 32, 32])
         mesh.refine_box([0.2, 0.2, 0.2], [0.5, 0.7, 0.8], 5)
@@ -22,41 +22,41 @@ class TestOcTreePlotting(unittest.TestCase):
         mesh.plot_grid(faces=True, edges=True, nodes=True)
 
         # CC plot
-        mod_cc = np.random.rand(len(mesh)) + 1j*np.random.rand(len(mesh))
-        mod_cc[np.random.rand(len(mesh))<0.2] = np.nan
+        mod_cc = np.random.rand(len(mesh)) + 1j * np.random.rand(len(mesh))
+        mod_cc[np.random.rand(len(mesh)) < 0.2] = np.nan
 
-        mesh.plot_slice(mod_cc, normal='X', grid=True)
-        mesh.plot_slice(mod_cc, normal='Y', ax=ax)
-        mesh.plot_slice(mod_cc, normal='Z', ax=ax)
-        mesh.plot_slice(mod_cc, view='imag', ax=ax)
-        mesh.plot_slice(mod_cc, view='abs', ax=ax)
+        mesh.plot_slice(mod_cc, normal="X", grid=True)
+        mesh.plot_slice(mod_cc, normal="Y", ax=ax)
+        mesh.plot_slice(mod_cc, normal="Z", ax=ax)
+        mesh.plot_slice(mod_cc, view="imag", ax=ax)
+        mesh.plot_slice(mod_cc, view="abs", ax=ax)
 
         mod_ccv = np.random.rand(len(mesh), 3)
-        mesh.plot_slice(mod_ccv, v_type='CCv', view='vec', ax=ax)
+        mesh.plot_slice(mod_ccv, v_type="CCv", view="vec", ax=ax)
 
         # F plot tests
         mod_f = np.random.rand(mesh.n_faces)
-        mesh.plot_slice(mod_f, v_type='Fx', ax=ax)
-        mesh.plot_slice(mod_f, v_type='Fy', ax=ax)
-        mesh.plot_slice(mod_f, v_type='Fz', ax=ax)
-        mesh.plot_slice(mod_f, v_type='F', ax=ax)
-        mesh.plot_slice(mod_f, v_type='F', view='vec', ax=ax)
+        mesh.plot_slice(mod_f, v_type="Fx", ax=ax)
+        mesh.plot_slice(mod_f, v_type="Fy", ax=ax)
+        mesh.plot_slice(mod_f, v_type="Fz", ax=ax)
+        mesh.plot_slice(mod_f, v_type="F", ax=ax)
+        mesh.plot_slice(mod_f, v_type="F", view="vec", ax=ax)
 
         # E plot tests
         mod_e = np.random.rand(mesh.n_edges)
-        mesh.plot_slice(mod_e, v_type='Ex', ax=ax)
-        mesh.plot_slice(mod_e, v_type='Ey', ax=ax)
-        mesh.plot_slice(mod_e, v_type='Ez', ax=ax)
-        mesh.plot_slice(mod_e, v_type='E', ax=ax)
-        mesh.plot_slice(mod_e, v_type='E', view='vec', ax=ax)
+        mesh.plot_slice(mod_e, v_type="Ex", ax=ax)
+        mesh.plot_slice(mod_e, v_type="Ey", ax=ax)
+        mesh.plot_slice(mod_e, v_type="Ez", ax=ax)
+        mesh.plot_slice(mod_e, v_type="E", ax=ax)
+        mesh.plot_slice(mod_e, v_type="E", view="vec", ax=ax)
 
-        #Nodes
+        # Nodes
         mod_n = np.random.rand(mesh.n_nodes)
-        mesh.plot_slice(mod_n, v_type='N')
+        mesh.plot_slice(mod_n, v_type="N")
         plt.close()
 
-class TestQuadTreePlotting(unittest.TestCase):
 
+class TestQuadTreePlotting(unittest.TestCase):
     def setUp(self):
         mesh = TreeMesh([32, 32])
         mesh.refine_box([0.2, 0.2], [0.5, 0.8], 5)
@@ -70,32 +70,32 @@ class TestQuadTreePlotting(unittest.TestCase):
         mesh.plot_grid(faces=True, edges=True, nodes=True)
 
         # CC plot
-        mod_cc = np.random.rand(len(mesh)) + 1j*np.random.rand(len(mesh))
-        mod_cc[np.random.rand(len(mesh))<0.2] = np.nan
+        mod_cc = np.random.rand(len(mesh)) + 1j * np.random.rand(len(mesh))
+        mod_cc[np.random.rand(len(mesh)) < 0.2] = np.nan
 
         mesh.plot_image(mod_cc)
         mesh.plot_image(mod_cc, ax=ax)
-        mesh.plot_image(mod_cc, view='imag', ax=ax)
-        mesh.plot_image(mod_cc, view='abs', ax=ax)
+        mesh.plot_image(mod_cc, view="imag", ax=ax)
+        mesh.plot_image(mod_cc, view="abs", ax=ax)
 
         mod_ccv = np.random.rand(len(mesh), 2)
-        mesh.plot_image(mod_ccv, v_type='CCv', view='vec', ax=ax)
+        mesh.plot_image(mod_ccv, v_type="CCv", view="vec", ax=ax)
 
         # F plot tests
         mod_f = np.random.rand(mesh.n_faces)
-        mesh.plot_image(mod_f, v_type='Fx', ax=ax)
-        mesh.plot_image(mod_f, v_type='Fy', ax=ax)
-        mesh.plot_image(mod_f, v_type='F', ax=ax)
-        mesh.plot_image(mod_f, v_type='F', view='vec', ax=ax)
+        mesh.plot_image(mod_f, v_type="Fx", ax=ax)
+        mesh.plot_image(mod_f, v_type="Fy", ax=ax)
+        mesh.plot_image(mod_f, v_type="F", ax=ax)
+        mesh.plot_image(mod_f, v_type="F", view="vec", ax=ax)
 
         # E plot tests
         mod_e = np.random.rand(mesh.n_edges)
-        mesh.plot_image(mod_e, v_type='Ex', ax=ax)
-        mesh.plot_image(mod_e, v_type='Ey', ax=ax)
-        mesh.plot_image(mod_e, v_type='E', ax=ax)
-        mesh.plot_image(mod_e, v_type='E', view='vec', ax=ax)
+        mesh.plot_image(mod_e, v_type="Ex", ax=ax)
+        mesh.plot_image(mod_e, v_type="Ey", ax=ax)
+        mesh.plot_image(mod_e, v_type="E", ax=ax)
+        mesh.plot_image(mod_e, v_type="E", view="vec", ax=ax)
 
-        #Nodes
+        # Nodes
         mod_n = np.random.rand(mesh.n_nodes)
-        mesh.plot_image(mod_n, v_type='N', ax=ax)
+        mesh.plot_image(mod_n, v_type="N", ax=ax)
         plt.close()

--- a/tests/tree/test_tree_utils.py
+++ b/tests/tree/test_tree_utils.py
@@ -28,18 +28,17 @@ class TestRefineOcTree(unittest.TestCase):
         )
         cell_levels = mesh.cell_levels_by_index(np.arange(mesh.n_cells))
 
-        vol = 4.0 * np.pi / 3.0 * (rad+dx) ** 3.0
+        vol = 4.0 * np.pi / 3.0 * (rad + dx) ** 3.0
 
         vol_mesh = mesh.cell_volumes[cell_levels == mesh.max_level].sum()
 
-        self.assertLess(np.abs(vol - vol_mesh)/vol, 0.05)
+        self.assertLess(np.abs(vol - vol_mesh) / vol, 0.05)
 
         levels, cells_per_level = np.unique(cell_levels, return_counts=True)
 
         self.assertEqual(mesh.n_cells, 311858)
         np.testing.assert_array_equal(levels, [3, 4, 5, 6, 7])
         np.testing.assert_array_equal(cells_per_level, [232, 1176, 2671, 9435, 298344])
-
 
     def test_box(self):
         dx = 0.25
@@ -61,9 +60,9 @@ class TestRefineOcTree(unittest.TestCase):
         )
         cell_levels = mesh.cell_levels_by_index(np.arange(mesh.n_cells))
 
-        vol = (2*(dl+2*dx))**3  # 2*dx is cell size at second to highest level
+        vol = (2 * (dl + 2 * dx)) ** 3  # 2*dx is cell size at second to highest level
         vol_mesh = np.sum(mesh.cell_volumes[cell_levels == mesh.max_level - 1])
-        self.assertLess((vol-vol_mesh)/vol, 0.05)
+        self.assertLess((vol - vol_mesh) / vol, 0.05)
 
         levels, cells_per_level = np.unique(cell_levels, return_counts=True)
 


### PR DESCRIPTION
This adds more refinement functions for tree meshes.
- Line segment (determines whether a line segment and a cell intersect)
- triangle (determines whether a triangle and a cell intersect)
- Tetrahedron (determines whether a tetrahedron and a cell intersect)

They all are "exact" to floating point precision. Using the Separating Axis Theorem to determine the triangle and tetrahedron intersections.

The triangle and tetrahedron should make it natural to extend to any polyhedron body (Because those can always be broken into multiple triangles/tetrahedrons).

I think the next step is to update the `refine_tree_xyz` function and split it off into the three individual helper functions (at which point we would deprecate `refine_tree_xyz`). 