### PR TITLE
Add new refine surface, bounding box, and point refine methods.

### DIFF
--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -132,6 +132,11 @@ class Cell{
       double* x0, double* x1, double* x2, double* e0, double* e1, double* e2, double* t_norm,
       int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false
     );
+    void refine_vert_triang_prism(node_map_t& nodes,
+      double* x0, double* x1, double* x2, double h,
+      double* e0, double* e1, double* e2, double* t_norm,
+      int_t p_level, double *xs, double *ys, double* zs, bool diag_balance=false
+    );
     void refine_tetra(
       node_map_t& nodes,
       double* x0, double* x1, double* x2, double* x3,
@@ -178,6 +183,9 @@ class Tree{
     );
     void refine_tetra(
         double* x0, double* x1, double* x2, double* x3, int_t p_level, bool diag_balance=false
+    );
+    void refine_vert_triang_prism(
+        double* x0, double* x1, double* x2, double h, int_t p_level, bool diagonal_balance=false
     );
     void number();
     void finalize_lists();

--- a/discretize/_extensions/tree.pxd
+++ b/discretize/_extensions/tree.pxd
@@ -89,6 +89,7 @@ cdef extern from "tree.h":
         void refine_box(double*, double*, int_t, bool)
         void refine_line(double*, double*, int_t, bool)
         void refine_triangle(double*, double*, double*, int_t, bool)
+        void refine_vert_triang_prism(double*, double*, double*, double, int_t, bool)
         void refine_tetra(double*, double*, double*, double*, int_t, bool)
         void number()
         void initialize_roots()

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -857,6 +857,10 @@ cdef class _TreeMesh:
             Whether to balance cells diagonally in the refinement, `None` implies using
             the same setting used to instantiate the TreeMesh`.
 
+        See Also
+        --------
+        refine_surface
+
         Examples
         --------
         We create a simple mesh and refine the TreeMesh such that all cells that
@@ -865,23 +869,25 @@ cdef class _TreeMesh:
         >>> import discretize
         >>> import matplotlib.pyplot as plt
         >>> import matplotlib.patches as patches
-        >>> tree_mesh = discretize.TreeMesh([32, 32])
+        >>> tree_mesh = discretize.TreeMesh([32, 32, 32])
         >>> tree_mesh.max_level
         5
 
-        Next we define the points along the line and the level we want to refine to,
-        and refine the mesh.
+        Next we define the bottom points of the prism, its heights, and the level we
+        want to refine to, then refine the mesh.
 
-        >>> triangle = [[0.14, 0.31], [0.32, 0.96], [0.23, 0.87]]
+        >>> triangle = [[0.14, 0.31, 0.21], [0.32, 0.96, 0.34], [0.87, 0.23, 0.12]]
+        >>> height = 0.35
         >>> levels = 5
-        >>> tree_mesh.refine_triangle(triangle, levels)
+        >>> mesh.refine_vertical_trianglular_prism(triangle, height, levels)
 
-        Now lets look at the mesh, and overlay the line on it to ensure it refined
-        where we wanted it to.
+        Now lets look at the mesh.
 
-        >>> ax = tree_mesh.plot_grid()
-        >>> tri = patches.Polygon(triangle, fill=False)
-        >>> ax.add_patch(tri)
+        >>> v = mesh.cell_levels_by_index(np.arange(mesh.n_cells))
+        >>> fig, axs = plt.subplots(1, 3, figsize=(12,4))
+        >>> mesh.plot_slice(v, ax=axs[0], normal='x', grid=True, clim=[2, 5])
+        >>> mesh.plot_slice(v, ax=axs[1], normal='y', grid=True, clim=[2, 5])
+        >>> mesh.plot_slice(v, ax=axs[2], normal='z', grid=True, clim=[2, 5])
         >>> plt.show()
 
         """

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -2242,7 +2242,6 @@ cdef class _TreeMesh:
         of the x and y-boundary cells.
 
         >>> from discretize import TreeMesh
-        >>> from discretize.utils import refine_tree_xyz
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
 
@@ -2341,7 +2340,6 @@ cdef class _TreeMesh:
         of the x and y-boundary faces.
 
         >>> from discretize import TreeMesh
-        >>> from discretize.utils import refine_tree_xyz
         >>> import numpy as np
         >>> import matplotlib.pyplot as plt
 

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -521,9 +521,9 @@ cdef class _TreeMesh:
         ----------
         points : (N, dim) array_like
             The centers of the refinement balls
-        radii : (N) array_like
+        radii : float or (N) array_like of float
             A 1D array defining the radius for each ball
-        levels : (N) array_like of int
+        levels : int or (N) array_like of int
             A 1D array defining the maximum refinement level for each ball
         finalize : bool, optional
             Whether to finalize after refining
@@ -566,12 +566,19 @@ cdef class _TreeMesh:
         if points.shape[1] != self.dim:
             raise ValueError(f"points array must be (N, {self.dim})")
         cdef double[:, :] cs = points
-        cdef double[:] rs = np.require(np.atleast_1d(radii), dtype=np.float64,
+        radii = np.require(np.atleast_1d(radii), dtype=np.float64,
                                        requirements='C')
+        if radii.shape[0] == 1:
+           radii = np.full(points.shape[0], radii[0], dtype=np.float64)
+        cdef double[:] rs = radii
         if points.shape[0] != rs.shape[0]:
             raise ValueError("radii length must match the points array's first dimension")
-        cdef int[:] ls = np.require(np.atleast_1d(levels), dtype=np.int32,
+
+        levels = np.require(np.atleast_1d(levels), dtype=np.int32,
                                     requirements='C')
+        if levels.shape[0] == 1:
+            levels = np.full(points.shape[0], levels[0], dtype=np.int32)
+        cdef int[:] ls = levels
         if points.shape[0] != ls.shape[0]:
             raise ValueError("level length must match the points array's first dimension")
 
@@ -603,11 +610,11 @@ cdef class _TreeMesh:
             The minimum location of the boxes
         x1s : (N, dim) array_like
             The maximum location of the boxes
-        levels : (N) array_like of int
+        levels : int or (N) array_like of int
             The level to refine intersecting cells to
         finalize : bool, optional
             Whether to finalize after refining
-        diagonal_balance : bool or None, optional
+        diagonal_balance : None or bool, optional
             Whether to balance cells diagonally in the refinement, `None` implies using
             the same setting used to instantiate the TreeMesh`.
 
@@ -640,7 +647,6 @@ cdef class _TreeMesh:
         >>> rect = patches.Rectangle([0.8, 0.8], 0.1, 0.2, facecolor='none', edgecolor='k', linewidth=3)
         >>> ax.add_patch(rect)
         >>> plt.show()
-
         """
         x0s = np.require(np.atleast_2d(x0s), dtype=np.float64,
                             requirements='C')
@@ -654,8 +660,11 @@ cdef class _TreeMesh:
             raise ValueError(f"x0s and x1s must have the same length")
         cdef double[:, :] x0 = x0s
         cdef double[:, :] x1 = x1s
-        cdef int[:] ls = np.require(np.atleast_1d(levels), dtype=np.int32,
+        levels = np.require(np.atleast_1d(levels), dtype=np.int32,
                                     requirements='C')
+        if levels.shape[0] == 1:
+            levels = np.full(x0.shape[0], levels[0], dtype=np.int32)
+        cdef int[:] ls = levels
         if x0.shape[0] != ls.shape[0]:
             raise ValueError("level length must match the points array's first dimension")
 

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -837,6 +837,96 @@ cdef class _TreeMesh:
             self.finalize()
 
     @cython.cdivision(True)
+    def refine_vertical_trianglular_prism(self, triangle, h, levels, finalize=True, diagonal_balance=None):
+        """Refines the :class:`~discretize.TreeMesh` along the trianglular prism to the desired level
+
+        Refines the TreeMesh by determining if a cell intersects the given trianglular prism(s)
+        to the prescribed level(s).
+
+        Parameters
+        ----------
+        triangle : (N, 3, dim) array_like
+            The nodes of the bottom triangle(s).
+        h : (N) array_like
+            The height of the prism(s).
+        levels : int or (N) array_like of int
+            The level to refine intersecting cells to.
+        finalize : bool, optional
+            Whether to finalize after refining
+        diagonal_balance : bool or None, optional
+            Whether to balance cells diagonally in the refinement, `None` implies using
+            the same setting used to instantiate the TreeMesh`.
+
+        Examples
+        --------
+        We create a simple mesh and refine the TreeMesh such that all cells that
+        intersect the line segment path are at the given levels.
+
+        >>> import discretize
+        >>> import matplotlib.pyplot as plt
+        >>> import matplotlib.patches as patches
+        >>> tree_mesh = discretize.TreeMesh([32, 32])
+        >>> tree_mesh.max_level
+        5
+
+        Next we define the points along the line and the level we want to refine to,
+        and refine the mesh.
+
+        >>> triangle = [[0.14, 0.31], [0.32, 0.96], [0.23, 0.87]]
+        >>> levels = 5
+        >>> tree_mesh.refine_triangle(triangle, levels)
+
+        Now lets look at the mesh, and overlay the line on it to ensure it refined
+        where we wanted it to.
+
+        >>> ax = tree_mesh.plot_grid()
+        >>> tri = patches.Polygon(triangle, fill=False)
+        >>> ax.add_patch(tri)
+        >>> plt.show()
+
+        """
+        if self.dim == 2:
+            raise NotImplementedError("refine_vertical_trianglular_prism only implemented in 3D.")
+        triangle = np.require(np.atleast_2d(triangle), dtype=np.float64, requirements="C")
+        if triangle.ndim == 2:
+            triangle = triangle[None, ...]
+        if triangle.shape[-1] != self.dim or triangle.shape[-2] != 3:
+            raise ValueError(f"triangle array must be (N, 3, {self.dim})")
+        cdef double[:, :, :] tris = triangle
+
+        h = np.require(np.atleast_1d(h), dtype=np.float64, requirements="C")
+        levels = np.require(np.atleast_1d(levels), dtype=np.int32,
+                                    requirements='C')
+        cdef int n_triangles = triangle.shape[0];
+        if levels.shape[0] == 1:
+            levels = np.full(n_triangles, levels[0], dtype=np.int32)
+        if h.shape[0] == 1:
+            h = np.full(n_triangles, h[0], dtype=np.float64)
+        if n_triangles != levels.shape[0]:
+            raise ValueError(f"inconsistent number of triangles {n_triangles} and levels {levels.shape[0]}")
+        if n_triangles != h.shape[0]:
+            raise ValueError(f"inconsistent number of triangles {n_triangles} and heights {h.shape[0]}")
+        if np.any(h < 0):
+            raise ValueError("All heights must be positive.")
+
+        cdef int[:] ls = levels
+        cdef double[:] hs = h
+
+        if diagonal_balance is None:
+            diagonal_balance = self._diagonal_balance
+        cdef bool diag_balance = diagonal_balance
+
+        cdef int l
+        cdef int max_level = self.max_level
+        for i in range(n_triangles):
+            l = ls[i]
+            if l < 0:
+                l = (max_level + 1) - (abs(l) % (max_level + 1))
+            self.tree.refine_vert_triang_prism(&tris[i, 0, 0], &tris[i, 1, 0], &tris[i, 2, 0], hs[i], l, diag_balance)
+        if finalize:
+            self.finalize()
+
+    @cython.cdivision(True)
     def refine_tetrahedron(self, tetra, levels, finalize=True, diagonal_balance=None):
         """Refines the :class:`~discretize.TreeMesh` along the tetrahedron to the desired level
 

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -403,7 +403,7 @@ class TreeMesh(
 
         Now we want to refine to the maximum level, with a no padding the in `x`
         direction and `2` cells in `y`, and the second highest level we want 2 padding
-        cells in each direction equally beyond that.
+        cells in each direction beyond that.
 
         >>> levels = [-1, -2]
         >>> padding = [[0, 2], 2]
@@ -464,7 +464,7 @@ class TreeMesh(
             `padding_cells_by_level`). Negative values index backwards, (e.g. `-1` is
             `max_level`).
         padding_cells_by_level : None or (n_level) iterable, optional
-            The number of cells each level to pad around the point. The base cell size
+            The number of cells at each level to pad around the point. The base cell size
             is the largest value amongst the smallest cell widths for each dimension.
             None implies no padding.
         finalize : bool, optional
@@ -529,14 +529,16 @@ class TreeMesh(
         points. Every cell that intersects the surface will be refined to the given
         level.
 
-        It also optionally pads the bounding box at each level based on the number of
-        padding cells at each dimension.
+        It also optionally pads the surface at each level based on the number of
+        padding cells at each dimension. It does so by stretching the bounding box of
+        the surface in each dimension.
 
         Parameters
         ----------
-        xyz : (N, dim) array_like
+        xyz : (N, dim) array_like or tuple
             The points defining the surface. Will be triangulated along the horizontal
-            dimensions.
+            dimensions. You are able to supply your own triangulation in 3D by inputing
+            a tuple of (`xyz`, `triangle_indices`).
         level : int or (n_level) array_like of int
             The level of the tree mesh to refine to. If an array, it will
             refine at the surface to each level (mostly useful in combination with
@@ -613,6 +615,7 @@ class TreeMesh(
         padding_cells_by_level = padding_cells_by_level[sorted]
 
         if self.dim == 2:
+            xyz = np.asarray(xyz)
             sorted = np.argsort(xyz[:, 0])
             xyz = xyz[sorted]
             n_ps = len(xyz)
@@ -623,7 +626,10 @@ class TreeMesh(
         else:
             if isinstance(xyz, tuple):
                 xyz, simps = xyz
+                xyz = np.asarray(xyz)
+                simps = np.asarray(simps)
             else:
+                xyz = np.asarray(xyz)
                 triang = Delaunay(xyz[:, :2])
                 simps = triang.simplices
             n_ps = len(xyz)

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -416,8 +416,8 @@ class TreeMesh(
         >>> ax.add_patch(rect)
         >>> plt.show()
         """
-        bsw = np.min(np.atleast_2d(xyz), axis=0)
-        tnw = np.max(np.atleast_2d(xyz), axis=0)
+        bsw = np.min(np.atleast_2d(points), axis=0)
+        tnw = np.max(np.atleast_2d(points), axis=0)
         level = np.atleast_1d(level)
 
         # pad based on the number of cells at each level

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -111,8 +111,32 @@ class TreeMesh(
     larger than some base cell dimension. Unlike the :class:`~discretize.TensorMesh`
     class, gridded locations and numerical operators for instances of ``TreeMesh``
     cannot be simply constructed using tensor products. Furthermore, each cell
-    is an instance of ``TreeMesh`` is an instance of the
-    :class:`~discretize.tree_mesh.TreeCell` .
+    is an instance of :class:`~discretize.tree_mesh.TreeCell` .
+
+    Each cell of a `TreeMesh` has a certain level associated with it which describes its
+    height in the structure of the tree. The tree mesh is refined by specifying what
+    level you want in a given location. They start at level 0, defining the largest
+    possible cell on the mesh, and go to a level of `max_level` describing the
+    finest possible cell on the mesh. TreeMesh` contains several refinement functions
+    used to design the mesh, starting with a general purpose refinement function, along
+    with several faster specialized refinement functions based on fundamental geometric
+    entities:
+
+    - `refine` -> The general purpose refinement function supporting arbitrary defined functions
+    - `insert_cells`
+    - `refine_ball`
+    - `refine_line`
+    - `refine_triangle`
+    - `refine_box`
+    - `refine_tetrahedron`
+    - `refine_vertical_trianglular_prism`
+    - `refine_bounding_box`
+    - `refine_points`
+    - `refine_surface`
+
+    Like array indexing in python, you can also supply negative indices as a level
+    arguments to these functions to index levels in a reveresed order (i.e. -1 is
+    equivalent to `max_level`).
 
     Parameters
     ----------
@@ -390,6 +414,10 @@ class TreeMesh(
             Whether to balance cells diagonally in the refinement, `None` implies using
             the same setting used to instantiate the TreeMesh`.
 
+        See Also
+        --------
+        refine_box
+
         Examples
         --------
         Given a set of points, we want to refine the tree mesh with the bounding box
@@ -402,8 +430,8 @@ class TreeMesh(
         >>> mesh = discretize.TreeMesh([32, 32])
         >>> points = np.random.rand(20, 2) * 0.25 + 3/8
 
-        Now we want to refine to the maximum level, with a no padding the in `x`
-        direction and `2` cells in `y`, and the second highest level we want 2 padding
+        Now we want to refine to the maximum level, with no padding the in `x`
+        direction and `2` cells in `y`. At the second highest level we want 2 padding
         cells in each direction beyond that.
 
         >>> padding = [[0, 2], [2, 2]]
@@ -473,6 +501,10 @@ class TreeMesh(
             Whether to balance cells diagonally in the refinement, `None` implies using
             the same setting used to instantiate the TreeMesh`.
 
+        See Also
+        --------
+        refine_ball, insert_cells
+
         Examples
         --------
         Given a set of points, we want to refine the tree mesh around these points to
@@ -484,7 +516,7 @@ class TreeMesh(
         >>> mesh = discretize.TreeMesh([32, 32])
 
         Now we want to refine to the maximum level with 1 cell padding around the point,
-        and then refine at the second highest level with at least 3 cell beyond that.
+        and then refine at the second highest level with at least 3 cells beyond that.
 
         >>> points = np.array([[0.1, 0.3], [0.6, 0.8]])
         >>> padding = [1, 3]
@@ -536,9 +568,9 @@ class TreeMesh(
         ----------
         xyz : (N, dim) array_like or tuple
             The points defining the surface. Will be triangulated along the horizontal
-            dimensions. You are able to supply your own triangulation in 3D by inputing
+            dimensions. You are able to supply your own triangulation in 3D by passing
             a tuple of (`xyz`, `triangle_indices`).
-        level : int or (n_level) array_like of int
+        level : int, optional
             The level of the tree mesh to refine to. Negative values index tree levels
             backwards, (e.g. `-1` is `max_level`).
         padding_cells_by_level : None, int, (n_level) array_like or (n_level, dim) array_like, optional
@@ -558,6 +590,10 @@ class TreeMesh(
             Whether to balance cells diagonally in the refinement, `None` implies using
             the same setting used to instantiate the TreeMesh`.
 
+        See Also
+        --------
+        refine_triangle, refine_vertical_trianglular_prism
+
         Examples
         --------
         In 2D we define the surface as a line segment, which we would like to refine
@@ -568,8 +604,8 @@ class TreeMesh(
         >>> import matplotlib.patches as patches
         >>> mesh = discretize.TreeMesh([32, 32])
 
-        This surface is a simple sine curve. Which we would like to pad with at least
-        2 cells vertically below at the maximum level, with 3 cells below that at the
+        This surface is a simple sine curve, which we would like to pad with at least
+        2 cells vertically below at the maximum level, and 3 cells below that at the
         second highest level.
 
         >>> x = np.linspace(0.2, 0.8, 51)

--- a/discretize/utils/mesh_utils.py
+++ b/discretize/utils/mesh_utils.py
@@ -719,10 +719,10 @@ def refine_tree_xyz(
         # padding = octree_levels[non_zeros]
         # mesh.refine_points(xyz, levels, padding, finalize=finalize,)
         warnings.warn(
-            DeprecationWarning,
             "The radial option is deprecated as of `0.9.0` please update your code to "
             "use the `TreeMesh.refine_points` functionality. It will be removed in a "
             "future version of discretize."
+            DeprecationWarning,
         )
 
         # Compute the outer limits of each octree level
@@ -742,10 +742,10 @@ def refine_tree_xyz(
 
     elif method.lower() == "surface":
         warnings.warn(
-            DeprecationWarning,
             "The surface option is deprecated as of `0.9.0` please update your code to "
             "use the `TreeMesh.refine_surface` functionality. It will be removed in a "
-            "future version of discretize."
+            "future version of discretize.",
+            DeprecationWarning,
         )
         # padding = np.zeros((len(octree_levels), mesh.dim))
         # padding[:, -1] = np.maximum(octree_levels - 1, 0)
@@ -864,10 +864,10 @@ def refine_tree_xyz(
 
     elif method.lower() == "box":
         warnings.warn(
-            DeprecationWarning,
             "The box option is deprecated as of `0.9.0` please update your code to "
             "use the `TreeMesh.refine_bounding_box` functionality. It will be removed in a "
-            "future version of discretize."
+            "future version of discretize.",
+            DeprecationWarning,
         )
         # padding = np.zeros((len(octree_levels), mesh.dim))
         # padding[:, -1] = np.maximum(octree_levels - 1, 0)

--- a/discretize/utils/mesh_utils.py
+++ b/discretize/utils/mesh_utils.py
@@ -591,6 +591,14 @@ def refine_tree_xyz(
     hull, the cells will have a width of *2h* . Within a distance of *nc3 x (4h)* ,
     the cells will have a width of *4h* . Etc...
 
+    .. deprecated:: 0.9.0
+          `refine_tree_xyz` will be removed in a future version of discretize. It is
+          replaced by `discretize.TreeMesh.refine_surface`, `discretize.TreeMesh.refine_bounding_box`,
+          and `discretize.TreeMesh.refine_points`, to separate the calling convetions,
+          and improve the individual documentation. Those methods are more explicit
+          about which levels of the TreeMesh you are refining, and provide more
+          flexibility for padding cells in each dimension.
+
     Parameters
     ----------
     mesh : discretize.TreeMesh
@@ -625,6 +633,15 @@ def refine_tree_xyz(
     -------
     discretize.TreeMesh
         The refined tree mesh
+
+    See Also
+    --------
+    discretize.TreeMesh.refine_surface
+        Recommended to use instead of this function for the `surface` option.
+    discretize.TreeMesh.refine_bounding_box
+        Recommended to use instead of this function for the `box` option.
+    discretize.TreeMesh.refine_points
+        Recommended to use instead of this function for the `radial` option.
 
     Examples
     --------
@@ -693,8 +710,20 @@ def refine_tree_xyz(
     octree_levels = np.asarray(octree_levels)
     octree_levels_padding = np.asarray(octree_levels_padding)
 
+    # levels = mesh.max_level - np.arange(len(octree_levels))
+    # non_zeros = octree_levels != 0
+    # levels = levels[non_zeros]
+
     # Trigger different refine methods
     if method.lower() == "radial":
+        # padding = octree_levels[non_zeros]
+        # mesh.refine_points(xyz, levels, padding, finalize=finalize,)
+        warnings.warn(
+            DeprecationWarning,
+            "The radial option is deprecated as of `0.9.0` please update your code to "
+            "use the `TreeMesh.refine_points` functionality. It will be removed in a "
+            "future version of discretize."
+        )
 
         # Compute the outer limits of each octree level
         rMax = np.cumsum(
@@ -712,6 +741,17 @@ def refine_tree_xyz(
             mesh.finalize()
 
     elif method.lower() == "surface":
+        warnings.warn(
+            DeprecationWarning,
+            "The surface option is deprecated as of `0.9.0` please update your code to "
+            "use the `TreeMesh.refine_surface` functionality. It will be removed in a "
+            "future version of discretize."
+        )
+        # padding = np.zeros((len(octree_levels), mesh.dim))
+        # padding[:, -1] = np.maximum(octree_levels - 1, 0)
+        # padding[:, :-1] = octree_levels_padding[:, None]
+        # padding = padding[non_zeros]
+        # mesh.refine_surface(xyz, levels, padding, finalize=finalize, pad_down=True, pad_up=False)
 
         # Compute centroid
         centroid = np.mean(xyz, axis=0)
@@ -823,6 +863,18 @@ def refine_tree_xyz(
             mesh.finalize()
 
     elif method.lower() == "box":
+        warnings.warn(
+            DeprecationWarning,
+            "The box option is deprecated as of `0.9.0` please update your code to "
+            "use the `TreeMesh.refine_bounding_box` functionality. It will be removed in a "
+            "future version of discretize."
+        )
+        # padding = np.zeros((len(octree_levels), mesh.dim))
+        # padding[:, -1] = np.maximum(octree_levels - 1, 0)
+        # padding[:, :-1] = octree_levels_padding[:, None]
+        # padding = padding[non_zeros]
+        # mesh.refine_bounding_box(xyz, levels, padding, finalize=finalize)
+
         # Define the data extent [bottom SW, top NE]
         bsw = np.min(xyz, axis=0)
         tne = np.max(xyz, axis=0)

--- a/discretize/utils/mesh_utils.py
+++ b/discretize/utils/mesh_utils.py
@@ -721,7 +721,7 @@ def refine_tree_xyz(
         warnings.warn(
             "The radial option is deprecated as of `0.9.0` please update your code to "
             "use the `TreeMesh.refine_points` functionality. It will be removed in a "
-            "future version of discretize."
+            "future version of discretize.",
             DeprecationWarning,
         )
 

--- a/tests/tree/test_refine.py
+++ b/tests/tree/test_refine.py
@@ -452,7 +452,7 @@ def test_refine_points_errors():
         mesh1.refine_points(point, [-1, -2], [2, 2, 2])
 
     with pytest.raises(IndexError):
-        mesh1.refine_points(point, [20, -2], [2, 2])
+        mesh1.refine_points(point, [20, -2])
 
 
 def test_refine_surface2D():

--- a/tests/tree/test_refine.py
+++ b/tests/tree/test_refine.py
@@ -367,7 +367,7 @@ def test_box_errors():
 
     # incorrect number of levels
     with pytest.raises(ValueError):
-        mesh.refine_box(x0s2d, x1s2d, [mesh.max_level], finalize=False)
+        mesh.refine_box(x0s2d, x1s2d, [-1, -1, -1], finalize=False)
 
 
 def test_ball_errors():

--- a/tutorials/mesh_generation/4_tree_mesh.py
+++ b/tutorials/mesh_generation/4_tree_mesh.py
@@ -20,7 +20,7 @@ creating tree meshes, we must remember certain rules:
     - The number of base mesh cells in x, y and z must all be powers of 2
     - We cannot refine the mesh to create cells smaller than those defining the base mesh
     - The range of cell sizes in the tree mesh depends on the number of base mesh cells in x, y and z
-    
+
 
 """
 
@@ -33,7 +33,7 @@ creating tree meshes, we must remember certain rules:
 #
 
 from discretize import TreeMesh
-from discretize.utils import mkvc, refine_tree_xyz
+from discretize.utils import mkvc
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -60,10 +60,11 @@ mesh = TreeMesh([h, h])
 xp, yp = np.meshgrid([120.0, 240.0], [80.0, 160.0])
 xy = np.c_[mkvc(xp), mkvc(yp)]  # mkvc creates vectors
 
-# Discretize to finest cell size within rectangular box
-mesh = refine_tree_xyz(mesh, xy, octree_levels=[2, 2], method="box", finalize=False)
-
-mesh.finalize()  # Must finalize tree mesh before use
+# Discretize to finest cell size within rectangular box, with padding in the z direction
+# at the finest and second finest levels.
+levels = [-1, -2]
+padding = [[0, 2], [0, 2]]
+mesh.refine_bounding_box(xy, levels, padding)
 
 mesh.plotGrid(show_it=True)
 
@@ -101,15 +102,15 @@ mesh = TreeMesh([hx, hy], x0="CC")
 xx = mesh.vectorNx
 yy = -3 * np.exp((xx ** 2) / 100 ** 2) + 50.0
 pts = np.c_[mkvc(xx), mkvc(yy)]
-mesh = refine_tree_xyz(
-    mesh, pts, octree_levels=[2, 2], method="surface", finalize=False
-)
+levels = [-1, -2]
+padding = [[0, 2], [0, 2]]
+mesh.refine_surface(pts, levels, padding, finalize=False)
 
 # Refine mesh near points
 xx = np.array([0.0, 10.0, 0.0, -10.0])
 yy = np.array([-20.0, -10.0, 0.0, -10])
 pts = np.c_[mkvc(xx), mkvc(yy)]
-mesh = refine_tree_xyz(mesh, pts, octree_levels=[2, 2], method="radial", finalize=False)
+mesh.refine_points(pts, [-1, -2], [2, 2], finalize=False)
 
 mesh.finalize()
 
@@ -148,15 +149,15 @@ mesh = TreeMesh([hx, hy], x0="CC")
 xx = mesh.vectorNx
 yy = -3 * np.exp((xx ** 2) / 100 ** 2) + 50.0
 pts = np.c_[mkvc(xx), mkvc(yy)]
-mesh = refine_tree_xyz(
-    mesh, pts, octree_levels=[2, 2], method="surface", finalize=False
-)
+levels = [-1 , -2]
+padding = [[0, 2], [0, 2]]
+mesh.refine_surface(pts, levels, padding, finalize=False)
 
 # Refine near points
 xx = np.array([0.0, 10.0, 0.0, -10.0])
 yy = np.array([-20.0, -10.0, 0.0, -10])
 pts = np.c_[mkvc(xx), mkvc(yy)]
-mesh = refine_tree_xyz(mesh, pts, octree_levels=[2, 2], method="radial", finalize=False)
+mesh.refine_points(pts, [-1, -2], [2, 2], finalize=False)
 
 mesh.finalize()
 
@@ -213,16 +214,14 @@ mesh = TreeMesh([hx, hy, hz], x0="CCC")
 [xx, yy] = np.meshgrid(mesh.vectorNx, mesh.vectorNy)
 zz = -3 * np.exp((xx ** 2 + yy ** 2) / 100 ** 2) + 50.0
 pts = np.c_[mkvc(xx), mkvc(yy), mkvc(zz)]
-mesh = refine_tree_xyz(
-    mesh, pts, octree_levels=[2, 2], method="surface", finalize=False
-)
+levels = [-1, -2]
+padding = [[0, 0, 2], [0, 0, 2]]
+mesh.refine_surface(pts, levels, padding, finalize=False)
 
 # Refine box
 xp, yp, zp = np.meshgrid([-40.0, 40.0], [-40.0, 40.0], [-60.0, 0.0])
 xyz = np.c_[mkvc(xp), mkvc(yp), mkvc(zp)]
-
-mesh = refine_tree_xyz(mesh, xyz, octree_levels=[2, 2], method="box", finalize=False)
-
+mesh.refine_bounding_box(xyz, levels, padding, finalize=False)
 mesh.finalize()
 
 # The bottom west corner

--- a/tutorials/mesh_generation/4_tree_mesh.py
+++ b/tutorials/mesh_generation/4_tree_mesh.py
@@ -62,9 +62,8 @@ xy = np.c_[mkvc(xp), mkvc(yp)]  # mkvc creates vectors
 
 # Discretize to finest cell size within rectangular box, with padding in the z direction
 # at the finest and second finest levels.
-levels = [-1, -2]
 padding = [[0, 2], [0, 2]]
-mesh.refine_bounding_box(xy, levels, padding)
+mesh.refine_bounding_box(xy, level=-1, padding_cells_by_level=padding)
 
 mesh.plotGrid(show_it=True)
 
@@ -102,15 +101,14 @@ mesh = TreeMesh([hx, hy], x0="CC")
 xx = mesh.vectorNx
 yy = -3 * np.exp((xx ** 2) / 100 ** 2) + 50.0
 pts = np.c_[mkvc(xx), mkvc(yy)]
-levels = [-1, -2]
 padding = [[0, 2], [0, 2]]
-mesh.refine_surface(pts, levels, padding, finalize=False)
+mesh.refine_surface(pts, padding_cells_by_level=padding, finalize=False)
 
 # Refine mesh near points
 xx = np.array([0.0, 10.0, 0.0, -10.0])
 yy = np.array([-20.0, -10.0, 0.0, -10])
 pts = np.c_[mkvc(xx), mkvc(yy)]
-mesh.refine_points(pts, [-1, -2], [2, 2], finalize=False)
+mesh.refine_points(pts, padding_cells_by_level=[2, 2], finalize=False)
 
 mesh.finalize()
 
@@ -149,15 +147,14 @@ mesh = TreeMesh([hx, hy], x0="CC")
 xx = mesh.vectorNx
 yy = -3 * np.exp((xx ** 2) / 100 ** 2) + 50.0
 pts = np.c_[mkvc(xx), mkvc(yy)]
-levels = [-1 , -2]
 padding = [[0, 2], [0, 2]]
-mesh.refine_surface(pts, levels, padding, finalize=False)
+mesh.refine_surface(pts, padding_cells_by_level=padding, finalize=False)
 
 # Refine near points
 xx = np.array([0.0, 10.0, 0.0, -10.0])
 yy = np.array([-20.0, -10.0, 0.0, -10])
 pts = np.c_[mkvc(xx), mkvc(yy)]
-mesh.refine_points(pts, [-1, -2], [2, 2], finalize=False)
+mesh.refine_points(pts, padding_cells_by_level=[2, 2], finalize=False)
 
 mesh.finalize()
 
@@ -214,14 +211,13 @@ mesh = TreeMesh([hx, hy, hz], x0="CCC")
 [xx, yy] = np.meshgrid(mesh.vectorNx, mesh.vectorNy)
 zz = -3 * np.exp((xx ** 2 + yy ** 2) / 100 ** 2) + 50.0
 pts = np.c_[mkvc(xx), mkvc(yy), mkvc(zz)]
-levels = [-1, -2]
 padding = [[0, 0, 2], [0, 0, 2]]
-mesh.refine_surface(pts, levels, padding, finalize=False)
+mesh.refine_surface(pts, padding_cells_by_level=padding, finalize=False)
 
 # Refine box
 xp, yp, zp = np.meshgrid([-40.0, 40.0], [-40.0, 40.0], [-60.0, 0.0])
 xyz = np.c_[mkvc(xp), mkvc(yp), mkvc(zp)]
-mesh.refine_bounding_box(xyz, levels, padding, finalize=False)
+mesh.refine_bounding_box(xyz, padding_cells_by_level=padding, finalize=False)
 mesh.finalize()
 
 # The bottom west corner


### PR DESCRIPTION
This is intended to replace the functionality of the `refine_tree_xyz` utility, which will be marked as deprecated.
The new functions have slightly more intuitive inputs (in my opinion). They use the `level` argument to explicitly refer to the octree level, and `padding_cells_by_level` to refer to the amount of padding around the object.

The previous function split the padding descriptions into the `octree_levels` argument and the `octree_levels_padding`. The method of refining at specific levels is not intuitive and it was implied only by the length of the array passed to `octree_levels`, and not there values, as the name might imply.

~There is still missing tests~, but just wanted to get these out there for feedback on the inputs and descriptions in the documentation of these functions. The new `surface` function is not necessarily any quicker than the previous, but it is more well behaved. Although it's cost rises faster with the number of triangles in the triangulation.