### PR TITLE
Fix macos-latest build

### DIFF
--- a/.ci/azure/setup_miniconda_macos.sh
+++ b/.ci/azure/setup_miniconda_macos.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex #echo on and exit if any line fails
+
+echo "arch is $ARCH"
+if [[ $ARCH == "X64" ]]; then
+  MINICONDA_ARCH_LABEL="x86_64"
+else
+  MINICONDA_ARCH_LABEL="arm64"
+fi
+echo $MINICONDA_ARCH_LABEL
+mkdir -p ~/miniconda3
+curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-$MINICONDA_ARCH_LABEL.sh -o ~/miniconda3/miniconda.sh
+bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+rm ~/miniconda3/miniconda.sh
+echo "##vso[task.setvariable variable=CONDA;]${HOME}/miniconda3"

--- a/.ci/azure/test.yml
+++ b/.ci/azure/test.yml
@@ -35,14 +35,15 @@ jobs:
     vmImage: $(image)
   variables:
     varOS: $(Agent.OS)
+    ARCH: $(Agent.OSArchitecture)
   steps:
+    - bash: .ci/azure/setup_miniconda_macos.sh
+      displayName: Install miniconda on mac
+      condition: eq(variables.varOS, 'Darwin')
+
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
       condition: ne(variables.varOS, 'Windows_NT')
-
-    - bash: sudo chown -R $USER $CONDA
-      displayName: Take ownership of conda directory
-      condition: eq(variables.varOS, 'Darwin')
 
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
       displayName: Add conda to PATH


### PR DESCRIPTION
macos-latest images on azure no longer have conda by default