### PR TITLE
Add export config for git archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
This should include information necessary for setuptools_scm in archives created from github.

Instructions came from:
[setuptools_scm documentation](https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives)