### PR TITLE
Assert tests

### DIFF
--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -513,13 +513,6 @@ def check_derivative(
     ========================= PASS! =========================
     Once upon a time, a happy little test passed.
     """
-    # matplotlib is a soft dependencies for discretize,
-    # lazy-loaded to decrease load time of discretize.
-    try:
-        import matplotlib
-        import matplotlib.pyplot as plt
-    except ImportError:
-        matplotlib = False
 
     print("{0!s} checkDerivative {1!s}".format("=" * 20, "=" * 20))
     print(
@@ -564,38 +557,52 @@ def check_derivative(
     # Ensure we are about precision
     order0 = order0[E0[1:] > eps]
     order1 = order1[E1[1:] > eps]
-    belowTol = order1.size == 0 and order0.size >= 0
-    # Make sure we get the correct order
-    correctOrder = order1.size > 0 and np.mean(order1) > tolerance * expectedOrder
-
-    passTest = belowTol or correctOrder
-
-    if passTest:
+    # belowTol = order1.size == 0 and order0.size >= 0
+    # # Make sure we get the correct order
+    # correctOrder = order1.size > 0 and np.mean(order1) > tolerance * expectedOrder
+    #
+    # passTest = belowTol or correctOrder
+    try:
+        if order1.size == 0:
+            # This should happen if the original function was a linear function
+            # Thus it has no higher order derivatives.
+            assert order0.size >= 0
+        else:
+            assert np.mean(order1) > tolerance * expectedOrder
         print("{0!s} PASS! {1!s}".format("=" * 25, "=" * 25))
-        print(happiness[np.random.randint(len(happiness))] + "\n")
-    else:
+        print(np.random.choice(happiness) + "\n")
+    except AssertionError as err:
         print(
             "{0!s}\n{1!s} FAIL! {2!s}\n{3!s}".format(
                 "*" * 57, "<" * 25, ">" * 25, "*" * 57
             )
         )
-        print(sadness[np.random.randint(len(sadness))] + "\n")
+        print(np.random.choice(sadness) + "\n")
+        raise err
 
-    @requires({"matplotlib": matplotlib})
-    def plot_it(ax):
-        if plotIt:
-            if ax is None:
-                ax = plt.subplot(111)
-            ax.loglog(h, E0, "b")
-            ax.loglog(h, E1, "g--")
-            ax.set_title(
+    if plotIt:
+        # matplotlib is a soft dependencies for discretize,
+        # lazy-loaded to decrease load time of discretize.
+        try:
+            import matplotlib
+            import matplotlib.pyplot as plt
+        except ImportError:
+            matplotlib = False
+
+        @requires({"matplotlib": matplotlib})
+        def plot_it(axes):
+            if axes is None:
+                axes = plt.subplot(111)
+            axes.loglog(h, E0, "b")
+            axes.loglog(h, E1, "g--")
+            axes.set_title(
                 "Check Derivative - {0!s}".format(
                     ("PASSED :)" if passTest else "FAILED :(")
                 )
             )
-            ax.set_xlabel("h")
-            ax.set_ylabel("Error")
-            leg = ax.legend(
+            axes.set_xlabel("h")
+            axes.set_ylabel("Error")
+            leg = axes.legend(
                 [r"$\mathcal{O}(h)$", r"$\mathcal{O}(h^2)$"],
                 loc="best",
                 title=r"$f(x + h\Delta x) - f(x) - h g(x) \Delta x - \mathcal{O}(h^2) = 0$",
@@ -604,9 +611,9 @@ def check_derivative(
             plt.setp(leg.get_title(), fontsize=15)
             plt.show()
 
-    plot_it(ax)
+        plot_it(ax)
 
-    return passTest
+    return True
 
 
 def get_quadratic(A, b, c=0):

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -466,6 +466,8 @@ def assert_expected_order(
     That was easy!
     """
     n_cells = np.asarray(n_cells, dtype=int)
+    if test_type not in ["mean", "min", "last", "all", "mean_at_least"]:
+        raise ValueError
     orders = []
     # Do first values:
     nc = n_cells[0]
@@ -497,7 +499,6 @@ def assert_expected_order(
             np.testing.assert_allclose(orders[-1], expected_order, rtol=rtol)
         elif test_type == "all":
             np.testing.assert_allclose(orders, expected_order, rtol=rtol)
-
         print(np.random.choice(happiness))
     except AssertionError as err:
         print(np.random.choice(sadness))

--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -454,16 +454,6 @@ def assert_expected_order(
 
     Then run the expected order test.
     >>> assert_expected_order(deriv_error, [10, 20, 30, 40, 50])
-    _______________________________________________________
-      nc  |    h    |    error    | e(i-1)/e(i) |  order
-    ~~~~~~|~~~~~~~~~|~~~~~~~~~~~~~|~~~~~~~~~~~~~|~~~~~~~~~~
-      10  |1.00e-01 |  3.389e-04  |             |
-      20  |5.00e-02 |  8.622e-05  |   3.9306    |  1.9747
-      30  |3.33e-02 |  3.853e-05  |   2.2374    |  1.9861
-      40  |2.50e-02 |  2.174e-05  |   1.7729    |  1.9904
-      50  |2.00e-02 |  1.393e-05  |   1.5599    |  1.9926
-    -------------------------------------------------------
-    That was easy!
     """
     n_cells = np.asarray(n_cells, dtype=int)
     if test_type not in ["mean", "min", "last", "all", "mean_at_least"]:

--- a/tests/base/test_tests.py
+++ b/tests/base/test_tests.py
@@ -3,7 +3,8 @@ import pytest
 import discretize
 import subprocess
 import numpy as np
-from discretize.tests import assert_isadjoint
+import scipy.sparse as sp
+from discretize.tests import assert_isadjoint, checkDerivative, assert_expected_order
 
 
 class TestAssertIsAdjoint:
@@ -65,6 +66,74 @@ class TestAssertIsAdjoint:
             complex_v=True,
             clinear=False,
         )
+
+
+class TestCheckDerivative:
+    def test_simplePass(self):
+        def simplePass(x):
+            return np.sin(x), sp.diags(np.cos(x))
+
+        checkDerivative(simplePass, np.random.randn(5), plotIt=False)
+
+    def test_simpleFunction(self):
+        def simpleFunction(x):
+            return np.sin(x), lambda xi: np.cos(x) * xi
+
+        checkDerivative(simpleFunction, np.random.randn(5), plotIt=False)
+
+    def test_simpleFail(self):
+        def simpleFail(x):
+            return np.sin(x), -sp.diags(np.cos(x))
+
+        with pytest.raises(AssertionError):
+            checkDerivative(simpleFail, np.random.randn(5), plotIt=False)
+
+
+@pytest.mark.parametrize("test_type", ["mean", "min", "last", "all", "mean_at_least"])
+def test_expected_order_pass(test_type):
+    func = lambda y: np.cos(y)
+    func_deriv = lambda y: -np.sin(y)
+
+    def deriv_error(n):
+        # The l-inf norm of the average error vector does
+        # follow second order convergence.
+        nodes = np.linspace(0, 1, n + 1)
+        cc = 0.5 * (nodes[1:] + nodes[:-1])
+        dh = nodes[1] - nodes[0]
+        node_eval = func(nodes)
+        num_deriv = (node_eval[1:] - node_eval[:-1]) / dh
+        true_deriv = func_deriv(cc)
+        err = np.linalg.norm(num_deriv - true_deriv, ord=np.inf)
+        return err, dh
+
+    assert_expected_order(deriv_error, [10, 20, 30, 40, 50], test_type=test_type)
+
+
+@pytest.mark.parametrize("test_type", ["mean", "min", "last", "all", "mean_at_least"])
+def test_expected_order_failed(test_type):
+    func = lambda y: np.cos(y)
+    func_deriv = lambda y: -np.sin(y)
+
+    def deriv_error(n):
+        # The l2 norm of the average error vector does not
+        # follow second order convergence.
+        nodes = np.linspace(0, 1, n + 1)
+        cc = 0.5 * (nodes[1:] + nodes[:-1])
+        dh = nodes[1] - nodes[0]
+        node_eval = func(nodes)
+        num_deriv = (node_eval[1:] - node_eval[:-1]) / dh
+        true_deriv = func_deriv(cc)
+        err = np.linalg.norm(num_deriv - true_deriv)
+        return err, dh
+
+    with pytest.raises(AssertionError):
+        assert_expected_order(deriv_error, [10, 20, 30, 40, 50], test_type=test_type)
+
+
+def test_expected_order_bad_test_type():
+    # should fail fast if given a bad test_type
+    with pytest.raises(ValueError):
+        assert_expected_order(None, [10, 20, 30, 40, 50], test_type="not_a_test")
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Not Linux.")

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -23,7 +23,6 @@ from discretize.utils import (
     refine_tree_xyz,
     meshTensor,
 )
-from discretize.tests import checkDerivative
 import discretize
 
 TOL = 1e-8

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import numpy as np
 import scipy.sparse as sp
 from discretize.utils import (
@@ -29,27 +30,25 @@ import discretize
 TOL = 1e-8
 
 
-class TestCheckDerivative(unittest.TestCase):
+class TestCheckDerivative:
     def test_simplePass(self):
         def simplePass(x):
             return np.sin(x), sdiag(np.cos(x))
 
-        passed = checkDerivative(simplePass, np.random.randn(5), plotIt=False)
-        self.assertTrue(passed, True)
+        checkDerivative(simplePass, np.random.randn(5), plotIt=False)
 
     def test_simpleFunction(self):
         def simpleFunction(x):
             return np.sin(x), lambda xi: sdiag(np.cos(x)) * xi
 
-        passed = checkDerivative(simpleFunction, np.random.randn(5), plotIt=False)
-        self.assertTrue(passed, True)
+        checkDerivative(simpleFunction, np.random.randn(5), plotIt=False)
 
     def test_simpleFail(self):
         def simpleFail(x):
             return np.sin(x), -sdiag(np.cos(x))
 
-        passed = checkDerivative(simpleFail, np.random.randn(5), plotIt=False)
-        self.assertTrue(not passed, True)
+        with pytest.raises(AssertionError):
+            checkDerivative(simpleFail, np.random.randn(5), plotIt=False)
 
 
 class TestSequenceFunctions(unittest.TestCase):

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,5 +1,4 @@
 import unittest
-import pytest
 import numpy as np
 import scipy.sparse as sp
 from discretize.utils import (
@@ -28,27 +27,6 @@ from discretize.tests import checkDerivative
 import discretize
 
 TOL = 1e-8
-
-
-class TestCheckDerivative:
-    def test_simplePass(self):
-        def simplePass(x):
-            return np.sin(x), sdiag(np.cos(x))
-
-        checkDerivative(simplePass, np.random.randn(5), plotIt=False)
-
-    def test_simpleFunction(self):
-        def simpleFunction(x):
-            return np.sin(x), lambda xi: sdiag(np.cos(x)) * xi
-
-        checkDerivative(simpleFunction, np.random.randn(5), plotIt=False)
-
-    def test_simpleFail(self):
-        def simpleFail(x):
-            return np.sin(x), -sdiag(np.cos(x))
-
-        with pytest.raises(AssertionError):
-            checkDerivative(simpleFail, np.random.randn(5), plotIt=False)
 
 
 class TestSequenceFunctions(unittest.TestCase):


### PR DESCRIPTION
Changes check_derivative function to use assertions instead of returning True or False if the test passed or failed.
Will now raise an AssertionError if the tests fails, or return True if the test passed.

Also adds an `assert_expected_order` test function that doesn't use the `OrderTest` class. This is simpler to use with `pytests`'s parameterized tests.