### PR TITLE
Add safeguards to TreeMesh properties

### DIFF
--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -15,6 +15,9 @@ import scipy.sparse as sp
 import numpy as np
 from .interputils_cython cimport _bisect_left, _bisect_right
 
+class TreeMeshNotFinalizedError(RuntimeError):
+    """Raise when a TreeMesh is not finalized."""
+
 
 cdef class TreeCell:
     """A class for defining cells within instances of :class:`~discretize.TreeMesh`.
@@ -1959,7 +1962,7 @@ cdef class _TreeMesh:
         (n_cells, dim) numpy.ndarray of float
             Gridded cell center locations
         """
-        self._error_if_not_finalized("cell_centers", is_property=True)
+        self._error_if_not_finalized("cell_centers")
         cdef np.float64_t[:, :] gridCC
         cdef np.int64_t ii, ind, dim
         if self._cell_centers is None:
@@ -1985,7 +1988,7 @@ cdef class _TreeMesh:
         (n_nodes, dim) numpy.ndarray of float
             Gridded non-hanging node locations
         """
-        self._error_if_not_finalized("nodes", is_property=True)
+        self._error_if_not_finalized("nodes")
         cdef np.float64_t[:, :] gridN
         cdef Node *node
         cdef np.int64_t ii, ind, dim
@@ -2014,7 +2017,7 @@ cdef class _TreeMesh:
         (n_hanging_nodes, dim) numpy.ndarray of float
             Gridded hanging node locations
         """
-        self._error_if_not_finalized("hanging_nodes", is_property=True)
+        self._error_if_not_finalized("hanging_nodes")
         cdef np.float64_t[:, :] gridN
         cdef Node *node
         cdef np.int64_t ii, ind, dim
@@ -2041,7 +2044,7 @@ cdef class _TreeMesh:
         (n_boundary_nodes, dim) numpy.ndarray of float
             Gridded boundary node locations
         """
-        self._error_if_not_finalized("boundary_nodes", is_property=True)
+        self._error_if_not_finalized("boundary_nodes")
         nodes = self.nodes
         x0, xF = self._xs[0], self._xs[-1]
         y0, yF = self._ys[0], self._ys[-1]
@@ -2073,7 +2076,7 @@ cdef class _TreeMesh:
         (n_cells, dim) numpy.ndarray of float
             Gridded cell dimensions
         """
-        self._error_if_not_finalized("h_gridded", is_property=True)
+        self._error_if_not_finalized("h_gridded")
         if self._h_gridded is not None:
             return self._h_gridded
         cdef np.float64_t[:, :] gridCH
@@ -2102,7 +2105,7 @@ cdef class _TreeMesh:
         (n_edges_x, dim) numpy.ndarray of float
             Gridded locations of all non-hanging x-edges
         """
-        self._error_if_not_finalized("edges_x", is_property=True)
+        self._error_if_not_finalized("edges_x")
         cdef np.float64_t[:, :] gridEx
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2130,7 +2133,7 @@ cdef class _TreeMesh:
         (n_hanging_edges_x, dim) numpy.ndarray of float
             Gridded locations of all hanging x-edges
         """
-        self._error_if_not_finalized("hanging_edges_x", is_property=True)
+        self._error_if_not_finalized("hanging_edges_x")
         cdef np.float64_t[:, :] gridhEx
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2156,7 +2159,7 @@ cdef class _TreeMesh:
         (n_edges_y, dim) numpy.ndarray of float
             Gridded locations of all non-hanging y-edges
         """
-        self._error_if_not_finalized("edges_y", is_property=True)
+        self._error_if_not_finalized("edges_y")
         cdef np.float64_t[:, :] gridEy
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2184,7 +2187,7 @@ cdef class _TreeMesh:
         (n_haning_edges_y, dim) numpy.ndarray of float
             Gridded locations of all hanging y-edges
         """
-        self._error_if_not_finalized("hanging_edges_y", is_property=True)
+        self._error_if_not_finalized("hanging_edges_y")
         cdef np.float64_t[:, :] gridhEy
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2210,7 +2213,7 @@ cdef class _TreeMesh:
         (n_edges_z, dim) numpy.ndarray of float
             Gridded locations of all non-hanging z-edges
         """
-        self._error_if_not_finalized("edges_z", is_property=True)
+        self._error_if_not_finalized("edges_z")
         cdef np.float64_t[:, :] gridEz
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2238,7 +2241,7 @@ cdef class _TreeMesh:
         (n_hanging_edges_z, dim) numpy.ndarray of float
             Gridded locations of all hanging z-edges
         """
