### PR TITLE
Curvilinear vector boundary integral

### DIFF
--- a/discretize/curvilinear_mesh.py
+++ b/discretize/curvilinear_mesh.py
@@ -744,7 +744,10 @@ class CurvilinearMesh(
 
         Parameters
         ----------
-        only_boundary : whether to only operate on the boundary faces or not.
+        only_boundary : bool, optional
+            Whether to only operate on the boundary faces or not.
+        with_area : bool, optional
+            Whether to include the face area.
 
         Returns
         -------

--- a/tests/boundaries/test_boundary_integrals.py
+++ b/tests/boundaries/test_boundary_integrals.py
@@ -214,7 +214,7 @@ class Test3DBoundaryIntegral(discretize.tests.OrderTest):
         "sphereCurv",
     ]
     meshDimension = 3
-    expectedOrders = [2, 1, 2, 2, 2, 0]
+    expectedOrders = [2, 1, 2, 2, 2, 2]
     meshSizes = [4, 8, 16, 32]
 
     def getError(self):


### PR DESCRIPTION
Implements the 2nd order accurate surface integral for the 3D curvilinear mesh. Now properly takes into account the edge basis function dotted with a vector defined on the faces.