### PR TITLE
Warn for non-repeatable random tests in a testing environment

### DIFF
--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -25,7 +25,6 @@ Functions
   assert_isadjoint
 """  # NOQA D205
 
-import os
 import warnings
 
 import numpy as np
@@ -85,10 +84,9 @@ _happiness_rng = np.random.default_rng()
 
 
 def _warn_random_test():
-    in_pytest = "PYTEST_CURRENT_TEST" in os.environ
-    in_nosetest = any(
-        x[0].f_globals["__name__"].startswith("nose.") for x in inspect.stack()
-    )
+    stack = inspect.stack()
+    in_pytest = any(x[0].f_globals["__name__"].startswith("_pytest.") for x in stack)
+    in_nosetest = any(x[0].f_globals["__name__"].startswith("nose.") for x in stack)
 
     if in_pytest or in_nosetest:
         test = "pytest" if in_pytest else "nosetest"

--- a/tests/base/test_tests.py
+++ b/tests/base/test_tests.py
@@ -4,7 +4,13 @@ import discretize
 import subprocess
 import numpy as np
 import scipy.sparse as sp
-from discretize.tests import assert_isadjoint, check_derivative, assert_expected_order
+from discretize.tests import (
+    assert_isadjoint,
+    check_derivative,
+    assert_expected_order,
+    _warn_random_test,
+    setup_mesh,
+)
 
 
 class TestAssertIsAdjoint:
@@ -166,3 +172,22 @@ def test_import_time():
 
     # Currently we check t < 1.0s.
     assert float(out.stderr.decode("utf-8")[:-1]) < 1.0
+
+
+def test_random_test_warning():
+
+    match = r"You are running a pytest without setting a random seed.*"
+    with pytest.warns(UserWarning, match=match):
+        _warn_random_test()
+
+    def simple_deriv(x):
+        return np.sin(x), lambda y: np.cos(x) * y
+
+    with pytest.warns(UserWarning, match=match):
+        check_derivative(simple_deriv, np.zeros(10), plotIt=False)
+
+    with pytest.warns(UserWarning, match=match):
+        setup_mesh("randomTensorMesh", 10, 1)
+
+    with pytest.warns(UserWarning, match=match):
+        assert_isadjoint(lambda x: x, lambda x: x, 5, 5)


### PR DESCRIPTION
When someone runs a test that would randomly initialize a random number generator from `pytest` or `nosetest`, issue a warning recommending setting the seed for repeatable tests.

This checks by using stack inspection looking for either `_pytest.` or `nose.`