-        self._error_if_not_finalized("hanging_edges_z", is_property=True)
+        self._error_if_not_finalized("hanging_edges_z")
         cdef np.float64_t[:, :] gridhEz
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2266,7 +2269,7 @@ cdef class _TreeMesh:
         (n_boundary_edges, dim) numpy.ndarray of float
             Gridded boundary edge locations
         """
-        self._error_if_not_finalized("boundary_edges", is_property=True)
+        self._error_if_not_finalized("boundary_edges")
         edges_x = self.edges_x
         edges_y = self.edges_y
         x0, xF = self._xs[0], self._xs[-1]
@@ -2306,7 +2309,7 @@ cdef class _TreeMesh:
         (n_faces_x, dim) numpy.ndarray of float
             Gridded locations of all non-hanging x-faces
         """
-        self._error_if_not_finalized("faces_x", is_property=True)
+        self._error_if_not_finalized("faces_x")
         if(self._dim == 2): return self.edges_y
 
         cdef np.float64_t[:, :] gridFx
@@ -2336,7 +2339,7 @@ cdef class _TreeMesh:
         (n_faces_y, dim) numpy.ndarray of float
             Gridded locations of all non-hanging y-faces
         """
-        self._error_if_not_finalized("faces_y", is_property=True)
+        self._error_if_not_finalized("faces_y")
         if(self._dim == 2): return self.edges_x
         cdef np.float64_t[:, :] gridFy
         cdef Face *face
@@ -2365,7 +2368,7 @@ cdef class _TreeMesh:
         (n_faces_z, dim) numpy.ndarray of float
             Gridded locations of all non-hanging z-faces
         """
-        self._error_if_not_finalized("faces_z", is_property=True)
+        self._error_if_not_finalized("faces_z")
         if(self._dim == 2): return self.cell_centers
 
         cdef np.float64_t[:, :] gridFz
@@ -2395,7 +2398,7 @@ cdef class _TreeMesh:
         (n_hanging_faces_x, dim) numpy.ndarray of float
             Gridded locations of all hanging x-faces
         """
-        self._error_if_not_finalized("hanging_faces_x", is_property=True)
+        self._error_if_not_finalized("hanging_faces_x")
         if(self._dim == 2): return self.hanging_edges_y
 
         cdef np.float64_t[:, :] gridFx
@@ -2423,7 +2426,7 @@ cdef class _TreeMesh:
         (n_hanging_faces_y, dim) numpy.ndarray of float
             Gridded locations of all hanging y-faces
         """
-        self._error_if_not_finalized("hanging_faces_y", is_property=True)
+        self._error_if_not_finalized("hanging_faces_y")
         if(self._dim == 2): return self.hanging_edges_x
 
         cdef np.float64_t[:, :] gridhFy
@@ -2451,7 +2454,7 @@ cdef class _TreeMesh:
         (n_hanging_faces_z, dim) numpy.ndarray of float
             Gridded locations of all hanging z-faces
         """
-        self._error_if_not_finalized("hanging_faces_z", is_property=True)
+        self._error_if_not_finalized("hanging_faces_z")
         if(self._dim == 2): return np.array([])
 
         cdef np.float64_t[:, :] gridhFz
@@ -2481,7 +2484,7 @@ cdef class _TreeMesh:
         (n_boundary_faces, dim) numpy.ndarray of float
             Gridded boundary face locations
         """
-        self._error_if_not_finalized("boundary_faces", is_property=True)
+        self._error_if_not_finalized("boundary_faces")
         faces_x = self.faces_x
         faces_y = self.faces_y
         x0, xF = self._xs[0], self._xs[-1]
@@ -2511,7 +2514,7 @@ cdef class _TreeMesh:
         (n_boundary_faces, dim) numpy.ndarray of float
             Outward normals of boundary faces
         """
-        self._error_if_not_finalized("boundary_face_outward_normals", is_property=True)
+        self._error_if_not_finalized("boundary_face_outward_normals")
         faces_x = self.faces_x
         faces_y = self.faces_y
         x0, xF = self._xs[0], self._xs[-1]
@@ -2554,7 +2557,7 @@ cdef class _TreeMesh:
               - *3D:* Returns the cell volumes
 
         """
-        self._error_if_not_finalized("cell_volumes", is_property=True)
+        self._error_if_not_finalized("cell_volumes")
         cdef np.float64_t[:] vol
         if self._cell_volumes is None:
             self._cell_volumes = np.empty(self.n_cells, dtype=np.float64)
@@ -2579,7 +2582,7 @@ cdef class _TreeMesh:
               respectively
             - *3D:* returns the x, y and z-face areas in order
         """
-        self._error_if_not_finalized("face_areas", is_property=True)
+        self._error_if_not_finalized("face_areas")
         if self._dim == 2 and self._face_areas is None:
             self._face_areas = np.r_[self.edge_lengths[self.n_edges_x:], self.edge_lengths[:self.n_edges_x]]
         cdef np.float64_t[:] area
@@ -2622,7 +2625,7 @@ cdef class _TreeMesh:
             - *2D:* returns the x-edge and y-edge lengths in order
             - *3D:* returns the x, y and z-edge lengths in order
         """
-        self._error_if_not_finalized("edge_lengths", is_property=True)
+        self._error_if_not_finalized("edge_lengths")
         cdef np.float64_t[:] edge_l
         cdef Edge *edge
         cdef int_t ind, offset
