### PR TITLE
Set no diagonal balance when reading UBC tree meshes

### DIFF
--- a/discretize/mixins/mesh_io.py
+++ b/discretize/mixins/mesh_io.py
@@ -492,7 +492,7 @@ class TreeMeshIO(object):
         else:
             max_level = min(ls) + 1
 
-        mesh = TreeMesh(hs, origin=origin)
+        mesh = TreeMesh(hs, origin=origin, diagonal_balance=False)
         levels = indArr[:, -1]
         indArr = indArr[:, :-1]
 

--- a/discretize/mixins/mpl_mod.py
+++ b/discretize/mixins/mpl_mod.py
@@ -2149,7 +2149,7 @@ class InterfaceMPL(object):
         normal[normalInd] = 1
 
         # create a temporary TreeMesh with the slice through
-        temp_mesh = discretize.TreeMesh(h2d, x2d)
+        temp_mesh = discretize.TreeMesh(h2d, x2d, diagonal_balance=False)
         level_diff = self.max_level - temp_mesh.max_level
 
         # get list of cells which intersect the slicing plane

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -1070,7 +1070,7 @@ class TreeMesh(
 
     def __reduce__(self):
         """Return the necessary items to reconstruct this object's state."""
-        return TreeMesh, (self.h, self.origin), self.__getstate__()
+        return TreeMesh, (self.h, self.origin, False), self.__getstate__()
 
     cellGrad = deprecate_property(
         "cell_gradient", "cellGrad", removal_version="1.0.0", error=True

--- a/discretize/utils/mesh_utils.py
+++ b/discretize/utils/mesh_utils.py
@@ -401,6 +401,7 @@ def mesh_builder_xyz(
     depth_core=None,
     expansion_factor=1.3,
     mesh_type="tensor",
+    tree_diagonal_balance=None,
 ):
     """Generate a tensor or tree mesh using a cloud of points.
 
@@ -428,6 +429,9 @@ def mesh_builder_xyz(
         Expansion factor for padding cells. Ignored if *mesh_type* = *tree*
     mesh_type : {'tensor', 'tree'}
         Specify output mesh type
+    tree_diagonal_balance : bool, optional
+        Whether to diagonally balance the tree mesh, `None` will use the `TreeMesh`
+        default behavoir.
 
     Returns
     -------
@@ -521,7 +525,7 @@ def mesh_builder_xyz(
             h_dim += [np.ones(2**maxLevel) * h[ii]]
 
         # Define the mesh and origin
-        mesh = discretize.TreeMesh(h_dim)
+        mesh = discretize.TreeMesh(h_dim, diagonal_balance=tree_diagonal_balance)
 
         for ii, _cc in enumerate(nC):
             core = limits[ii][0] - limits[ii][1]

--- a/tests/tree/test_tree_io.py
+++ b/tests/tree/test_tree_io.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import discretize
 import pickle
@@ -47,6 +48,19 @@ def test_UBCfiles(mesh, tmp_path):
     mesh.write_model_UBC([model_file], [vec])
     vecUBC2 = mesh.read_model_UBC(model_file)
     np.testing.assert_array_equal(vec, vecUBC2)
+
+
+def test_ubc_files_no_warning_diagonal_balance(mesh, tmp_path):
+    """
+    Test that reading UBC files don't trigger the diagonal balance warning.
+    """
+    # Save the sample mesh into a UBC file
+    fname = tmp_path / "temp.msh"
+    mesh.write_UBC(fname)
+    # Make sure that no warning is raised when reading the mesh
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        discretize.TreeMesh.read_UBC(fname)
 
 
 if has_vtk:


### PR DESCRIPTION
Set `diagonal_balance=False` when creating a `TreeMesh` after reading a UBC file in `read_UBC`. This prevents raising the future warning related to the default value of `diagonal_balance`. Add test that checks that no warning is being raised by that method.
