### PR TITLE
bump sphinx and pydata-sphinx to more recent versions

### DIFF
--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -14,8 +14,8 @@ dependencies:
   # documentation
   - sphinx==8.2.3
   - pydata-sphinx-theme==0.16.1
-  - sphinx-gallery>=0.1.13
-  - numpydoc>=1.5
+  - sphinx-gallery==0.19.0
+  - numpydoc==1.9.0
   - jupyter
   - graphviz
   - pillow

--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
 
   # documentation
-  - sphinx==8.2.3
+  - sphinx==8.1.3
   - pydata-sphinx-theme==0.16.1
   - sphinx-gallery==0.19.0
   - numpydoc==1.9.0

--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -12,8 +12,8 @@ dependencies:
   - matplotlib
 
   # documentation
-  - sphinx
-  - pydata-sphinx-theme==0.15.4
+  - sphinx==8.2.3
+  - pydata-sphinx-theme==0.16.1
   - sphinx-gallery>=0.1.13
   - numpydoc>=1.5
   - jupyter

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -12,7 +12,7 @@
     {
         "name": "0.11.2",
         "version": "v0.11.2",
-        "url": "https://discretize.simpeg.xyz/en/v0.11.2/",
+        "url": "https://discretize.simpeg.xyz/en/v0.11.2/"
     },
     {
         "name": "0.11.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,10 @@ viz = ["vtk>=6", "pyvista"]
 omf = ["omf"]
 all = ["discretize[plot,viz,omf]"]
 doc = [
-    "sphinx!=4.1.0",
-    "pydata-sphinx-theme==0.15.4",
-    "sphinx-gallery==0.1.13",
-    "numpydoc>=1.5",
+    "sphinx==8.2.3",
+    "pydata-sphinx-theme==0.16.1",
+    "sphinx-gallery==0.19.0",
+    "numpydoc==1.9.0",
     "jupyter",
     "graphviz",
     "pillow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ viz = ["vtk>=6", "pyvista"]
 omf = ["omf"]
 all = ["discretize[plot,viz,omf]"]
 doc = [
-    "sphinx==8.2.3",
+    "sphinx==8.1.3",
     "pydata-sphinx-theme==0.16.1",
     "sphinx-gallery==0.19.0",
     "numpydoc==1.9.0",


### PR DESCRIPTION
Current doc builds fail combing the pinned pydata-sphinx-theme with the most recent sphinx, so let's bump and pin both