@@ -3587,7 +3590,7 @@ cdef class _TreeMesh:
         (n_total_faces_x, n_cells) scipy.sparse.csr_matrix
             The stencil for the x-component of the cell gradient
         """
-        self._error_if_not_finalized("stencil_cell_gradient_x", is_property=True)
+        self._error_if_not_finalized("stencil_cell_gradient_x")
         if getattr(self, '_stencil_cell_gradient_x', None) is not None:
             return self._stencil_cell_gradient_x
         cdef np.int64_t[:] I = np.zeros(2*self.n_total_faces_x, dtype=np.int64)
@@ -3665,7 +3668,7 @@ cdef class _TreeMesh:
         (n_total_faces_y, n_cells) scipy.sparse.csr_matrix
             The stencil for the y-component of the cell gradient
         """
-        self._error_if_not_finalized("stencil_cell_gradient_y", is_property=True)
+        self._error_if_not_finalized("stencil_cell_gradient_y")
         if getattr(self, '_stencil_cell_gradient_y', None) is not None:
             return self._stencil_cell_gradient_y
 
@@ -3744,7 +3747,7 @@ cdef class _TreeMesh:
         (n_total_faces_z, n_cells) scipy.sparse.csr_matrix
             The stencil for the z-component of the cell gradient
         """
-        self._error_if_not_finalized("stencil_cell_gradient_z", is_property=True)
+        self._error_if_not_finalized("stencil_cell_gradient_z")
         if getattr(self, '_stencil_cell_gradient_z', None) is not None:
             return self._stencil_cell_gradient_z
 
@@ -5045,7 +5048,7 @@ cdef class _TreeMesh:
 
             phi_f = Acf @ phi_c
         """
-        self._error_if_not_finalized("average_cell_to_face", is_property=True)
+        self._error_if_not_finalized("average_cell_to_face")
         if self._average_cell_to_face is not None:
             return self._average_cell_to_face
         stacks = [self.average_cell_to_face_x, self.average_cell_to_face_y]
@@ -5106,7 +5109,7 @@ cdef class _TreeMesh:
         in the x-direction. For boundary faces, nearest neighbor is used to extrapolate
         the values.
         """
-        self._error_if_not_finalized("average_cell_vector_to_face", is_property=True)
+        self._error_if_not_finalized("average_cell_vector_to_face")
         if self._average_cell_vector_to_face is not None:
             return self._average_cell_vector_to_face
         stacks = [self.average_cell_to_face_x, self.average_cell_to_face_y]
@@ -5130,7 +5133,7 @@ cdef class _TreeMesh:
         (n_faces_x, n_cells) scipy.sparse.csr_matrix
             The scalar averaging operator from cell centers to x faces
         """
-        self._error_if_not_finalized("average_cell_to_face_x", is_property=True)
+        self._error_if_not_finalized("average_cell_to_face_x")
         if self._average_cell_to_face_x is not None:
             return self._average_cell_to_face_x
         cdef np.int64_t[:] I = np.zeros(2*self.n_total_faces_x, dtype=np.int64)
@@ -5247,7 +5250,7 @@ cdef class _TreeMesh:
         (n_faces_y, n_cells) scipy.sparse.csr_matrix
             The scalar averaging operator from cell centers to y faces
         """
-        self._error_if_not_finalized("average_cell_to_face_y", is_property=True)
+        self._error_if_not_finalized("average_cell_to_face_y")
         if self._average_cell_to_face_y is not None:
             return self._average_cell_to_face_y
         cdef np.int64_t[:] I = np.zeros(2*self.n_total_faces_y, dtype=np.int64)
@@ -5364,7 +5367,7 @@ cdef class _TreeMesh:
         (n_faces_z, n_cells) scipy.sparse.csr_matrix
             The scalar averaging operator from cell centers to z faces
         """
-        self._error_if_not_finalized("average_cell_to_face_z", is_property=True)
+        self._error_if_not_finalized("average_cell_to_face_z")
         if self.dim == 2:
             raise Exception('TreeMesh has no z-faces in 2D')
         if self._average_cell_to_face_z is not None:
@@ -5455,7 +5458,7 @@ cdef class _TreeMesh:
         scipy.sparse.csr_matrix
             (n_boundary_faces, n_faces) Projection matrix with shape
         """
-        self._error_if_not_finalized("project_face_to_boundary_face", is_property=True)
+        self._error_if_not_finalized("project_face_to_boundary_face")
         faces_x = self.faces_x
         faces_y = self.faces_y
 
@@ -5491,7 +5494,7 @@ cdef class _TreeMesh:
         (n_boundary_edges, n_edges) scipy.sparse.csr_matrix
             Projection matrix with shape
         """
-        self._error_if_not_finalized("project_edge_to_boundary_edge", is_property=True)
+        self._error_if_not_finalized("project_edge_to_boundary_edge")
         edges_x = self.edges_x
         edges_y = self.edges_y
 
