### PR TITLE
Add functionality to refine a `TreeMesh` using an "image"

### DIFF
--- a/discretize/_extensions/tree.h
+++ b/discretize/_extensions/tree.h
@@ -136,6 +136,7 @@ class Cell{
     void insert_cell(node_map_t &nodes, double *new_center, int_t p_level, double* xs, double *ys, double *zs, bool diag_balance=false);
 
     void refine_func(node_map_t& nodes, function test_func, double *xs, double *ys, double* zs, bool diag_balance=false);
+    void refine_image(node_map_t& nodes, double* image, int_t *shape_cells, double *xs, double*ys, double *zs, bool diagonal_balance=false);
 
     inline bool is_leaf(){ return children[0]==NULL;};
     void spawn(node_map_t& nodes, Cell *kids[8], double* xs, double *ys, double *zs);
@@ -216,6 +217,8 @@ class Tree{
     Cell* containing_cell(double, double, double);
 
     void refine_function(function test_func, bool diagonal_balance=false);
+
+    void refine_image(double* image, bool diagonal_balance=false);
 
     template <class T>
     void refine_geom(const T& geom, int_t p_level, bool diagonal_balance=false){

--- a/discretize/_extensions/tree.pxd
+++ b/discretize/_extensions/tree.pxd
@@ -93,6 +93,8 @@ cdef extern from "tree.h":
 
         void refine_geom[T](const T&, int_t, bool)
 
+        void refine_image(double*, bool)
+
         void number()
         void initialize_roots()
         void insert_cell(double *new_center, int_t p_level, bool)

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -7,6 +7,7 @@ from libc.stdlib cimport malloc, free
 from libcpp.vector cimport vector
 from libcpp cimport bool
 from numpy.math cimport INFINITY
+from pkg_resources import require
 
 from .tree cimport int_t, Tree as c_Tree, PyWrapper, Node, Edge, Face, Cell as c_Cell
 from . cimport geom
@@ -1196,6 +1197,41 @@ cdef class _TreeMesh:
             i_p += p_step
         if finalize:
             self.finalize()
+
+    def refine_image(self, image, finalize=True, diagonal_balance=None):
+        """Refine using an ND image, ensuring that each cell contains exactly one unique value.
+
+        This function takes an N-dimensional image, defined on the underlying fine tensor mesh,
+        and recursively subdivides each cell if that cell contains more than 1 unique value in the
+        image. This is useful when using the TreeMesh to represent an exact compressed form of an input
+        model.
+
+        Parameters
+        ----------
+        image : (shape_cells) numpy.ndarray
+            Must have the same shape as the base tensor mesh (TreeMesh.shape_cells), as if every cell on this mesh was
+            refined to it's maximum level.
+
+        """
+        cdef int max_level = self.max_level
+        if diagonal_balance is None:
+            diagonal_balance = self._diagonal_balance
+        cdef bool diag_balance = diagonal_balance
+
+        image = self._require_ndarray_with_dim('image', image, ndim=self.dim, dtype=np.float64)
+        if image.shape != self.shape_cells:
+            raise ValueError(
+                f"image array shape: {image.shape} must match the base cell shapes: {self.shape_cells}"
+            )
+        if self.dim == 2:
+            image = image[..., None]
+
+        cdef double[:,:,::1] image_dat = image
+        self.tree.refine_image(&image[0, 0, 0], diagonal_balance)
+        if finalize:
+            self.finalize()
+
+
 
     def finalize(self):
         """Finalize the :class:`~discretize.TreeMesh`.

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -25,7 +25,7 @@ cdef class TreeCell:
 
     This cannot be created in python, it can only be accessed by indexing the
     :class:`~discretize.TreeMesh` object. ``TreeCell`` is the object being passed
-    to the user defined refine function when calling tshe
+    to the user defined refine function when calling the
     :py:attr:`~discretize.TreeMesh.refine` method for a :class:`~discretize.TreeMesh`.
 
     Examples
@@ -1219,19 +1219,19 @@ cdef class _TreeMesh:
 
         This function takes an N-dimensional image, defined on the underlying fine tensor mesh,
         and recursively subdivides each cell if that cell contains more than 1 unique value in the
-        image. This is useful when using the TreeMesh to represent an exact compressed form of an input
+        image. This is useful when using the `TreeMesh` to represent an exact compressed form of an input
         model.
 
         Parameters
         ----------
         image : (shape_cells) numpy.ndarray
-            Must have the same shape as the base tensor mesh (TreeMesh.shape_cells), as if every cell on this mesh was
+            Must have the same shape as the base tensor mesh (`TreeMesh.shape_cells`), as if every cell on this mesh was
             refined to it's maximum level.
         finalize : bool, optional
             Whether to finalize after inserting point(s)
         diagonal_balance : bool or None, optional
             Whether to balance cells diagonally in the refinement, `None` implies using
-            the same setting used to instantiate the TreeMesh`.
+            the same setting used to instantiate the `TreeMesh`.
 
         """
         if diagonal_balance is None:

--- a/discretize/_extensions/tree_ext.pyx
+++ b/discretize/_extensions/tree_ext.pyx
@@ -1227,6 +1227,11 @@ cdef class _TreeMesh:
         image : (shape_cells) numpy.ndarray
             Must have the same shape as the base tensor mesh (TreeMesh.shape_cells), as if every cell on this mesh was
             refined to it's maximum level.
+        finalize : bool, optional
+            Whether to finalize after inserting point(s)
+        diagonal_balance : bool or None, optional
+            Whether to balance cells diagonally in the refinement, `None` implies using
+            the same setting used to instantiate the TreeMesh`.
 
         """
         if diagonal_balance is None:


### PR DESCRIPTION
Adds a refinement function that accepts an ndarray input the same shape as the underlying base mesh of the tree mesh. It will recursively refine the cells if that cell contains more than a single unique value.