### PR TITLE
Use any Python 3 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ repos:
     rev: 23.1a1
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
-        language_version: python3.10
+        language_version: python3
         additional_dependencies: [flake8-bugbear, flake8-builtins, flake8-mutable, flake8-rst-docstrings, flake8-docstrings]
 
 


### PR DESCRIPTION
Unpin Python 3.10 in pre-commit configuration and use any available Python 3 interpreter. This fixes issues when the Python version in the environment is not 3.10.
