### PR TITLE
Documentation updates

### DIFF
--- a/discretize/operators/differential_operators.py
+++ b/discretize/operators/differential_operators.py
@@ -2,6 +2,7 @@
 import numpy as np
 from scipy import sparse as sp
 import warnings
+from discretize.base import BaseMesh
 from discretize.utils import (
     sdiag,
     speye,
@@ -128,7 +129,7 @@ def _ddxCellGradBC(n, bc):
     return D
 
 
-class DiffOperators(object):
+class DiffOperators(BaseMesh):
     """Class used for creating differential and averaging operators.
 
     ``DiffOperators`` is a class for managing the construction of

--- a/discretize/operators/inner_products.py
+++ b/discretize/operators/inner_products.py
@@ -1,5 +1,6 @@
 """Construct inner product operators for tensor like meshes."""
 from scipy import sparse as sp
+from discretize.base import BaseMesh
 from discretize.utils import (
     sub2ind,
     sdiag,
@@ -17,7 +18,7 @@ import numpy as np
 import warnings
 
 
-class InnerProducts(object):
+class InnerProducts(BaseMesh):
     """Class for constructing inner product matrices.
 
     ``InnerProducts`` is a mixin class for constructing inner product matrices,

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -214,7 +214,7 @@ class OrderTest(unittest.TestCase):
     for the convergence testing and defines a method :py:attr:`~OrderTest.getError`
     which defines the error as a norm of the residual (see example).
 
-    OrderTest inherits from :py:class:`unittest.TestCase`.
+    OrderTest inherits from :class:`unittest.TestCase`.
 
     Parameters
     ----------

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -214,6 +214,8 @@ class OrderTest(unittest.TestCase):
     for the convergence testing and defines a method :py:attr:`~OrderTest.getError`
     which defines the error as a norm of the residual (see example).
 
+    OrderTest inherits from :py:class:`unittest.TestCase`.
+
     Parameters
     ----------
     name : str

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ import discretize
 import subprocess
 from sphinx_gallery.sorting import FileNameSortKey
 import shutil
+from collections import defaultdict
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -53,6 +54,22 @@ extensions = [
 autosummary_generate = True
 
 numpydoc_attributes_as_param_list = False
+
+numpydoc_show_inherited_class_members = {
+    "discretize.base.BaseMesh": False,
+    "discretize.base.BaseRegularMesh": False,
+    "discretize.base.BaseRectangularMesh": False,
+    "discretize.base.BaseTensorMesh": False,
+    "discretize.operators.DiffOperators": False,
+    "discretize.operators.InnerProducts": False,
+    "discretize.mixins.TensorMeshIO": False,
+    "discretize.mixins.TreeMeshIO": False,
+    "discretize.mixins.InterfaceMPL": False,
+    "discretize.mixins.InterfaceVTK": False,
+    "discretize.mixins.InterfaceOMF": False,
+    "discretize.mixins.Slicer": False,
+    "discretize.tests.OrderTest": False,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/release/0.8.1-notes.rst
+++ b/docs/release/0.8.1-notes.rst
@@ -12,7 +12,7 @@ This patch release, in addition to some small bug fixes and runtime improvements
 also implements some missing functionality for cylindrical meshes.
 
 ``CylindricalMesh``
----------------
+-------------------
 The big news is that 3D cylindrical meshes can now be output to a vtk format, which
 represents the wedges and arced cells as rational bezier curves in an unstructured vtk
 mesh.

--- a/docs/release/0.8.2-notes.rst
+++ b/docs/release/0.8.2-notes.rst
@@ -1,9 +1,9 @@
 .. currentmodule:: discretize
 
-.. _0.8.1_notes:
+.. _0.8.2_notes:
 
 ===================================
-``discretize`` 0.8.1 Release Notes
+``discretize`` 0.8.2 Release Notes
 ===================================
 
 August 17, 2022

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -14,7 +14,7 @@ dependencies:
   - sphinx-toolbox
   - sphinxcontrib-apidoc
   - pydata-sphinx-theme
-  - numpydoc
+  - numpydoc>=1.5
   - pillow
   - sympy
   - wheel

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,7 @@ wheel
 twine
 vtk
 pyvista>=0.20.1
-numpydoc
+numpydoc>=1.5
 nbsphinx
 omf
 matplotlib


### PR DESCRIPTION
Small updates to documentation.

`DiffOperators` and `InnerProducts` now inherit `BaseMesh` so that we get proper doc string inheritance for those methods defined in them.

Also, conditionally sets which classes we want to show the full inherited members of (Only our primary mesh classes)