### PR TITLE
display dev doc banner

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,10 +1,10 @@
 [
-    {
-        "version": "main",
+    {   "name": "main",
+        "version": "dev",
         "url": "https://discretize.simpeg.xyz/en/main/"
     },
     {
-        "name": "0.10.0 (latest)",
+        "name": "0.10.0 (stable)",
         "version": "v0.10.0",
         "url": "https://discretize.simpeg.xyz/en/v0.10.0/",
         "preferred": true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -282,8 +282,8 @@ html_theme_options = {
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     # Configure version switcher (remember to add it to the "navbar_end")
     "switcher": {
-        "version_match": branch,
-        "json_url": "https://discretize.simpeg.xyz/en/latest/_static/versions.json",
+        "version_match": "dev" if branch == "main" else branch,
+        "json_url": "https://discretize.simpeg.xyz/en/main/_static/versions.json",
     },
     "show_version_warning_banner": True,
 }


### PR DESCRIPTION
Apparently... (and this is not well documented), for the pydata-sphinx-theme to display the development banner either:
* the string `dev`, `rc`, or `pre` must appear in the "version" for the matcher
* or the version must compare greater than the preferred version.

So this just gives the main branch a `dev` version in the matcher, and also makes the `json_url` point to the version on `main`