### PR TITLE
Replace `build` for `python-build` in environment_test.yml

### DIFF
--- a/environment_test.yml
+++ b/environment_test.yml
@@ -27,7 +27,7 @@ dependencies:
   - meson-python>=0.14.0
   - meson
   - ninja
-  - build
+  - python-build
   - cython>=0.29.35
   - setuptools_scm
   # Distribute


### PR DESCRIPTION
The `build` package in `conda-forge` is outdated, `python-build` should be used instead.
