### PR TITLE
Update a test expression to fix a logical short circuit

### DIFF
--- a/discretize/unstructured_mesh.py
+++ b/discretize/unstructured_mesh.py
@@ -402,7 +402,7 @@ class SimplexMesh(BaseMesh, SimplexMeshIO, InterfaceMixins):
     def __get_inner_product_projection_matrices(
         self, i_type, with_volume=True, return_pointers=True
     ):
-        if getattr(self, "_proj_stash", None is None):
+        if getattr(self, "_proj_stash", None) is None:
             self._proj_stash = {}
         if i_type not in self._proj_stash:
             dim = self.dim


### PR DESCRIPTION
In file: unstructured_mesh.py, method: `__get_inner_product_projection_matrices`, a logical equality check operation was performed with the same operand on both sides. The comparison operation always returns either true or false. Such logical short circuits in code lead to unintended behavior. 

I think this was probably a typo as a similar check is done in a different way in many other parts of the same code. I suggested that the logical operation should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.