@@ -5534,7 +5537,7 @@ cdef class _TreeMesh:
         (n_boundary_nodes, n_nodes) scipy.sparse.csr_matrix
             Projection matrix with shape
         """
-        self._error_if_not_finalized("project_node_to_boundary_node", is_property=True)
+        self._error_if_not_finalized("project_node_to_boundary_node")
         nodes = self.nodes
         x0, xF = self._xs[0], self._xs[-1]
         y0, yF = self._ys[0], self._ys[-1]
@@ -6998,7 +7001,7 @@ cdef class _TreeMesh:
         """
         return self.get_cells_in_aabb(*rectangle.reshape(self.dim, 2).T)
 
-    def _error_if_not_finalized(self, method: str, is_property: bool):
+    def _error_if_not_finalized(self, method: str):
         """
         Raise error if mesh is not finalized.
         """

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -1959,6 +1959,7 @@ cdef class _TreeMesh:
         (n_cells, dim) numpy.ndarray of float
             Gridded cell center locations
         """
+        self._error_if_not_finalized("cell_centers", is_property=True)
         cdef np.float64_t[:, :] gridCC
         cdef np.int64_t ii, ind, dim
         if self._cell_centers is None:
@@ -1984,6 +1985,7 @@ cdef class _TreeMesh:
         (n_nodes, dim) numpy.ndarray of float
             Gridded non-hanging node locations
         """
+        self._error_if_not_finalized("nodes", is_property=True)
         cdef np.float64_t[:, :] gridN
         cdef Node *node
         cdef np.int64_t ii, ind, dim
@@ -2012,6 +2014,7 @@ cdef class _TreeMesh:
         (n_hanging_nodes, dim) numpy.ndarray of float
             Gridded hanging node locations
         """
+        self._error_if_not_finalized("hanging_nodes", is_property=True)
         cdef np.float64_t[:, :] gridN
         cdef Node *node
         cdef np.int64_t ii, ind, dim
@@ -2038,6 +2041,7 @@ cdef class _TreeMesh:
         (n_boundary_nodes, dim) numpy.ndarray of float
             Gridded boundary node locations
         """
+        self._error_if_not_finalized("boundary_nodes", is_property=True)
         nodes = self.nodes
         x0, xF = self._xs[0], self._xs[-1]
         y0, yF = self._ys[0], self._ys[-1]
@@ -2098,6 +2102,7 @@ cdef class _TreeMesh:
         (n_edges_x, dim) numpy.ndarray of float
             Gridded locations of all non-hanging x-edges
         """
+        self._error_if_not_finalized("edges_x", is_property=True)
         cdef np.float64_t[:, :] gridEx
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2125,6 +2130,7 @@ cdef class _TreeMesh:
         (n_hanging_edges_x, dim) numpy.ndarray of float
             Gridded locations of all hanging x-edges
         """
+        self._error_if_not_finalized("hanging_edges_x", is_property=True)
         cdef np.float64_t[:, :] gridhEx
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2150,6 +2156,7 @@ cdef class _TreeMesh:
         (n_edges_y, dim) numpy.ndarray of float
             Gridded locations of all non-hanging y-edges
         """
+        self._error_if_not_finalized("edges_y", is_property=True)
         cdef np.float64_t[:, :] gridEy
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2177,6 +2184,7 @@ cdef class _TreeMesh:
         (n_haning_edges_y, dim) numpy.ndarray of float
             Gridded locations of all hanging y-edges
         """
+        self._error_if_not_finalized("hanging_edges_y", is_property=True)
         cdef np.float64_t[:, :] gridhEy
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2202,6 +2210,7 @@ cdef class _TreeMesh:
         (n_edges_z, dim) numpy.ndarray of float
             Gridded locations of all non-hanging z-edges
         """
+        self._error_if_not_finalized("edges_z", is_property=True)
         cdef np.float64_t[:, :] gridEz
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2229,6 +2238,7 @@ cdef class _TreeMesh:
         (n_hanging_edges_z, dim) numpy.ndarray of float
             Gridded locations of all hanging z-edges
         """
+        self._error_if_not_finalized("hanging_edges_z", is_property=True)
         cdef np.float64_t[:, :] gridhEz
         cdef Edge *edge
         cdef np.int64_t ii, ind, dim
@@ -2256,6 +2266,7 @@ cdef class _TreeMesh:
         (n_boundary_edges, dim) numpy.ndarray of float
             Gridded boundary edge locations
         """
+        self._error_if_not_finalized("boundary_edges", is_property=True)
         edges_x = self.edges_x
         edges_y = self.edges_y
         x0, xF = self._xs[0], self._xs[-1]
@@ -2295,6 +2306,7 @@ cdef class _TreeMesh:
         (n_faces_x, dim) numpy.ndarray of float
             Gridded locations of all non-hanging x-faces
         """
+        self._error_if_not_finalized("faces_x", is_property=True)
         if(self._dim == 2): return self.edges_y
 
         cdef np.float64_t[:, :] gridFx
