### PR TITLE
Capture scroll

### DIFF
--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -2580,6 +2580,8 @@ class Slicer(object):
         # Create subplots
         self.fig = plt.gcf()
         self.fig.subplots_adjust(wspace=0.075, hspace=0.1)
+        # To capture mouse scroll in notebooks (otherwise it is hard to slice through volume)
+        self.fig.canvas.capture_scroll = True
 
         # X-Y
         self.ax1 = plt.subplot2grid(


### PR DESCRIPTION
The behaviour changed with the advent of ipympl (Lab; modern Notebook), I think. Currently the scroll over a figure makes the notebook keep scrolling, so it is hard to scroll over a slicer-image through the volume.

This PR implements the fix suggested by Matplotlib (PR 235).