### PR TITLE
change name and description of average edge to face

### DIFF
--- a/discretize/base/base_mesh.py
+++ b/discretize/base/base_mesh.py
@@ -2975,12 +2975,11 @@ class BaseMesh:
         )
 
     @property
-    def average_edge_to_face_vector(self):
-        r"""Averaging operator from edges to faces (vector quantities).
+    def average_edge_to_face(self):
+        r"""Averaging operator from edges to faces.
 
-        This property constructs the averaging operator that independently maps the
-        Cartesian components of vector quantities from edges to faces.
-        This averaging operators is used when a discrete vector quantity defined on mesh edges
+        This property constructs the averaging operator that maps uantities from edges to faces.
+        This averaging operators is used when a discrete quantity defined on mesh edges
         must be approximated at faces. The operation is implemented as a
         matrix vector product, i.e.::
 
@@ -2991,23 +2990,19 @@ class BaseMesh:
         Returns
         -------
         (n_faces, n_edges) scipy.sparse.csr_matrix
-            The vector averaging operator from edges to faces.
+            The averaging operator from edges to faces.
 
         Notes
         -----
-        Let :math:`\mathbf{u_e}` be the discrete representation of a vector
-        quantity whose Cartesian components are defined on their respective edges;
-        e.g. the x-component is defined on x-edges. **average_edge_to_face_vector**
+        Let :math:`\mathbf{u_e}` be the discrete representation of aquantity whose
+        that is defined on the edges. **average_edge_to_face**
         constructs a discrete linear operator :math:`\mathbf{A_{ef}}` that
-        projects each Cartesian component of :math:`\mathbf{u_e}` to
-        its corresponding face, i.e.:
+        projects :math:`\mathbf{u_e}` to its corresponding face, i.e.:
 
         .. math::
             \mathbf{u_f} = \mathbf{A_{ef}} \, \mathbf{u_e}
 
-        where :math:`\mathbf{u_f}` is a discrete vector quantity whose Cartesian
-        components are defined on their respective faces; e.g. the x-component is
-        defined on x-faces.
+        where :math:`\mathbf{u_f}` is a quantity defined on the respective faces.
 
         Examples
         --------
@@ -3025,20 +3020,19 @@ class BaseMesh:
 
         Create a discrete vector on mesh edges
 