@@ -2324,6 +2336,7 @@ cdef class _TreeMesh:
         (n_faces_y, dim) numpy.ndarray of float
             Gridded locations of all non-hanging y-faces
         """
+        self._error_if_not_finalized("faces_y", is_property=True)
         if(self._dim == 2): return self.edges_x
         cdef np.float64_t[:, :] gridFy
         cdef Face *face
@@ -2352,6 +2365,7 @@ cdef class _TreeMesh:
         (n_faces_z, dim) numpy.ndarray of float
             Gridded locations of all non-hanging z-faces
         """
+        self._error_if_not_finalized("faces_z", is_property=True)
         if(self._dim == 2): return self.cell_centers
 
         cdef np.float64_t[:, :] gridFz
@@ -2381,6 +2395,7 @@ cdef class _TreeMesh:
         (n_hanging_faces_x, dim) numpy.ndarray of float
             Gridded locations of all hanging x-faces
         """
+        self._error_if_not_finalized("hanging_faces_x", is_property=True)
         if(self._dim == 2): return self.hanging_edges_y
 
         cdef np.float64_t[:, :] gridFx
@@ -2408,6 +2423,7 @@ cdef class _TreeMesh:
         (n_hanging_faces_y, dim) numpy.ndarray of float
             Gridded locations of all hanging y-faces
         """
+        self._error_if_not_finalized("hanging_faces_y", is_property=True)
         if(self._dim == 2): return self.hanging_edges_x
 
         cdef np.float64_t[:, :] gridhFy
@@ -2435,6 +2451,7 @@ cdef class _TreeMesh:
         (n_hanging_faces_z, dim) numpy.ndarray of float
             Gridded locations of all hanging z-faces
         """
+        self._error_if_not_finalized("hanging_faces_z", is_property=True)
         if(self._dim == 2): return np.array([])
 
         cdef np.float64_t[:, :] gridhFz
@@ -2464,6 +2481,7 @@ cdef class _TreeMesh:
         (n_boundary_faces, dim) numpy.ndarray of float
             Gridded boundary face locations
         """
+        self._error_if_not_finalized("boundary_faces", is_property=True)
         faces_x = self.faces_x
         faces_y = self.faces_y
         x0, xF = self._xs[0], self._xs[-1]
@@ -2493,6 +2511,7 @@ cdef class _TreeMesh:
         (n_boundary_faces, dim) numpy.ndarray of float
             Outward normals of boundary faces
         """
+        self._error_if_not_finalized("boundary_face_outward_normals", is_property=True)
         faces_x = self.faces_x
         faces_y = self.faces_y
         x0, xF = self._xs[0], self._xs[-1]
@@ -2535,6 +2554,7 @@ cdef class _TreeMesh:
               - *3D:* Returns the cell volumes
 
         """
+        self._error_if_not_finalized("cell_volumes", is_property=True)
         cdef np.float64_t[:] vol
         if self._cell_volumes is None:
             self._cell_volumes = np.empty(self.n_cells, dtype=np.float64)
@@ -2559,6 +2579,7 @@ cdef class _TreeMesh:
               respectively
             - *3D:* returns the x, y and z-face areas in order
         """
+        self._error_if_not_finalized("face_areas", is_property=True)
         if self._dim == 2 and self._face_areas is None:
             self._face_areas = np.r_[self.edge_lengths[self.n_edges_x:], self.edge_lengths[:self.n_edges_x]]
         cdef np.float64_t[:] area
@@ -2601,6 +2622,7 @@ cdef class _TreeMesh:
             - *2D:* returns the x-edge and y-edge lengths in order
             - *3D:* returns the x, y and z-edge lengths in order
         """
+        self._error_if_not_finalized("edge_lengths", is_property=True)
         cdef np.float64_t[:] edge_l
         cdef Edge *edge
         cdef int_t ind, offset
@@ -3565,6 +3587,7 @@ cdef class _TreeMesh:
         (n_total_faces_x, n_cells) scipy.sparse.csr_matrix
             The stencil for the x-component of the cell gradient
         """
+        self._error_if_not_finalized("stencil_cell_gradient_x", is_property=True)
         if getattr(self, '_stencil_cell_gradient_x', None) is not None:
             return self._stencil_cell_gradient_x
         cdef np.int64_t[:] I = np.zeros(2*self.n_total_faces_x, dtype=np.int64)
@@ -3642,6 +3665,7 @@ cdef class _TreeMesh:
         (n_total_faces_y, n_cells) scipy.sparse.csr_matrix
             The stencil for the y-component of the cell gradient
         """
+        self._error_if_not_finalized("stencil_cell_gradient_y", is_property=True)
         if getattr(self, '_stencil_cell_gradient_y', None) is not None:
             return self._stencil_cell_gradient_y
 
