### PR TITLE
Fix formatting new warning

### DIFF
--- a/discretize/tests.py
+++ b/discretize/tests.py
@@ -91,9 +91,9 @@ def _warn_random_test():
     if in_pytest or in_nosetest:
         test = "pytest" if in_pytest else "nosetest"
         warnings.warn(
-            f"You are running a {test} without setting a random seed, the results might not be"
-            "repeatable. For repeatable tests please pass an argument to `random seed` that is"
-            "not `None`.",
+            f"You are running a {test} without setting a random seed, the results might not "
+            "be repeatable. For repeatable tests please pass an argument to `random seed` "
+            "that is not `None`.",
             UserWarning,
             stacklevel=3,
         )


### PR DESCRIPTION
https://github.com/simpeg/discretize/pull/384 popped up as warning in my tests, where is saw the missing white spaces ("berepeatable" and "isnot"):
```
  /home/dtr/Codes/emg3d/tests/test_simulations.py:959: UserWarning: You are running a pytest without setting a random seed, the results might not berepeatable. For repeatable tests please pass an argument to `random seed` that isnot `None`.
    discretize.tests.assert_isadjoint(
```