-        >>> edges_x = mesh.edges_x
-        >>> edges_y = mesh.edges_y
-        >>> u_ex = -(edges_x[:, 1] / np.sqrt(np.sum(edges_x ** 2, axis=1))) * np.exp(
-        ...     -(edges_x[:, 0] ** 2 + edges_x[:, 1] ** 2) / 6 ** 2
+        >>> edges = mesh.edges
+        >>> u_ex = -(edges[:, 1] / np.sqrt(np.sum(edges ** 2, axis=1))) * np.exp(
+        ...     -(edges[:, 0] ** 2 + edges[:, 1] ** 2) / 6 ** 2
         ... )
-        >>> u_ey = (edges_y[:, 0] / np.sqrt(np.sum(edges_y ** 2, axis=1))) * np.exp(
-        ...     -(edges_y[:, 0] ** 2 + edges_y[:, 1] ** 2) / 6 ** 2
+        >>> u_ey = (edges[:, 0] / np.sqrt(np.sum(edges ** 2, axis=1))) * np.exp(
+        ...     -(edges[:, 0] ** 2 + edges[:, 1] ** 2) / 6 ** 2
         ... )
-        >>> u_e = np.r_[u_ex, u_ey]
+        >>> u_e = np.c_[u_ex, u_ey]
 
         Next, we construct the averaging operator and apply it to
         the discrete vector quantity to approximate the value at the faces.
 
-        >>> Aef = mesh.average_edge_to_face_vector
+        >>> Aef = mesh.average_edge_to_face
         >>> u_f = Aef @ u_e
 
         Plot the results,
@@ -3047,10 +3041,12 @@ class BaseMesh:
 
             >>> fig = plt.figure(figsize=(11, 5))
             >>> ax1 = fig.add_subplot(121)
-            >>> mesh.plot_image(u_e, ax=ax1, v_type="E", view='vec')
+            >>> proj_ue = mesh.project_edge_vector(u_e)
+            >>> mesh.plot_image(proj_ue, ax=ax1, v_type="E", view='vec')
             >>> ax1.set_title("Variable at edges", fontsize=16)
             >>> ax2 = fig.add_subplot(122)
-            >>> mesh.plot_image(u_f, ax=ax2, v_type="F", view='vec')
+            >>> proj_uf = mesh.project_face_vector(u_f)
+            >>> mesh.plot_image(proj_uf, ax=ax2, v_type="F", view='vec')
             >>> ax2.set_title("Averaged to faces", fontsize=16)
             >>> plt.show()
 
@@ -3067,7 +3063,7 @@ class BaseMesh:
             >>> plt.show()
         """
         raise NotImplementedError(
-            f"average_edge_to_face_vector not implemented for {type(self)}"
+            f"average_edge_to_face not implemented for {type(self)}"
         )
 
     @property

--- a/discretize/operators/differential_operators.py
+++ b/discretize/operators/differential_operators.py
@@ -2293,7 +2293,9 @@ class DiffOperators(BaseMesh):
 
         n_boundary_edges = len(w)
 
-        Av = Pf @ self.average_edge_to_face_vector @ Pe.T
+        Av = Pf @ self.average_edge_to_face @ Pe.T
+        if self.dim > 2:
+            Av *= 2
 
         w_cross_n = np.cross(-w, Av.T @ dA)
 
@@ -3279,7 +3281,7 @@ class DiffOperators(BaseMesh):
         return self._average_edge_z_to_cell
 
     @property
-    def average_edge_to_face_vector(self):  # NOQA D102
+    def average_edge_to_face(self):  # NOQA D102
         # Documentation inherited from discretize.base.BaseMesh
         if self.dim == 1:
             return self.average_cell_to_face
@@ -3299,7 +3301,7 @@ class DiffOperators(BaseMesh):
         ez_to_fx = kron3(speye(n3), av(n2), speye(n1 + 1))
         ez_to_fy = kron3(speye(n3), speye(n2 + 1), av(n1))
 
-        e_to_f = sp.bmat(
+        e_to_f = 0.5 * sp.bmat(
             [
                 [None, ey_to_fx, ez_to_fx],
                 [ex_to_fy, None, ez_to_fy],

--- a/tests/base/test_basemesh.py
+++ b/tests/base/test_basemesh.py
@@ -39,7 +39,7 @@ class TestBaseMesh(unittest.TestCase):
         "average_cell_to_edge",
         "average_edge_to_cell",
         "average_edge_to_cell_vector",
-        "average_edge_to_face_vector",
+        "average_edge_to_face",
         "average_node_to_cell",
         "average_node_to_edge",
         "average_node_to_face",

--- a/tests/base/test_operators.py
+++ b/tests/base/test_operators.py
@@ -500,10 +500,8 @@ class TestAveraging1D(discretize.tests.OrderTest):
         fun = lambda x: np.cos(x)
         self.getHere = lambda M: fun(M.edges)
         self.getThere = lambda M: fun(M.faces)
-        self.getAve = lambda M: M.average_edge_to_face_vector
-        self.expectedOrders = 1
+        self.getAve = lambda M: M.average_edge_to_face
         self.orderTest()
-        self.expectedOrders = 2
 
 
 class TestAverating2DSimple(unittest.TestCase):

--- a/tests/tree/test_tree_interpolation.py
+++ b/tests/tree/test_tree_interpolation.py
@@ -223,8 +223,8 @@ class TestCaching(unittest.TestCase):
 
     def testCaching(self):
         mesh = self.mesh
-        A1 = mesh.average_edge_to_face_vector
-        A2 = mesh.average_edge_to_face_vector
+        A1 = mesh.average_edge_to_face
+        A2 = mesh.average_edge_to_face
         self.assertIs(A1, A2)
 
 


### PR DESCRIPTION
Fixes the averaging operator to actually do something that it describes. Before it was doing an odd operation that was only relevant to the boundary integrals, and even then only to coordinate aligned axes. Now it switches it to actually average things, and then changes it to the needed part for the boundary integral