@@ -3720,6 +3744,7 @@ cdef class _TreeMesh:
         (n_total_faces_z, n_cells) scipy.sparse.csr_matrix
             The stencil for the z-component of the cell gradient
         """
+        self._error_if_not_finalized("stencil_cell_gradient_z", is_property=True)
         if getattr(self, '_stencil_cell_gradient_z', None) is not None:
             return self._stencil_cell_gradient_z
 
@@ -5020,6 +5045,7 @@ cdef class _TreeMesh:
 
             phi_f = Acf @ phi_c
         """
+        self._error_if_not_finalized("average_cell_to_face", is_property=True)
         if self._average_cell_to_face is not None:
             return self._average_cell_to_face
         stacks = [self.average_cell_to_face_x, self.average_cell_to_face_y]
@@ -5080,6 +5106,7 @@ cdef class _TreeMesh:
         in the x-direction. For boundary faces, nearest neighbor is used to extrapolate
         the values.
         """
+        self._error_if_not_finalized("average_cell_vector_to_face", is_property=True)
         if self._average_cell_vector_to_face is not None:
             return self._average_cell_vector_to_face
         stacks = [self.average_cell_to_face_x, self.average_cell_to_face_y]
@@ -5103,6 +5130,7 @@ cdef class _TreeMesh:
         (n_faces_x, n_cells) scipy.sparse.csr_matrix
             The scalar averaging operator from cell centers to x faces
         """
+        self._error_if_not_finalized("average_cell_to_face_x", is_property=True)
         if self._average_cell_to_face_x is not None:
             return self._average_cell_to_face_x
         cdef np.int64_t[:] I = np.zeros(2*self.n_total_faces_x, dtype=np.int64)
@@ -5219,6 +5247,7 @@ cdef class _TreeMesh:
         (n_faces_y, n_cells) scipy.sparse.csr_matrix
             The scalar averaging operator from cell centers to y faces
         """
+        self._error_if_not_finalized("average_cell_to_face_y", is_property=True)
         if self._average_cell_to_face_y is not None:
             return self._average_cell_to_face_y
         cdef np.int64_t[:] I = np.zeros(2*self.n_total_faces_y, dtype=np.int64)
@@ -5335,6 +5364,7 @@ cdef class _TreeMesh:
         (n_faces_z, n_cells) scipy.sparse.csr_matrix
             The scalar averaging operator from cell centers to z faces
         """
+        self._error_if_not_finalized("average_cell_to_face_z", is_property=True)
         if self.dim == 2:
             raise Exception('TreeMesh has no z-faces in 2D')
         if self._average_cell_to_face_z is not None:
@@ -5425,6 +5455,7 @@ cdef class _TreeMesh:
         scipy.sparse.csr_matrix
             (n_boundary_faces, n_faces) Projection matrix with shape
         """
+        self._error_if_not_finalized("project_face_to_boundary_face", is_property=True)
         faces_x = self.faces_x
         faces_y = self.faces_y
 
@@ -5460,6 +5491,7 @@ cdef class _TreeMesh:
         (n_boundary_edges, n_edges) scipy.sparse.csr_matrix
             Projection matrix with shape
         """
+        self._error_if_not_finalized("project_edge_to_boundary_edge", is_property=True)
         edges_x = self.edges_x
         edges_y = self.edges_y
 
@@ -5502,6 +5534,7 @@ cdef class _TreeMesh:
         (n_boundary_nodes, n_nodes) scipy.sparse.csr_matrix
             Projection matrix with shape
         """
+        self._error_if_not_finalized("project_node_to_boundary_node", is_property=True)
         nodes = self.nodes
         x0, xF = self._xs[0], self._xs[-1]
         y0, yF = self._ys[0], self._ys[-1]

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -2069,6 +2069,7 @@ cdef class _TreeMesh:
         (n_cells, dim) numpy.ndarray of float
             Gridded cell dimensions
         """
+        self._error_if_not_finalized("h_gridded", is_property=True)
         if self._h_gridded is not None:
             return self._h_gridded
         cdef np.float64_t[:, :] gridCH
@@ -6963,6 +6964,19 @@ cdef class _TreeMesh:
             The indices of cells which overlap the axis aligned rectangle.
         """
         return self.get_cells_in_aabb(*rectangle.reshape(self.dim, 2).T)
+
+    def _error_if_not_finalized(self, method: str, is_property: bool):
+        """
+        Raise error if mesh is not finalized.
+        """
+        object_name = "property" if is_property else "method"
+        if not self.finalized:
+            msg = (
+                f"The `{method}` {object_name} "
+                "cannot be accessed before the mesh is finalized. "
+                "Use the `finalize()` method to finalize it."
+            )
+            raise AttributeError(msg)
 
     def _require_ndarray_with_dim(self, name, arr, ndim=1, dtype=None, requirements=None):
         """Returns an ndarray that has dim along it's last dimension, with ndim dims,

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -7002,14 +7002,12 @@ cdef class _TreeMesh:
         """
         Raise error if mesh is not finalized.
         """
