### PR TITLE
Fix small typos in diagonal_balance warning

### DIFF
--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -243,8 +243,9 @@ class TreeMesh(
             diagonal_balance = False
             warnings.warn(
                 "In discretize v1.0 the TreeMesh will change the default value of "
-                "diagonal_balance to True, which will likely slightly change meshes you have"
-                "previously created. If you need to keep the current behavoir, explicitly set "
+                "diagonal_balance to True, which will likely slightly change meshes "
+                "you have previously created. "
+                "If you need to keep the current behavior, explicitly set "
                 "diagonal_balance=False.",
                 FutureWarning,
                 stacklevel=2,


### PR DESCRIPTION
Add missing space between "have" and "previously", fix spelling in "behavior".