-        object_name = "property" if is_property else "method"
         if not self.finalized:
             msg = (
-                f"The `{method}` {object_name} "
-                "cannot be accessed before the mesh is finalized. "
+                f"`{type(self).__name__}.{method}` requires a finalized mesh. "
                 "Use the `finalize()` method to finalize it."
             )
-            raise AttributeError(msg)
+            raise TreeMeshNotFinalizedError(msg)
 
     def _require_ndarray_with_dim(self, name, arr, ndim=1, dtype=None, requirements=None):
         """Returns an ndarray that has dim along it's last dimension, with ndim dims,

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -92,11 +92,16 @@ import warnings
 from discretize.base import BaseTensorMesh
 from discretize.operators import InnerProducts, DiffOperators
 from discretize.mixins import InterfaceMixins, TreeMeshIO
-from discretize._extensions.tree_ext import _TreeMesh, TreeCell, TreeMeshNotFinalizedError  # NOQA F401
+from discretize._extensions.tree_ext import (  # noqa: F401
+    _TreeMesh,
+    TreeCell,
+    TreeMeshNotFinalizedError,
+)
 import numpy as np
 import scipy.sparse as sp
 from discretize.utils.code_utils import deprecate_property
 from scipy.spatial import Delaunay
+
 
 class TreeMesh(
     _TreeMesh,

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -768,6 +768,7 @@ class TreeMesh(
         (n_total_nodes, dim) numpy.ndarray of float
             Gridded hanging and non-hanging node locations
         """
+        self._error_if_not_finalized("total_nodes", is_property=True)
         return np.vstack((self.nodes, self.hanging_nodes))
 
     @property

--- a/discretize/tree_mesh.py
+++ b/discretize/tree_mesh.py
@@ -92,12 +92,11 @@ import warnings
 from discretize.base import BaseTensorMesh
 from discretize.operators import InnerProducts, DiffOperators
 from discretize.mixins import InterfaceMixins, TreeMeshIO
-from discretize._extensions.tree_ext import _TreeMesh, TreeCell  # NOQA F401
+from discretize._extensions.tree_ext import _TreeMesh, TreeCell, TreeMeshNotFinalizedError  # NOQA F401
 import numpy as np
 import scipy.sparse as sp
 from discretize.utils.code_utils import deprecate_property
 from scipy.spatial import Delaunay
-
 
 class TreeMesh(
     _TreeMesh,
@@ -768,7 +767,7 @@ class TreeMesh(
         (n_total_nodes, dim) numpy.ndarray of float
             Gridded hanging and non-hanging node locations
         """
-        self._error_if_not_finalized("total_nodes", is_property=True)
+        self._error_if_not_finalized("total_nodes")
         return np.vstack((self.nodes, self.hanging_nodes))
 
     @property

--- a/tests/tree/test_safeguards.py
+++ b/tests/tree/test_safeguards.py
@@ -30,7 +30,43 @@ def refine_mesh(mesh):
     mesh.refine_box(p1, p2, levels=5, finalize=False)
 
 
-PROPERTIES = ["h_gridded"]
+PROPERTIES = [
+    "average_cell_to_face",
+    "average_cell_to_face_x",
+    "average_cell_to_face_y",
+    "average_cell_to_face_z",
+    "average_cell_vector_to_face",
+    "boundary_edges",
+    "boundary_face_outward_normals",
+    "boundary_faces",
+    "boundary_nodes",
+    "cell_centers",
+    "cell_volumes",
+    "edge_lengths",
+    "edges_x",
+    "edges_y",
+    "edges_z",
+    "face_areas",
+    "faces_x",
+    "faces_y",
+    "faces_z",
+    "h_gridded",
+    "hanging_edges_x",
+    "hanging_edges_y",
+    "hanging_edges_z",
+    "hanging_faces_x",
+    "hanging_faces_y",
+    "hanging_faces_z",
+    "hanging_nodes",
+    "nodes",
+    "project_edge_to_boundary_edge",
+    "project_face_to_boundary_face",
+    "project_node_to_boundary_node",
+    "stencil_cell_gradient_x",
+    "stencil_cell_gradient_y",
+    "stencil_cell_gradient_z",
+    "total_nodes",
+]
 
 
 class TestSafeGuards:

--- a/tests/tree/test_safeguards.py
+++ b/tests/tree/test_safeguards.py
@@ -1,0 +1,64 @@
+"""
+Test safeguards against accessing certain properties on non-finalized TreeMesh.
+"""
+
+import re
+import pytest
+
+from discretize import TreeMesh
+
+
+@pytest.fixture
+def mesh():
+    """Return a sample TreeMesh"""
+    nc = 16
+    h = [nc, nc, nc]
+    origin = (-32.4, 245.4, 192.3)
+    mesh = TreeMesh(h, origin, diagonal_balance=True)
+    return mesh
+
+
+def refine_mesh(mesh):
+    """
+    Refine the sample tree mesh.
+
+    Don't finalize the mesh.
+    """
+    origin = mesh.origin
+    p1 = (origin[0] + 0.4, origin[1] + 0.4, origin[2] + 0.7)
+    p2 = (origin[0] + 0.6, origin[1] + 0.6, origin[2] + 0.9)
+    mesh.refine_box(p1, p2, levels=5, finalize=False)
+
+
+PROPERTIES = ["h_gridded"]
+
+
+class TestSafeGuards:
+
+    @pytest.mark.parametrize("prop_name", PROPERTIES)
+    @pytest.mark.parametrize("refine", [True, False], ids=["refined", "non-refined"])
+    def test_errors(self, mesh, prop_name, refine):
+        """
+        Test error after trying to access the property before finalizing the mesh.
+
+        Run tests by accessing the property before and after mesh refinement.
+        """
+        if refine:
+            refine_mesh(mesh)
+        msg = re.escape(
+            f"The `{prop_name}` property cannot be accessed before "
+            "the mesh is finalized."
+        )
+        with pytest.raises(AttributeError, match=msg):
+            getattr(mesh, prop_name)
+
+    @pytest.mark.parametrize("prop_name", PROPERTIES)
+    def test_no_errors(self, mesh, prop_name):
+        """
+        Test if no error is raised when accessing the property on finalized mesh.
+        """
+        # Refine and finalize mesh
+        refine_mesh(mesh)
+        mesh.finalize()
+        # Accessing the property should not error out
+        getattr(mesh, prop_name)

--- a/tests/tree/test_safeguards.py
+++ b/tests/tree/test_safeguards.py
@@ -118,6 +118,11 @@ class TestSafeGuards:
         These inherited properties are the ones that ``TreeMesh`` inherit, but
         they depend on the ones defined by it that should not be accessed
         before finalizing the mesh (e.g. ``edges`` and ``faces``).
+
+        These inherited properties raise errors after trying to access one of
+        the other properties. Their error message does not include the name of
+        the inherited property, but the first offending property that is being
+        accessed.
         """
         if refine:
             refine_mesh(mesh)

--- a/tests/tree/test_safeguards.py
+++ b/tests/tree/test_safeguards.py
@@ -6,6 +6,7 @@ import re
 import pytest
 
 from discretize import TreeMesh
+from discretize.tree_mesh import TreeMeshNotFinalizedError
 
 
 @pytest.fixture
@@ -82,10 +83,9 @@ class TestSafeGuards:
         if refine:
             refine_mesh(mesh)
         msg = re.escape(
-            f"The `{prop_name}` property cannot be accessed before "
-            "the mesh is finalized."
+            f"`TreeMesh.{prop_name}` requires a finalized mesh. "
         )
-        with pytest.raises(AttributeError, match=msg):
+        with pytest.raises(TreeMeshNotFinalizedError, match=msg):
             getattr(mesh, prop_name)
 
     @pytest.mark.parametrize("prop_name", PROPERTIES)

--- a/tests/tree/test_safeguards.py
+++ b/tests/tree/test_safeguards.py
@@ -82,9 +82,7 @@ class TestSafeGuards:
         """
         if refine:
             refine_mesh(mesh)
-        msg = re.escape(
-            f"`TreeMesh.{prop_name}` requires a finalized mesh. "
-        )
+        msg = re.escape(f"`TreeMesh.{prop_name}` requires a finalized mesh. ")
         with pytest.raises(TreeMeshNotFinalizedError, match=msg):
             getattr(mesh, prop_name)
 

--- a/tests/tree/test_safeguards.py
+++ b/tests/tree/test_safeguards.py
@@ -56,6 +56,7 @@ INHERITED_PROPERTIES = [
     "permute_cells",
     "permute_edges",
     "permute_faces",
+    "stencil_cell_gradient",
 ]
 
 


### PR DESCRIPTION
Raise errors when trying to access some of the `TreeMesh` properties before it gets finalized. The properties that got the safeguards are the ones that generate an ill-defined mesh if they are accessed before finalizing the mesh. Add tests to check if the errors are correctly raised.

Fixes #293 #392


## What's an offending property?

A property generate an ill-defined mesh if accessing it before the mesh gets
finalized modifies the ultimate definition of the mesh.
For example, an offending property `prop_name` would make the following code to
generate `property_value` and `expected_value` with non-equivalent values.
Therefore, just accessing `prop_name` changes the definition of the mesh.

```python
mesh = TreeMesh(...)
mesh.refine_ball(..., finalize=False)
mesh.finalize()

expected_value = mesh.prop_name

mesh = TreeMesh(...)
mesh.prop_name  # access the property before finalizing
mesh.refine_ball(..., finalize=False)
mesh.finalize()

property_value = mesh.prop_name
```

## Todo

- [ ] Do we need personalized error messages for?
  - `boundary_edge_vector_integral`
  - `boundary_face_scalar_integral`
  - `boundary_node_vector_integral`
  - `edges`
  - `faces`
  - `permute_cells`
  - `permute_edges`
  - `permute_faces`
